### PR TITLE
Enable LTO for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,11 @@ aws-sdk-bedrockruntime = "1.15.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 jemallocator = { version = "0.5", features = ["disable_initial_exec_tls"] }
+
+[profile.release]
+codegen-units = 1
+lto = true
+
+[profile.optimized-dev]
+inherits = "release"
+lto = false


### PR DESCRIPTION
## Summary
- reduce binary size and enable more compiler optimizations by setting up Link-Time Optimization
- provide an optimized-dev profile without LTO so debug builds remain fast

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: FileNotFoundError: ... polar_llama.so)*
- `cargo test` *(fails to build due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_684c17260b70832ea606b62a886ee7fc