### PR TITLE
Enable Link-Time Optimization in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,7 @@ jemallocator = { version = "0.5", features = ["disable_initial_exec_tls"] }
 [dev-dependencies]
 dotenvy = "0.15"
 tokio-test = "0.4"
+
+[profile.release]
+codegen-units = 1
+lto = true


### PR DESCRIPTION
- Enable Link-Time Optimization (LTO) for release builds
- Set codegen-units=1 to maximize optimization potential
- Expected benefits: 23% binary size reduction (10 MiB → 7.7 MiB)
- Build time impact: Only affects release builds (~2 min additional per platform)