### PR TITLE
Bump version to 0.2.0 for PyPI release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polar-llama"
-version = "0.1.6"
+version = "0.2.0"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
Update version from 0.1.6 to 0.2.0 in preparation for PyPI deployment. This version includes structured output validation and Pydantic schema support.