### PR TITLE
Refactor async runtime, add DSPy-style optimization engine, improve provider defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-10
+
+### Added
+- **DSPy-style prompt optimization engine** (`polar_llama.optimize`):
+  - `Signature` — declarative task specs (`"question -> answer"` shorthand or explicit `InputField`/`OutputField` with types and descriptions)
+  - `Predict` — executable LLM module that runs one parallel, batched inference per DataFrame and returns `pred_<field>` columns
+  - `evaluate` — metric-based scoring of a module against a labeled DataFrame
+  - `BootstrapFewShot` — mines few-shot demonstrations from training rows the module already answers correctly (akin to `dspy.BootstrapFewShot`)
+  - `InstructionOptimizer` — COPRO-style instruction search: an LLM proposes instruction rewrites, every candidate is evaluated on the trainset, best one wins
+  - Fully testable offline via an injectable `inference_fn` backend
+- `OPENAI_BASE_URL` / `ANTHROPIC_BASE_URL` environment overrides for proxies and gateways
+- `POLAR_LLAMA_MAX_CONCURRENCY` environment variable to bound concurrent in-flight requests per batch (default 64; previously unbounded)
+- Gemini: native `system_instruction` support and native JSON-schema structured outputs (`response_json_schema`)
+- Pricing data for current models (GPT-5/4.1/o-series, Claude 4.x/Fable 5, Gemini 2.5, Bedrock Claude 4.5) and o200k tokenizer detection for GPT-4.1/GPT-5/o3/o4
+
+### Changed
+- **Updated default models** (previous defaults were retired/decommissioned):
+  - OpenAI: `gpt-4-turbo` → `gpt-4o-mini`
+  - Anthropic: `claude-3-opus-20240229` (retired) → `claude-opus-4-8`
+  - Gemini: `gemini-1.5-pro` → `gemini-2.5-flash`
+  - Groq: `llama3-70b-8192` (decommissioned) → `llama-3.3-70b-versatile`
+  - Bedrock: `anthropic.claude-3-haiku-20240307-v1:0` → `us.anthropic.claude-haiku-4-5-20251001-v1:0`
+- OpenAI/Groq requests no longer hardcode `temperature`/`max_tokens` (newer models such as the o-series and GPT-5 reject those parameters)
+- Bedrock region now respects `AWS_REGION`/`AWS_DEFAULT_REGION` before falling back to `us-east-1`
+- Removed import-time debug printing from the Python package and the native module
+- Minimum supported Python version is now 3.9 (abi3-py39 wheels)
+- Removed deprecated `new()`/`with_model()` Rust constructors (deprecated since 0.2.0); use `new_with_model()`
+
+### Fixed
+- **Gemini structured outputs** previously sent OpenAI-style Bearer auth and always failed; Gemini now authenticates via the `x-goog-api-key` header on all paths
+- **Bedrock structured outputs** previously attempted a raw HTTP POST to the Bedrock endpoint; they now route through the AWS SDK like plain requests
+- Bedrock now works from the synchronous `inference` expression (previously returned an error)
+- TLS verification is no longer disabled (`danger_accept_invalid_certs` removed); the shared client uses rustls with the OS certificate store
+
+### Performance
+- Single shared HTTP client with connection pooling (previously a new client per batch)
+- Bounded request concurrency via buffered streams instead of unbounded `join_all`
+- JSON schemas are compiled once per batch instead of once per row
+- AWS Bedrock client/credential chain is cached per region instead of being rebuilt per request
+- Vector similarity ops (`cosine_similarity`, `dot_product`, `euclidean_distance`) use a contiguous-slice fast path
+- Tokenizer/pricing lookups hoisted out of per-row loops in cost expressions
+- Removed redundant per-row clones of schemas, models, and message batches in the expression layer (~400 lines of duplicated dispatch removed)
+
+### Security
+- **Fixed RUSTSEC-2025-0020** (pyo3 buffer overflow): upgraded pyo3 0.23 → 0.27 via pyo3-polars 0.26
+- Removed `ureq` 2.x and `once_cell` dependencies (sync path now reuses the async clients; `std::sync::LazyLock` replaces `once_cell`)
+- Updated polars 0.46 → 0.53, jsonschema 0.28 → 0.46, tiktoken-rs 0.6 → 0.12, aws-sdk-bedrockruntime to latest
+
 ## [0.2.2] - 2025-12-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -32,6 +38,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "ar_archive_writer"
@@ -61,6 +73,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f13d10a41ac8d2ec79ee34178d61e6f47a29c2edfe7ef1721c7383b0359e65"
 dependencies = [
+ "half",
  "num-traits",
 ]
 
@@ -105,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "atoi_simd"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a49e05797ca52e312a0c658938b7d00693ef037799ef7187678f212d7684cf"
+checksum = "8ad17c7c205c2c28b527b9845eeb91cf1b4d008b438f98ce0e628227a822758e"
 dependencies = [
  "debug_unsafe",
 ]
@@ -544,6 +557,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,18 +591,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "shlex",
  "syn",
-]
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec 0.6.3",
 ]
 
 [[package]]
@@ -578,14 +602,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -598,6 +616,9 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -613,6 +634,12 @@ name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
+name = "boxcar"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
 name = "bstr"
@@ -726,13 +753,15 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "windows-link",
+ "serde",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -766,21 +795,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "comfy-table"
-version = "7.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03b7db8e0b4b2fdad6c551e634134e99ec000e5c8c3b6856c65e8bbaded7a3b"
-dependencies = [
- "crossterm",
- "unicode-segmentation",
- "unicode-width",
-]
-
-[[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -836,15 +854,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,42 +873,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "crossterm"
-version = "0.29.0"
+name = "crunchy"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "document-features",
- "parking_lot",
- "rustix",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
-]
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -910,6 +893,12 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "debug_unsafe"
@@ -949,15 +938,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "document-features"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
-dependencies = [
- "litrs",
-]
-
-[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,6 +960,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "email_address"
@@ -991,32 +974,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum_dispatch"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
-dependencies = [
- "once_cell",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "ethnum"
@@ -1032,22 +993,11 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
-version = "0.13.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
- "bit-set 0.5.3",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "fancy-regex"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
-dependencies = [
- "bit-set 0.8.0",
+ "bit-set",
  "regex-automata",
  "regex-syntax",
 ]
@@ -1071,10 +1021,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
-name = "fluent-uri"
-version = "0.3.2"
+name = "flate2"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
 dependencies = [
  "borrow-or-share",
  "ref-cast",
@@ -1092,6 +1052,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1289,15 +1255,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.14.5"
+name = "half"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
- "ahash",
- "allocator-api2",
- "rayon",
+ "bytemuck",
+ "cfg-if",
+ "crunchy",
+ "num-traits",
  "serde",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1308,9 +1276,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
- "rayon",
- "serde",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1318,6 +1284,13 @@ name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "rayon",
+ "serde",
+]
 
 [[package]]
 name = "heck"
@@ -1500,7 +1473,6 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots 1.0.4",
 ]
 
 [[package]]
@@ -1539,7 +1511,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -1768,26 +1740,28 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.28.3"
+version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f66fe41fa46a5c83ed1c717b7e0b4635988f427083108c8cf0a882cc13441"
+checksum = "50180452e7808015fe083eae3efcf1ec98b89b45dd8cc204f7b4a6b7b81ea675"
 dependencies = [
  "ahash",
- "base64 0.22.1",
  "bytecount",
+ "data-encoding",
  "email_address",
- "fancy-regex 0.14.0",
+ "fancy-regex",
  "fraction",
+ "getrandom 0.3.4",
  "idna",
  "itoa",
  "num-cmp",
- "once_cell",
+ "num-traits",
  "percent-encoding",
  "referencing",
+ "regex",
  "regex-syntax",
- "reqwest",
  "serde",
  "serde_json",
+ "unicode-general-category",
  "uuid-simd",
 ]
 
@@ -1810,7 +1784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1820,22 +1794,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
-
-[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
-
-[[package]]
-name = "litrs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -1878,6 +1840,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1902,10 +1874,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -1916,6 +1904,21 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
 ]
 
 [[package]]
@@ -1935,15 +1938,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d89e9874397a1f0a52fc1f197a8effd9735223cb2390e9dcc83ac6cd02923d0"
 dependencies = [
  "chrono",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -1990,6 +1984,17 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "num-integer"
@@ -2040,6 +2045,23 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "numpy"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aac2e6a6e4468ffa092ad43c39b81c79196c2bb773b8db4085f695efe3bba17"
+dependencies = [
+ "half",
+ "libc",
+ "ndarray",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "pyo3",
+ "pyo3-build-config",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -2098,7 +2120,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2145,16 +2167,17 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "planus"
-version = "0.3.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1691dd09e82f428ce8d6310bd6d5da2557c82ff17694d2a32cad7242aea89f"
+checksum = "3daf8e3d4b712abe1d690838f6e29fb76b76ea19589c4afa39ec30e12f62af71"
 dependencies = [
  "array-init-cursor",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
 name = "polar-llama"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2164,7 +2187,6 @@ dependencies = [
  "instant-distance",
  "jemallocator",
  "jsonschema",
- "once_cell",
  "polars",
  "polars-arrow",
  "polars-core",
@@ -2177,56 +2199,53 @@ dependencies = [
  "tiktoken-rs",
  "tokio",
  "tokio-test",
- "ureq",
 ]
 
 [[package]]
 name = "polars"
-version = "0.46.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72571dde488ecccbe799798bf99ab7308ebdb7cf5d95bcc498dbd5a132f0da4d"
+checksum = "899852b723e563dc3cbdc7ea833b14ec44e61309f55df29ba86d45cfd6bc141a"
 dependencies = [
  "getrandom 0.2.16",
+ "getrandom 0.3.4",
  "polars-arrow",
+ "polars-buffer",
+ "polars-compute",
  "polars-core",
  "polars-error",
- "polars-io",
- "polars-lazy",
- "polars-ops",
- "polars-parquet",
- "polars-sql",
- "polars-time",
  "polars-utils",
  "version_check",
 ]
 
 [[package]]
 name = "polars-arrow"
-version = "0.46.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6611c758d52e799761cc25900666b71552e6c929d88052811bc9daad4b3321a8"
+checksum = "6f672743a042b72ace4f88b29f8205ab200b29c5ac976c0560899680c07d2d09"
 dependencies = [
- "ahash",
- "atoi_simd",
+ "bitflags",
  "bytemuck",
+ "bytes",
  "chrono",
  "chrono-tz",
  "dyn-clone",
  "either",
  "ethnum",
  "getrandom 0.2.16",
- "hashbrown 0.15.5",
- "itoa",
+ "getrandom 0.3.4",
+ "half",
+ "hashbrown 0.16.0",
  "lz4",
  "num-traits",
- "parking_lot",
  "polars-arrow-format",
+ "polars-buffer",
  "polars-error",
  "polars-schema",
  "polars-utils",
+ "serde",
  "simdutf8",
  "streaming-iterator",
- "strength_reduce",
  "strum_macros",
  "version_check",
  "zstd",
@@ -2234,111 +2253,122 @@ dependencies = [
 
 [[package]]
 name = "polars-arrow-format"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b0ef2474af9396b19025b189d96e992311e6a47f90c53cd998b36c4c64b84c"
+checksum = "a556ac0ee744e61e167f34c1eb0013ce740e0ee6cd8c158b2ec0b518f10e6675"
 dependencies = [
  "planus",
  "serde",
 ]
 
 [[package]]
-name = "polars-compute"
-version = "0.46.0"
+name = "polars-buffer"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332f2547dbb27599a8ffe68e56159f5996ba03d1dad0382ccb62c109ceacdeb6"
+checksum = "5d7011424c3a79ca9c1272c7b4f5fe98695d3bed45595e37bb23c16a2978c80c"
+dependencies = [
+ "bytemuck",
+ "either",
+ "serde",
+ "version_check",
+]
+
+[[package]]
+name = "polars-compute"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a32eca8e08ac4cc5de2ac3996d2b38567bba72cdb19bbfd94c370193ed51dd"
 dependencies = [
  "atoi_simd",
  "bytemuck",
  "chrono",
  "either",
  "fast-float2",
+ "hashbrown 0.16.0",
  "itoa",
  "num-traits",
  "polars-arrow",
+ "polars-buffer",
  "polars-error",
  "polars-utils",
- "ryu",
+ "rand 0.9.2",
+ "serde",
  "strength_reduce",
+ "strum_macros",
  "version_check",
+ "zmij",
 ]
 
 [[package]]
 name = "polars-core"
-version = "0.46.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796d06eae7e6e74ed28ea54a8fccc584ebac84e6cf0e1e9ba41ffc807b169a01"
+checksum = "726296966d04268ee9679c2062af2d06c83c7a87379be471defe616b244c5029"
 dependencies = [
- "ahash",
  "bitflags",
+ "boxcar",
  "bytemuck",
  "chrono",
- "chrono-tz",
- "comfy-table",
  "either",
- "hashbrown 0.14.5",
- "hashbrown 0.15.5",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.0",
  "indexmap",
  "itoa",
  "num-traits",
- "once_cell",
  "polars-arrow",
+ "polars-buffer",
  "polars-compute",
+ "polars-dtype",
  "polars-error",
  "polars-row",
  "polars-schema",
  "polars-utils",
- "rand 0.8.5",
+ "rand 0.9.2",
  "rand_distr",
  "rayon",
  "regex",
+ "serde",
+ "serde_json",
  "strum_macros",
- "thiserror 2.0.17",
+ "uuid",
  "version_check",
  "xxhash-rust",
 ]
 
 [[package]]
-name = "polars-error"
-version = "0.46.0"
+name = "polars-dtype"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d6529cae0d1db5ed690e47de41fac9b35ae0c26d476830c2079f130887b847"
+checksum = "51976dc46d42cd1e7ca252a9e3bdc90c63b0bfa7030047ebaf5250c2b7838fa6"
 dependencies = [
- "polars-arrow-format",
- "regex",
- "simdutf8",
- "thiserror 2.0.17",
+ "boxcar",
+ "hashbrown 0.16.0",
+ "polars-arrow",
+ "polars-error",
+ "polars-utils",
+ "serde",
+ "uuid",
 ]
 
 [[package]]
-name = "polars-expr"
-version = "0.46.0"
+name = "polars-error"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e639991a8ad4fb12880ab44bcc3cf44a5703df003142334d9caf86d77d77e7"
+checksum = "8c13126f8baebc13dadf26a80dcf69a607977fc8a67b18671ad2cefc713a7bdd"
 dependencies = [
- "ahash",
- "bitflags",
- "hashbrown 0.15.5",
- "num-traits",
- "once_cell",
- "polars-arrow",
- "polars-compute",
- "polars-core",
- "polars-io",
- "polars-ops",
- "polars-plan",
- "polars-row",
- "polars-time",
- "polars-utils",
- "rand 0.8.5",
- "rayon",
+ "parking_lot",
+ "polars-arrow-format",
+ "pyo3",
+ "regex",
+ "signal-hook",
+ "simdutf8",
 ]
 
 [[package]]
 name = "polars-ffi"
-version = "0.46.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657a2cd278a9f9b40d5eedc5816d5fd0c65619ed2f53f0ff5ff4ef20916d3a8"
+checksum = "a9526b18335cfddc556eb5c34cdecba3ecf49bba7734470a82728569d44e72a0"
 dependencies = [
  "polars-arrow",
  "polars-core",
@@ -2346,106 +2376,55 @@ dependencies = [
 
 [[package]]
 name = "polars-io"
-version = "0.46.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719a77e94480f6be090512da196e378cbcbeb3584c6fe1134c600aee906e38ab"
+checksum = "059724d7762d7332cbc225e6504d996091b28fa1337716e06e5a81d9e54a34ad"
 dependencies = [
- "ahash",
  "async-trait",
  "atoi_simd",
  "bytes",
- "chrono",
  "fast-float2",
  "futures",
  "glob",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
  "home",
  "itoa",
  "memchr",
  "memmap2",
  "num-traits",
- "once_cell",
  "percent-encoding",
  "polars-arrow",
+ "polars-buffer",
+ "polars-compute",
  "polars-core",
  "polars-error",
  "polars-parquet",
  "polars-schema",
- "polars-time",
  "polars-utils",
  "rayon",
  "regex",
- "ryu",
+ "serde",
  "simdutf8",
  "tokio",
- "tokio-util",
-]
-
-[[package]]
-name = "polars-lazy"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a731a672dfc8ac38c1f73c9a4b2ae38d2fc8ac363bfb64c5f3a3e072ffc5ad"
-dependencies = [
- "ahash",
- "bitflags",
- "chrono",
- "memchr",
- "once_cell",
- "polars-arrow",
- "polars-core",
- "polars-expr",
- "polars-io",
- "polars-mem-engine",
- "polars-ops",
- "polars-pipe",
- "polars-plan",
- "polars-stream",
- "polars-time",
- "polars-utils",
- "rayon",
- "version_check",
-]
-
-[[package]]
-name = "polars-mem-engine"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33442189bcbf2e2559aa7914db3835429030a13f4f18e43af5fba9d1b018cf12"
-dependencies = [
- "memmap2",
- "polars-arrow",
- "polars-core",
- "polars-error",
- "polars-expr",
- "polars-io",
- "polars-ops",
- "polars-plan",
- "polars-time",
- "polars-utils",
- "rayon",
+ "zmij",
 ]
 
 [[package]]
 name = "polars-ops"
-version = "0.46.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb83218b0c216104f0076cd1a005128be078f958125f3d59b094ee73d78c18e"
+checksum = "7e47b2d9b3627662650da0a8c76ce5101ed1c61b104cb2b3663e0dc711571b12"
 dependencies = [
- "ahash",
  "argminmax",
- "base64 0.22.1",
  "bytemuck",
- "chrono",
- "chrono-tz",
  "either",
- "hashbrown 0.15.5",
- "hex",
+ "hashbrown 0.16.0",
  "indexmap",
+ "libm",
  "memchr",
  "num-traits",
- "once_cell",
  "polars-arrow",
+ "polars-buffer",
  "polars-compute",
  "polars-core",
  "polars-error",
@@ -2454,31 +2433,32 @@ dependencies = [
  "rayon",
  "regex",
  "regex-syntax",
+ "serde",
  "strum_macros",
- "unicode-normalization",
- "unicode-reverse",
  "version_check",
 ]
 
 [[package]]
 name = "polars-parquet"
-version = "0.46.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c60ee85535590a38db6c703a21be4cb25342e40f573f070d1e16f9d84a53ac7"
+checksum = "436bae3e89438cafe69400e7567057d7d9820d21ac9a4f69a33b413f2666f03d"
 dependencies = [
- "ahash",
  "async-stream",
  "base64 0.22.1",
  "bytemuck",
  "ethnum",
  "futures",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
  "num-traits",
  "polars-arrow",
+ "polars-buffer",
  "polars-compute",
  "polars-error",
  "polars-parquet-format",
  "polars-utils",
+ "regex",
+ "serde",
  "simdutf8",
  "streaming-decompression",
 ]
@@ -2494,152 +2474,81 @@ dependencies = [
 ]
 
 [[package]]
-name = "polars-pipe"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d238fb76698f56e51ddfa89b135e4eda56a4767c6e8859eed0ab78386fcd52"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-queue",
- "enum_dispatch",
- "hashbrown 0.15.5",
- "num-traits",
- "once_cell",
- "polars-arrow",
- "polars-compute",
- "polars-core",
- "polars-expr",
- "polars-io",
- "polars-ops",
- "polars-plan",
- "polars-row",
- "polars-utils",
- "rayon",
- "uuid",
- "version_check",
-]
-
-[[package]]
 name = "polars-plan"
-version = "0.46.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f03533a93aa66127fcb909a87153a3c7cfee6f0ae59f497e73d7736208da54c"
+checksum = "f7930d5ae1d006179e65f01af57c859307b5875a4cc078dc75257250b9ae5162"
 dependencies = [
- "ahash",
  "bitflags",
  "bytemuck",
  "bytes",
- "chrono",
- "chrono-tz",
  "either",
- "hashbrown 0.15.5",
+ "futures",
+ "hashbrown 0.16.0",
  "memmap2",
  "num-traits",
- "once_cell",
  "percent-encoding",
  "polars-arrow",
+ "polars-buffer",
  "polars-compute",
  "polars-core",
+ "polars-error",
+ "polars-ffi",
  "polars-io",
  "polars-ops",
  "polars-time",
  "polars-utils",
+ "pyo3",
  "rayon",
  "recursive",
- "regex",
+ "serde",
+ "sha2",
+ "slotmap",
  "strum_macros",
+ "tokio",
  "version_check",
 ]
 
 [[package]]
 name = "polars-row"
-version = "0.46.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf47f7409f8e75328d7d034be390842924eb276716d0458607be0bddb8cc839"
+checksum = "d29ea1a4554fe06442db1d6229235cd358e8eacba96aed8718f612caf3e3a646"
 dependencies = [
  "bitflags",
  "bytemuck",
  "polars-arrow",
+ "polars-buffer",
  "polars-compute",
+ "polars-dtype",
  "polars-error",
  "polars-utils",
 ]
 
 [[package]]
 name = "polars-schema"
-version = "0.46.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416621ae82b84466cf4ff36838a9b0aeb4a67e76bd3065edc8c9cb7da19b1bc7"
+checksum = "d688e73f9156f93cb29350be144c8f1e84c1bc705f00ee7f15eb9706a7971273"
 dependencies = [
  "indexmap",
  "polars-error",
  "polars-utils",
- "version_check",
-]
-
-[[package]]
-name = "polars-sql"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edaab553b90aa4d6743bb538978e1982368acb58a94408d7dd3299cad49c7083"
-dependencies = [
- "hex",
- "polars-core",
- "polars-error",
- "polars-lazy",
- "polars-ops",
- "polars-plan",
- "polars-time",
- "polars-utils",
- "rand 0.8.5",
- "regex",
  "serde",
- "sqlparser",
-]
-
-[[package]]
-name = "polars-stream"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498997b656c779610c1496b3d96a59fe569ef22a5b81ccfe5325cb3df8dff2fd"
-dependencies = [
- "atomic-waker",
- "crossbeam-deque",
- "crossbeam-utils",
- "futures",
- "memmap2",
- "parking_lot",
- "pin-project-lite",
- "polars-core",
- "polars-error",
- "polars-expr",
- "polars-io",
- "polars-mem-engine",
- "polars-ops",
- "polars-parquet",
- "polars-plan",
- "polars-utils",
- "rand 0.8.5",
- "rayon",
- "recursive",
- "slotmap",
- "tokio",
  "version_check",
 ]
 
 [[package]]
 name = "polars-time"
-version = "0.46.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d192efbdab516d28b3fab1709a969e3385bd5cda050b7c9aa9e2502a01fda879"
+checksum = "72e80404e1e418c997230e3b2972c3be331f45df8bdd3150fe3bef562c7a332f"
 dependencies = [
  "atoi_simd",
  "bytemuck",
  "chrono",
- "chrono-tz",
  "now",
  "num-traits",
- "once_cell",
  "polars-arrow",
  "polars-compute",
  "polars-core",
@@ -2648,31 +2557,45 @@ dependencies = [
  "polars-utils",
  "rayon",
  "regex",
+ "serde",
  "strum_macros",
 ]
 
 [[package]]
 name = "polars-utils"
-version = "0.46.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f6c8166a4a7fbc15b87c81645ed9e1f0651ff2e8c96cafc40ac5bf43441a10"
+checksum = "c97cabf53eb8fbf6050cde3fef8f596c51cc25fd7d55fbde108d815ee6674abf"
 dependencies = [
- "ahash",
+ "argminmax",
+ "bincode",
  "bytemuck",
  "bytes",
  "compact_str",
- "hashbrown 0.15.5",
+ "either",
+ "flate2",
+ "foldhash 0.2.0",
+ "half",
+ "hashbrown 0.16.0",
  "indexmap",
  "libc",
  "memmap2",
+ "num-derive",
  "num-traits",
- "once_cell",
+ "numpy",
  "polars-error",
- "rand 0.8.5",
+ "pyo3",
+ "rand 0.9.2",
  "raw-cpuid",
  "rayon",
+ "regex",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "serde_stacker",
+ "slotmap",
  "stacker",
- "sysinfo",
+ "uuid",
  "version_check",
 ]
 
@@ -2681,6 +2604,15 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2737,11 +2669,10 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
 dependencies = [
- "cfg-if",
  "indoc",
  "libc",
  "memoffset",
@@ -2755,19 +2686,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2775,9 +2705,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2787,9 +2717,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2800,15 +2730,16 @@ dependencies = [
 
 [[package]]
 name = "pyo3-polars"
-version = "0.20.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e7db078e647fbd863d7605d13ef1553c06dd84ba9559f76512d3ca63d5fff20"
+checksum = "f29248c4baefdfa23a7768341d1e431a5dee7348a757fa74315c810f3b8710d4"
 dependencies = [
  "libc",
  "once_cell",
  "polars",
  "polars-arrow",
  "polars-core",
+ "polars-error",
  "polars-ffi",
  "polars-plan",
  "pyo3",
@@ -2820,9 +2751,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-polars-derive"
-version = "0.14.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a247f5b03316e317f42e9a3fec4ff5b26cfa2b05fc2d9e821b7a182c82ef08f"
+checksum = "9e99f749c099d1928efa02e1019454d2b86b6089951f5d814f7f2a31f65d0fac"
 dependencies = [
  "polars-arrow",
  "polars-core",
@@ -2844,7 +2775,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.35",
  "socket2 0.6.1",
  "thiserror 2.0.17",
@@ -2864,7 +2795,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.35",
  "rustls-pki-types",
  "slab",
@@ -2964,12 +2895,12 @@ dependencies = [
 
 [[package]]
 name = "rand_distr"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -2980,6 +2911,12 @@ checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -3052,22 +2989,26 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.28.3"
+version = "0.46.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0dcb5ab28989ad7c91eb1b9531a37a1a137cc69a0499aee4117cae4a107c464"
+checksum = "69e4e17ef386c5383591d07623d3de49cbc601156e7582973e6db98d66a57de2"
 dependencies = [
  "ahash",
  "fluent-uri",
- "once_cell",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.0",
+ "itoa",
+ "micromap",
+ "parking_lot",
  "percent-encoding",
  "serde_json",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3094,9 +3035,9 @@ checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -3106,9 +3047,7 @@ checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -3121,6 +3060,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.35",
+ "rustls-native-certs 0.8.2",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3135,7 +3075,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.4",
 ]
 
 [[package]]
@@ -3153,10 +3092,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-hash"
-version = "1.1.0"
+name = "rmp"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -3171,19 +3123,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3205,7 +3144,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
  "aws-lc-rs",
- "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3424,6 +3362,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_stacker"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4936375d50c4be7eff22293a9344f8e46f323ed2b3c243e52f89138d9bb0f4a"
+dependencies = [
+ "serde",
+ "serde_core",
+ "stacker",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3453,6 +3402,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3460,6 +3419,12 @@ checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simdutf8"
@@ -3485,6 +3450,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
 dependencies = [
+ "serde",
  "version_check",
 ]
 
@@ -3512,15 +3478,6 @@ checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "sqlparser"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a528114c392209b3264855ad491fcce534b94a38771b0a0b97a79379275ce8"
-dependencies = [
- "log",
 ]
 
 [[package]]
@@ -3571,14 +3528,13 @@ checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn",
 ]
 
@@ -3620,23 +3576,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysinfo"
-version = "0.33.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
-dependencies = [
- "core-foundation-sys",
- "libc",
- "memchr",
- "ntapi",
- "windows",
-]
-
-[[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "thiserror"
@@ -3680,18 +3623,17 @@ dependencies = [
 
 [[package]]
 name = "tiktoken-rs"
-version = "0.6.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44075987ee2486402f0808505dd65692163d243a337fc54363d49afac41087f6"
+checksum = "027853bbf8c7763b77c5c595f1c271c7d536ced7d6f83452911b944621e57fc2"
 dependencies = [
  "anyhow",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bstr",
- "fancy-regex 0.13.0",
+ "fancy-regex",
  "lazy_static",
- "parking_lot",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -3758,7 +3700,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.1",
@@ -3923,40 +3864,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
-name = "unicode-reverse"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6f4888ebc23094adfb574fdca9fdc891826287a6397d2cd28802ffd6f20c76"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unindent"
@@ -3971,19 +3888,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "ureq"
-version = "2.12.1"
+name = "unty"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64 0.22.1",
- "log",
- "once_cell",
- "rustls 0.23.35",
- "rustls-pki-types",
- "url",
- "webpki-roots 0.26.11",
-]
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "url"
@@ -4017,6 +3925,7 @@ checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 
@@ -4027,7 +3936,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
 dependencies = [
  "outref",
- "uuid",
  "vsimd",
 ]
 
@@ -4036,6 +3944,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vsimd"
@@ -4146,89 +4060,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.4",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
-dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
-dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link",
- "windows-result 0.4.1",
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -4236,17 +4077,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4266,18 +4096,15 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
-]
 
 [[package]]
 name = "windows-result"
@@ -4285,7 +4112,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4294,7 +4121,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4330,7 +4157,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4355,7 +4182,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -4588,6 +4415,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polar-llama"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 
 [lib]
@@ -8,36 +8,29 @@ name = "polar_llama"
 crate-type = ["cdylib", "rlib"]
 
 [build-dependencies]
-pyo3-build-config = "0.23.5"
+pyo3-build-config = "0.27"
 
 [dependencies]
-# NOTE: pyo3 0.24 would fix RUSTSEC-2025-0020 but pyo3-polars 0.20.0 requires 0.23
-# Keeping at 0.23 until pyo3-polars is updated. The vulnerability is in PyString::from_object
-# which we don't directly use. Tracking issue for pyo3-polars update needed.
-pyo3 = { version = "0.23", features = ["extension-module", "abi3-py38"] }
-pyo3-polars = { version = "0.20.0", features = ["derive"] }
+pyo3 = { version = "0.27", features = ["extension-module", "abi3-py39"] }
+pyo3-polars = { version = "0.26", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-# Updated reqwest to get newer rustls versions
-reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
-polars = { version = "0.46.0", default-features = false }
-polars-arrow = { version = "0.46.0", default-features = false }
-polars-core = { version = "0.46.0", default-features = false }
-# Updated futures to avoid yanked version
-futures = "0.3.31"
-# Updated ureq from 0.11 to 2.x to fix rustls 0.16 vulnerabilities
-ureq = { version = "2", features = ["tls"], default-features = false }
-# Updated tokio to fix RUSTSEC-2025-0023 (unsound broadcast channel)
-tokio = { version = "1.41", features = ["full", "rt-multi-thread"] }
-once_cell = "1"
+# rustls with the OS certificate store, so TLS verification stays on even
+# behind corporate proxies with custom CAs
+reqwest = { version = "0.12", features = ["json", "rustls-tls-native-roots"], default-features = false }
+polars = { version = "0.53", default-features = false }
+polars-arrow = { version = "0.53", default-features = false }
+polars-core = { version = "0.53", default-features = false }
+futures = "0.3"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
 async-trait = "0.1"
-aws-config = "1.1.0"
-aws-sdk-bedrockruntime = "1.116.0"
-jsonschema = "0.28"
+aws-config = "1"
+aws-sdk-bedrockruntime = "1"
+jsonschema = { version = "0.46", default-features = false }
 # Approximate nearest neighbor search using HNSW
 instant-distance = { version = "0.6", features = ["with-serde"] }
 # Token counting for cost calculation (tiktoken compatible)
-tiktoken-rs = "0.6"
+tiktoken-rs = "0.12"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 jemallocator = { version = "0.5", features = ["disable_initial_exec_tls"] }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Polar Llama is a Python library designed to enhance the efficiency of making par
 - **Structured Outputs**: Define response schemas using Pydantic models for type-safe, validated LLM outputs returned as Polars Structs with direct field access.
 - **Vector Similarity**: Rust-powered similarity metrics (cosine, dot product, Euclidean distance) for high-performance vector operations.
 - **Approximate Nearest Neighbor Search**: HNSW algorithm for fast semantic search and recommendations at scale.
+- **Prompt Optimization**: A DSPy-style optimization engine (`Signature`, `Predict`, `BootstrapFewShot`, `InstructionOptimizer`) that tunes instructions and few-shot demos against your labeled data using parallel batched evaluation.
 
 #### Installation
 
@@ -192,6 +193,62 @@ if error:
     print(f"Error: {error}")
     print(f"Details: {df['recommendation'].struct.field('_details')[0]}")
     print(f"Raw response: {df['recommendation'].struct.field('_raw')[0]}")
+```
+
+#### Prompt Optimization (DSPy-style)
+
+Polar Llama ships a lightweight prompt optimization engine inspired by [DSPy](https://github.com/stanfordnlp/dspy). Declare your task as a `Signature`, wrap it in a `Predict` module, and let an optimizer tune the prompt against your labeled DataFrame — every candidate is evaluated with one parallel, batched inference call:
+
+```python
+import polars as pl
+from polar_llama import Predict, Signature, BootstrapFewShot, InstructionOptimizer, evaluate
+
+# 1. Declare the task
+module = Predict(
+    Signature("question -> answer", instructions="Answer concisely."),
+    provider="openai",
+    model="gpt-4o-mini",
+)
+
+# 2. Labeled training data
+trainset = pl.DataFrame({
+    "question": ["What is 2+2?", "Capital of France?", "Largest planet?"],
+    "answer": ["4", "Paris", "Jupiter"],
+})
+
+# 3. A metric: (gold row, prediction) -> bool | float
+def exact_match(example, prediction):
+    return example["answer"].strip().lower() == (prediction["answer"] or "").strip().lower()
+
+# 4a. Bootstrap few-shot demos from rows the model already gets right
+compiled = BootstrapFewShot(metric=exact_match, max_demos=4).compile(module, trainset)
+
+# 4b. Or search for better instructions (COPRO-style)
+optimizer = InstructionOptimizer(metric=exact_match, n_candidates=4)
+compiled = optimizer.compile(module, trainset)
+print(optimizer.history)  # [(instructions, score), ...]
+
+# 5. Run the optimized module on new data — outputs land in pred_* columns
+result = compiled(pl.DataFrame({"question": ["What is 3+3?"]}))
+print(result["pred_answer"])
+
+# Score any module against a labeled set
+print(evaluate(compiled, trainset, exact_match).score)
+```
+
+Output fields can be typed and described for stronger structured outputs:
+
+```python
+from polar_llama import OutputField
+
+sig = Signature(
+    "review -> sentiment, confidence",
+    instructions="Classify the sentiment of the review.",
+    outputs={
+        "sentiment": OutputField(desc="one of: positive, negative, neutral"),
+        "confidence": OutputField(desc="confidence from 0.0 to 1.0", dtype=float),
+    },
+)
 ```
 
 #### Vector Embeddings

--- a/polar_llama/__init__.py
+++ b/polar_llama/__init__.py
@@ -350,16 +350,19 @@ def inference_async(
         or String (if no response_model)
     """
     expr = parse_into_expr(expr)
-    kwargs = {}
 
-    if provider is not None:
-        # Convert Provider to string to make it picklable
-        if isinstance(provider, Provider):
-            provider = str(provider)
-        kwargs["provider"] = provider
-
-    if model is not None:
-        kwargs["model"] = model
+    # Convert Provider to string to make it picklable. All keys are always
+    # present (None values deserialize to Option::None) because polars
+    # serializes an empty kwargs dict to empty bytes, which the plugin
+    # cannot parse.
+    if provider is not None and isinstance(provider, Provider):
+        provider = str(provider)
+    kwargs = {
+        "provider": provider,
+        "model": model,
+        "response_schema": None,
+        "response_model_name": None,
+    }
 
     # Handle response_format alias
     if response_model is None and response_format is not None:
@@ -426,16 +429,19 @@ def inference(
         or String (if no response_model)
     """
     expr = parse_into_expr(expr)
-    kwargs = {}
 
-    if provider is not None:
-        # Convert Provider to string to make it picklable
-        if isinstance(provider, Provider):
-            provider = str(provider)
-        kwargs["provider"] = provider
-
-    if model is not None:
-        kwargs["model"] = model
+    # Convert Provider to string to make it picklable. All keys are always
+    # present (None values deserialize to Option::None) because polars
+    # serializes an empty kwargs dict to empty bytes, which the plugin
+    # cannot parse.
+    if provider is not None and isinstance(provider, Provider):
+        provider = str(provider)
+    kwargs = {
+        "provider": provider,
+        "model": model,
+        "response_schema": None,
+        "response_model_name": None,
+    }
 
     # Handle response_format alias
     if response_model is None and response_format is not None:
@@ -505,21 +511,19 @@ def inference_messages(
         or String (if no response_model)
     """
     expr = parse_into_expr(expr)
-    kwargs = {}
 
-    if provider is not None:
-        # Convert Provider to string to make it picklable
-        if hasattr(provider, 'as_str'):
-            provider_str = provider.as_str()
-        elif hasattr(provider, '__str__'):
-            provider_str = str(provider)
-        else:
-            provider_str = provider
-
-        kwargs["provider"] = provider_str
-
-    if model is not None:
-        kwargs["model"] = model
+    # Convert Provider to string to make it picklable. All keys are always
+    # present (None values deserialize to Option::None) because polars
+    # serializes an empty kwargs dict to empty bytes, which the plugin
+    # cannot parse.
+    if provider is not None and not isinstance(provider, str):
+        provider = provider.as_str() if hasattr(provider, "as_str") else str(provider)
+    kwargs = {
+        "provider": provider,
+        "model": model,
+        "response_schema": None,
+        "response_model_name": None,
+    }
 
     # Handle response_format alias
     if response_model is None and response_format is not None:
@@ -535,22 +539,13 @@ def inference_messages(
         # Create the target struct dtype for later conversion
         struct_dtype = _json_schema_to_polars_dtype(schema)
 
-    # Don't pass empty kwargs dictionary
-    if not kwargs:
-        result_expr = register_plugin(
-            args=[expr],
-            symbol="inference_messages",
-            is_elementwise=True,
-            lib=lib,
-        )
-    else:
-        result_expr = register_plugin(
-            args=[expr],
-            symbol="inference_messages",
-            is_elementwise=True,
-            lib=lib,
-            kwargs=kwargs,
-        )
+    result_expr = register_plugin(
+        args=[expr],
+        symbol="inference_messages",
+        is_elementwise=True,
+        lib=lib,
+        kwargs=kwargs,
+    )
 
     # If response_model was provided, convert JSON strings to structs
     if struct_dtype is not None:
@@ -675,32 +670,20 @@ def embedding_async(
     ... ])
     """
     expr = parse_into_expr(expr)
-    kwargs = {}
 
-    if provider is not None:
-        # Convert Provider to string to make it picklable
-        if isinstance(provider, Provider):
-            provider = str(provider)
-        kwargs["provider"] = provider
+    # Convert Provider to string to make it picklable; keep all keys present
+    # so the serialized kwargs are never empty.
+    if provider is not None and isinstance(provider, Provider):
+        provider = str(provider)
+    kwargs = {"provider": provider, "model": model}
 
-    if model is not None:
-        kwargs["model"] = model
-
-    if kwargs:
-        return register_plugin(
-            args=[expr],
-            symbol="embedding_async",
-            is_elementwise=True,
-            lib=lib,
-            kwargs=kwargs,
-        )
-    else:
-        return register_plugin(
-            args=[expr],
-            symbol="embedding_async",
-            is_elementwise=True,
-            lib=lib,
-        )
+    return register_plugin(
+        args=[expr],
+        symbol="embedding_async",
+        is_elementwise=True,
+        lib=lib,
+        kwargs=kwargs,
+    )
 
 
 def cosine_similarity(
@@ -1315,6 +1298,24 @@ def template(format_string: str, *args: IntoExpr, **kwargs: IntoExpr) -> pl.Expr
             # But the recommendation says "Abstract Prompt Templating... ensure the library works consistently".
             pass
         return pl.format(format_string, *args)
+
+# ============================================================================
+# Prompt Optimization (DSPy-style)
+# ============================================================================
+
+# Imported late so optimize.py can lazily import inference helpers from here.
+from polar_llama import optimize  # noqa: E402
+from polar_llama.optimize import (  # noqa: E402
+    BootstrapFewShot,
+    Evaluation,
+    InputField,
+    InstructionOptimizer,
+    OutputField,
+    Predict,
+    Signature,
+    evaluate,
+)
+
 
 def _validate_strict_mode_schema(model: Type['BaseModel']) -> None:
     """

--- a/polar_llama/expressions.py
+++ b/polar_llama/expressions.py
@@ -7,13 +7,19 @@ import polars as pl
 
 # Import the register_expressions function to ensure it gets called
 try:
-    from polar_llama import register_expressions
+    from polar_llama.polar_llama import register_expressions
     # Call it to make sure expressions are registered
     register_expressions()
 except ImportError:
-    print("Warning: Could not import register_expressions from polar_llama.polar_llama")
-except Exception as e:
-    print(f"Warning: Error calling register_expressions: {e}")
+    import warnings
+    warnings.warn(
+        "Could not import register_expressions from polar_llama.polar_llama",
+        RuntimeWarning,
+        stacklevel=2,
+    )
+except Exception as e:  # noqa: BLE001
+    import warnings
+    warnings.warn(f"Error calling register_expressions: {e}", RuntimeWarning, stacklevel=2)
 
 def get_lib_path():
     """Get the path to the native library."""
@@ -25,33 +31,22 @@ def get_lib_path():
     
     if potential_libs:
         # Return the first one found
-        lib_path = str(potential_libs[0])
-        print(f"Found library at: {lib_path}")
-        return lib_path
+        return str(potential_libs[0])
     else:
         # As a fallback, guess the name based on the module name
         if os.name == 'posix':
-            fallback_path = str(lib_dir / "polar_llama.so")
-        else:
-            fallback_path = str(lib_dir / "polar_llama.pyd")
-        print(f"No library found, using fallback: {fallback_path}")
-        return fallback_path
+            return str(lib_dir / "polar_llama.so")
+        return str(lib_dir / "polar_llama.pyd")
 
 def ensure_expressions_registered():
     """Ensure all expressions are registered with Polars."""
-    # This is mainly for debugging
     lib_path = get_lib_path()
-    print(f"Using library at: {lib_path}")
-    
-    # Check if the library file actually exists
-    if os.path.exists(lib_path):
-        print(f"✓ Library file exists: {lib_path}")
-    else:
-        print(f"✗ Library file not found: {lib_path}")
-        # List what files are actually in the directory
-        lib_dir = Path(lib_path).parent
-        print(f"Files in {lib_dir}:")
-        for file in lib_dir.iterdir():
-            print(f"  - {file.name}")
-    
+    if not os.path.exists(lib_path):
+        import warnings
+        warnings.warn(
+            f"polar_llama native library not found at {lib_path}; "
+            "expressions will not be available. Did the build succeed?",
+            RuntimeWarning,
+            stacklevel=2,
+        )
     return True 

--- a/polar_llama/optimize.py
+++ b/polar_llama/optimize.py
@@ -1,0 +1,518 @@
+"""
+DSPy-style prompt optimization engine for polar-llama.
+
+This module provides a small, declarative framework for building and
+optimizing LLM programs over Polars DataFrames, inspired by DSPy:
+
+- ``Signature`` declares a task: typed input fields -> typed output fields,
+  plus natural-language instructions.
+- ``Predict`` is a module that executes a signature against an LLM using
+  polar-llama's parallel inference (one batched, concurrent call per
+  DataFrame instead of per row).
+- ``evaluate`` scores a module against a labeled DataFrame with a metric.
+- ``BootstrapFewShot`` improves a module by mining few-shot demonstrations
+  from training rows the module already gets right (akin to
+  ``dspy.BootstrapFewShot``).
+- ``InstructionOptimizer`` asks an LLM to propose improved instruction
+  variants and keeps the best-scoring one (akin to ``dspy.COPRO``).
+
+Example
+-------
+>>> import polars as pl
+>>> from polar_llama import optimize as po
+>>>
+>>> sig = po.Signature(
+...     "question -> answer",
+...     instructions="Answer the question concisely.",
+... )
+>>> module = po.Predict(sig, provider="openai", model="gpt-4o-mini")
+>>>
+>>> trainset = pl.DataFrame({
+...     "question": ["What is 2+2?", "Capital of France?"],
+...     "answer": ["4", "Paris"],
+... })
+>>>
+>>> def exact_match(example, prediction):
+...     return float(example["answer"].strip().lower()
+...                  == (prediction["answer"] or "").strip().lower())
+>>>
+>>> optimizer = po.BootstrapFewShot(metric=exact_match, max_demos=2)
+>>> compiled = optimizer.compile(module, trainset)
+>>> result = compiled(pl.DataFrame({"question": ["What is 3+3?"]}))
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, replace
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+)
+
+import polars as pl
+
+__all__ = [
+    "InputField",
+    "OutputField",
+    "Signature",
+    "Predict",
+    "Evaluation",
+    "evaluate",
+    "BootstrapFewShot",
+    "InstructionOptimizer",
+]
+
+# Type of a metric: (gold example row, prediction row) -> score.
+# Booleans are coerced to 0.0/1.0.
+Metric = Callable[[Dict[str, Any], Dict[str, Any]], Union[bool, float]]
+
+# Pluggable inference backend, mainly for testing: receives the list of
+# JSON-encoded message arrays (one per row) and the Pydantic output model,
+# and returns one JSON string (or None) per row.
+InferenceFn = Callable[[List[str], Type], List[Optional[str]]]
+
+_PYTHON_TYPES: Dict[type, str] = {str: "string", int: "integer", float: "number", bool: "boolean"}
+
+
+# ============================================================================
+# Fields and Signatures
+# ============================================================================
+
+@dataclass(frozen=True)
+class _Field:
+    desc: str = ""
+    dtype: type = str
+
+
+class InputField(_Field):
+    """An input field of a Signature."""
+
+
+class OutputField(_Field):
+    """An output field of a Signature."""
+
+
+@dataclass(frozen=True)
+class Signature:
+    """
+    A declarative task specification: inputs -> outputs with instructions.
+
+    Can be created from a DSPy-style shorthand string::
+
+        Signature("question -> answer")
+        Signature("context, question -> answer", instructions="...")
+
+    or with explicit fields::
+
+        Signature(
+            instructions="Classify the sentiment.",
+            inputs={"text": InputField(desc="The document to classify")},
+            outputs={"sentiment": OutputField(desc="positive, negative or neutral")},
+        )
+    """
+
+    shorthand: Optional[str] = None
+    instructions: str = ""
+    inputs: Dict[str, InputField] = field(default_factory=dict)
+    outputs: Dict[str, OutputField] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.shorthand:
+            if "->" not in self.shorthand:
+                raise ValueError(
+                    f"Signature shorthand must look like 'a, b -> c', got: {self.shorthand!r}"
+                )
+            lhs, rhs = self.shorthand.split("->", 1)
+            inputs = {name.strip(): InputField() for name in lhs.split(",") if name.strip()}
+            outputs = {name.strip(): OutputField() for name in rhs.split(",") if name.strip()}
+            # Explicit fields take precedence over shorthand-derived ones
+            inputs.update(self.inputs)
+            outputs.update(self.outputs)
+            object.__setattr__(self, "inputs", inputs)
+            object.__setattr__(self, "outputs", outputs)
+
+        if not self.inputs or not self.outputs:
+            raise ValueError("A Signature requires at least one input and one output field")
+
+    def with_instructions(self, instructions: str) -> "Signature":
+        """Return a copy of this signature with different instructions."""
+        return Signature(
+            instructions=instructions,
+            inputs=dict(self.inputs),
+            outputs=dict(self.outputs),
+        )
+
+    # ------------------------------------------------------------------
+    # Prompt construction helpers
+    # ------------------------------------------------------------------
+
+    def output_model(self) -> Type:
+        """Build a Pydantic model matching the output fields (for structured outputs)."""
+        from pydantic import Field as PydField, create_model
+
+        fields = {
+            name: (spec.dtype, PydField(..., description=spec.desc or name))
+            for name, spec in self.outputs.items()
+        }
+        return create_model("SignatureOutput", **fields)
+
+    def system_prompt(self) -> str:
+        parts: List[str] = []
+        if self.instructions:
+            parts.append(self.instructions.strip())
+        parts.append("You will be given input fields and must produce the output fields.")
+
+        parts.append("\nInput fields:")
+        for name, spec in self.inputs.items():
+            parts.append(f"- {name}: {spec.desc}" if spec.desc else f"- {name}")
+
+        parts.append("\nOutput fields:")
+        for name, spec in self.outputs.items():
+            type_name = _PYTHON_TYPES.get(spec.dtype, "string")
+            desc = f" — {spec.desc}" if spec.desc else ""
+            parts.append(f"- {name} ({type_name}){desc}")
+
+        keys = ", ".join(self.outputs)
+        parts.append(f"\nRespond with a JSON object containing exactly these keys: {keys}.")
+        return "\n".join(parts)
+
+    def render_inputs(self, row: Dict[str, Any]) -> str:
+        """Render one example's input fields as the user message."""
+        return "\n\n".join(f"{name}: {row[name]}" for name in self.inputs)
+
+    def render_outputs(self, row: Dict[str, Any]) -> str:
+        """Render one example's output fields as a JSON assistant message."""
+        return json.dumps({name: row.get(name) for name in self.outputs})
+
+
+# ============================================================================
+# Predict module
+# ============================================================================
+
+@dataclass(frozen=True)
+class Predict:
+    """
+    An executable LLM module for a Signature.
+
+    Calling the module on a DataFrame runs one parallel, batched inference
+    over all rows and returns the DataFrame with one ``pred_<field>`` column
+    per output field.
+
+    Parameters
+    ----------
+    signature : Signature or str
+        The task specification (a shorthand string like ``"question -> answer"``
+        is accepted).
+    provider : str, optional
+        polar-llama provider name (openai, anthropic, gemini, groq, bedrock).
+    model : str, optional
+        Model name for the provider.
+    demos : sequence of dict, optional
+        Few-shot demonstrations; each dict must contain the signature's
+        input and output fields. Usually produced by an optimizer.
+    inference_fn : callable, optional
+        Override the inference backend (used for testing). Receives the
+        JSON message arrays and the Pydantic output model, returns one JSON
+        string (or None) per row.
+    """
+
+    signature: Signature
+    provider: Optional[str] = None
+    model: Optional[str] = None
+    demos: Tuple[Dict[str, Any], ...] = ()
+    inference_fn: Optional[InferenceFn] = None
+
+    def __post_init__(self) -> None:
+        if isinstance(self.signature, str):
+            object.__setattr__(self, "signature", Signature(self.signature))
+        object.__setattr__(self, "demos", tuple(self.demos))
+
+    # ------------------------------------------------------------------
+    # Derived modules
+    # ------------------------------------------------------------------
+
+    def with_instructions(self, instructions: str) -> "Predict":
+        return replace(self, signature=self.signature.with_instructions(instructions))
+
+    def with_demos(self, demos: Sequence[Dict[str, Any]]) -> "Predict":
+        return replace(self, demos=tuple(demos))
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+
+    def prediction_columns(self) -> Dict[str, str]:
+        """Mapping of output field name -> prediction column name."""
+        return {name: f"pred_{name}" for name in self.signature.outputs}
+
+    def _build_messages(self, df: pl.DataFrame) -> List[str]:
+        """Build the JSON message array for every row."""
+        system = self.signature.system_prompt()
+
+        demo_turns: List[Tuple[str, str]] = []
+        for demo in self.demos:
+            demo_turns.append(("user", self.signature.render_inputs(demo)))
+            demo_turns.append(("assistant", self.signature.render_outputs(demo)))
+
+        messages: List[str] = []
+        for row in df.iter_rows(named=True):
+            convo = [{"role": "system", "content": system}]
+            convo.extend({"role": role, "content": content} for role, content in demo_turns)
+            convo.append({"role": "user", "content": self.signature.render_inputs(row)})
+            messages.append(json.dumps(convo))
+        return messages
+
+    def __call__(self, df: pl.DataFrame) -> pl.DataFrame:
+        """Run the module over a DataFrame, adding ``pred_<field>`` columns."""
+        output_model = self.signature.output_model()
+        messages = self._build_messages(df)
+
+        if self.inference_fn is not None:
+            raw = self.inference_fn(messages, output_model)
+        else:
+            raw = self._run_inference(messages, output_model)
+
+        # Parse JSON responses into per-field prediction columns
+        columns: Dict[str, List[Any]] = {col: [] for col in self.prediction_columns().values()}
+        for response in raw:
+            parsed: Dict[str, Any] = {}
+            if response:
+                try:
+                    value = json.loads(response)
+                    if isinstance(value, dict):
+                        parsed = value
+                except (TypeError, ValueError):
+                    parsed = {}
+            for name, col in self.prediction_columns().items():
+                columns[col].append(parsed.get(name))
+
+        height = df.height
+        prediction_df = pl.DataFrame(
+            {col: values + [None] * (height - len(values)) for col, values in columns.items()}
+        )
+        return pl.concat([df, prediction_df], how="horizontal")
+
+    def _run_inference(self, messages: List[str], output_model: Type) -> List[Optional[str]]:
+        # Imported lazily to avoid a circular import with the package root.
+        from polar_llama import inference_messages
+
+        frame = pl.DataFrame({"_messages": messages})
+        # Request the raw JSON string (no response_model) so parsing stays in
+        # one place; the schema is still enforced server-side via the
+        # response_schema kwarg by passing the model through.
+        result = frame.with_columns(
+            _response=inference_messages(
+                pl.col("_messages"),
+                provider=self.provider,
+                model=self.model,
+                response_model=output_model,
+            )
+        )
+        response = result.get_column("_response")
+        if isinstance(response.dtype, pl.Struct):
+            # Structured output path: re-serialize the struct rows to JSON
+            return [
+                json.dumps(row) if row is not None else None
+                for row in response.to_list()
+            ]
+        return response.to_list()
+
+
+# ============================================================================
+# Evaluation
+# ============================================================================
+
+@dataclass(frozen=True)
+class Evaluation:
+    """Result of evaluating a module against a labeled DataFrame."""
+
+    score: float
+    scores: Tuple[float, ...]
+    predictions: pl.DataFrame
+
+    def __repr__(self) -> str:  # pragma: no cover - cosmetic
+        return f"Evaluation(score={self.score:.4f}, n={len(self.scores)})"
+
+
+def evaluate(module: Predict, dataset: pl.DataFrame, metric: Metric) -> Evaluation:
+    """
+    Run ``module`` over ``dataset`` and score each row with ``metric``.
+
+    The metric receives the gold row (all original columns) and the
+    prediction (plain output-field names) and returns a bool or float.
+    Rows whose prediction failed entirely score 0.0.
+    """
+    predictions = module(dataset)
+    columns = module.prediction_columns()
+
+    scores: List[float] = []
+    for row in predictions.iter_rows(named=True):
+        prediction = {name: row.get(col) for name, col in columns.items()}
+        if all(value is None for value in prediction.values()):
+            scores.append(0.0)
+            continue
+        try:
+            scores.append(float(metric(row, prediction)))
+        except Exception:  # noqa: BLE001 - a failing metric scores zero
+            scores.append(0.0)
+
+    score = sum(scores) / len(scores) if scores else 0.0
+    return Evaluation(score=score, scores=tuple(scores), predictions=predictions)
+
+
+# ============================================================================
+# Optimizers
+# ============================================================================
+
+@dataclass
+class BootstrapFewShot:
+    """
+    Bootstrap few-shot demonstrations from a training DataFrame.
+
+    Runs the module over the trainset and keeps up to ``max_demos``
+    examples whose predictions pass the metric (score >= ``threshold``)
+    as demonstrations, mirroring ``dspy.BootstrapFewShot``.
+
+    With ``use_gold_outputs=True``, the gold labels are used as the
+    demonstration outputs instead of the module's own (passing) predictions
+    (similar to ``dspy.LabeledFewShot``, but still filtered by the metric).
+    """
+
+    metric: Metric
+    max_demos: int = 4
+    threshold: float = 1.0
+    use_gold_outputs: bool = False
+
+    def compile(self, module: Predict, trainset: pl.DataFrame) -> Predict:
+        evaluation = evaluate(module, trainset, self.metric)
+        columns = module.prediction_columns()
+
+        demos: List[Dict[str, Any]] = []
+        for row, score in zip(evaluation.predictions.iter_rows(named=True), evaluation.scores):
+            if score < self.threshold:
+                continue
+            demo = {name: row[name] for name in module.signature.inputs}
+            if self.use_gold_outputs:
+                demo.update({name: row[name] for name in module.signature.outputs})
+            else:
+                demo.update({name: row[col] for name, col in columns.items()})
+            demos.append(demo)
+            if len(demos) >= self.max_demos:
+                break
+
+        return module.with_demos(demos)
+
+
+_PROPOSER_TEMPLATE = """\
+You are an expert prompt engineer. A language model performs the task below.
+
+Input fields: {inputs}
+Output fields: {outputs}
+
+Current instruction:
+\"\"\"{instructions}\"\"\"
+
+Current score on a held-out training set: {score:.3f} (1.0 is perfect).
+
+Propose {n} alternative instructions that would make the language model more
+accurate at this task. Each proposal must be self-contained, specific, and
+phrased as a direct instruction to the model. Vary tone, level of detail,
+and strategy across proposals."""
+
+
+@dataclass
+class InstructionOptimizer:
+    """
+    COPRO-style instruction search.
+
+    Asks an LLM to propose ``n_candidates`` rewritten instructions for the
+    module's signature, evaluates every candidate (plus the original) on the
+    trainset, and returns the module with the best-scoring instructions.
+
+    Parameters
+    ----------
+    metric : callable
+        Scoring function, as for :func:`evaluate`.
+    n_candidates : int
+        Number of instruction rewrites to request per round.
+    rounds : int
+        Optimization rounds; each round proposes candidates derived from the
+        current best instructions.
+    provider, model : str, optional
+        LLM used for proposing instructions. Defaults to the module's own
+        provider/model.
+    proposer_fn : callable, optional
+        Override candidate generation (used for testing): receives the
+        meta-prompt string and returns a list of candidate instructions.
+    """
+
+    metric: Metric
+    n_candidates: int = 4
+    rounds: int = 1
+    provider: Optional[str] = None
+    model: Optional[str] = None
+    proposer_fn: Optional[Callable[[str], List[str]]] = None
+
+    def compile(self, module: Predict, trainset: pl.DataFrame) -> Predict:
+        best_module = module
+        best = evaluate(module, trainset, self.metric)
+        history: List[Tuple[str, float]] = [(module.signature.instructions, best.score)]
+
+        for _ in range(max(1, self.rounds)):
+            prompt = _PROPOSER_TEMPLATE.format(
+                inputs=", ".join(best_module.signature.inputs),
+                outputs=", ".join(best_module.signature.outputs),
+                instructions=best_module.signature.instructions or "(no instructions)",
+                score=best.score,
+                n=self.n_candidates,
+            )
+
+            for candidate in self._propose(module, prompt):
+                candidate = candidate.strip()
+                if not candidate or candidate == best_module.signature.instructions:
+                    continue
+                candidate_module = best_module.with_instructions(candidate)
+                result = evaluate(candidate_module, trainset, self.metric)
+                history.append((candidate, result.score))
+                if result.score > best.score:
+                    best = result
+                    best_module = candidate_module
+
+        # Expose the search trace for inspection
+        self.history = history
+        return best_module
+
+    def _propose(self, module: Predict, prompt: str) -> List[str]:
+        if self.proposer_fn is not None:
+            return self.proposer_fn(prompt)
+
+        proposer = Predict(
+            Signature(
+                "task_description -> instructions",
+                instructions=(
+                    "Rewrite prompts to maximize task accuracy. Return the "
+                    "requested number of alternative instructions."
+                ),
+                outputs={
+                    "instructions": OutputField(
+                        desc="One proposed instruction per line, no numbering"
+                    )
+                },
+            ),
+            provider=self.provider or module.provider,
+            model=self.model or module.model,
+            inference_fn=module.inference_fn,
+        )
+        result = proposer(pl.DataFrame({"task_description": [prompt]}))
+        raw = result.get_column("pred_instructions")[0]
+        if not raw:
+            return []
+        return [line.strip("-• \t") for line in str(raw).splitlines() if line.strip()]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/daviddrummond95/polar_llama"
 documentation = "https://github.com/daviddrummond95/polar_llama#readme"
 keywords = ["llm", "polars", "parallel", "inference", "ai", "openai", "anthropic", "gemini", "groq", "bedrock", "chatgpt", "dataframe", "pydantic", "structured-outputs", "schema-validation"]
 license = {text = "MIT"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
@@ -21,11 +21,11 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Programming Language :: Rust",
@@ -36,7 +36,6 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "requests>=2.32.4",
     "pydantic>=2.0.0",
     "polars>=1.0.0",
 ]

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -5,7 +5,7 @@
 
 use crate::model_client::Provider;
 use tiktoken_rs::{cl100k_base, o200k_base, CoreBPE};
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use std::collections::HashMap;
 
 /// Pricing information for a model (costs per 1 million tokens in USD)
@@ -38,16 +38,30 @@ impl ModelPricing {
 
 /// Static pricing data for all supported models.
 /// Prices are in USD per 1 million tokens.
-/// Last updated: January 2025
+/// Last updated: June 2026
 ///
 /// Note: These prices should be periodically updated as providers change their pricing.
-static PRICING: Lazy<HashMap<(&'static str, &'static str), ModelPricing>> = Lazy::new(|| {
+static PRICING: LazyLock<HashMap<(&'static str, &'static str), ModelPricing>> = LazyLock::new(|| {
     let mut m = HashMap::new();
 
     // ============================================================================
     // OpenAI Models
     // https://openai.com/pricing
     // ============================================================================
+
+    // GPT-5 models
+    m.insert(("openai", "gpt-5"), ModelPricing::new(1.25, 10.00));
+    m.insert(("openai", "gpt-5-mini"), ModelPricing::new(0.25, 2.00));
+    m.insert(("openai", "gpt-5-nano"), ModelPricing::new(0.05, 0.40));
+
+    // GPT-4.1 models
+    m.insert(("openai", "gpt-4.1"), ModelPricing::new(2.00, 8.00));
+    m.insert(("openai", "gpt-4.1-mini"), ModelPricing::new(0.40, 1.60));
+    m.insert(("openai", "gpt-4.1-nano"), ModelPricing::new(0.10, 0.40));
+
+    // o-series reasoning models
+    m.insert(("openai", "o3"), ModelPricing::new(2.00, 8.00));
+    m.insert(("openai", "o4-mini"), ModelPricing::new(1.10, 4.40));
 
     // GPT-4o models
     m.insert(("openai", "gpt-4o"), ModelPricing::new(2.50, 10.00));
@@ -91,6 +105,24 @@ static PRICING: Lazy<HashMap<(&'static str, &'static str), ModelPricing>> = Lazy
     // https://www.anthropic.com/pricing
     // ============================================================================
 
+    // Claude 5 models
+    m.insert(("anthropic", "claude-fable-5"), ModelPricing::new(10.00, 50.00));
+
+    // Claude 4.x models
+    m.insert(("anthropic", "claude-opus-4-8"), ModelPricing::new(5.00, 25.00));
+    m.insert(("anthropic", "claude-opus-4-7"), ModelPricing::new(5.00, 25.00));
+    m.insert(("anthropic", "claude-opus-4-6"), ModelPricing::new(5.00, 25.00));
+    m.insert(("anthropic", "claude-opus-4-5"), ModelPricing::new(5.00, 25.00));
+    m.insert(("anthropic", "claude-opus-4-1"), ModelPricing::new(15.00, 75.00));
+    m.insert(("anthropic", "claude-opus-4-0"), ModelPricing::new(15.00, 75.00));
+    m.insert(("anthropic", "claude-sonnet-4-6"), ModelPricing::new(3.00, 15.00));
+    m.insert(("anthropic", "claude-sonnet-4-5"), ModelPricing::new(3.00, 15.00));
+    m.insert(("anthropic", "claude-sonnet-4-0"), ModelPricing::new(3.00, 15.00));
+    m.insert(("anthropic", "claude-haiku-4-5"), ModelPricing::new(1.00, 5.00));
+
+    // Claude 3.7 models
+    m.insert(("anthropic", "claude-3-7-sonnet-20250219"), ModelPricing::new(3.00, 15.00));
+
     // Claude 3.5 models
     m.insert(("anthropic", "claude-3-5-sonnet-20241022"), ModelPricing::new(3.00, 15.00));
     m.insert(("anthropic", "claude-3-5-sonnet-20240620"), ModelPricing::new(3.00, 15.00));
@@ -111,7 +143,14 @@ static PRICING: Lazy<HashMap<(&'static str, &'static str), ModelPricing>> = Lazy
     // https://ai.google.dev/pricing
     // ============================================================================
 
+    // Gemini 2.5 models
+    m.insert(("gemini", "gemini-2.5-pro"), ModelPricing::new(1.25, 10.00));
+    m.insert(("gemini", "gemini-2.5-flash"), ModelPricing::new(0.30, 2.50));
+    m.insert(("gemini", "gemini-2.5-flash-lite"), ModelPricing::new(0.10, 0.40));
+
     // Gemini 2.0 models
+    m.insert(("gemini", "gemini-2.0-flash"), ModelPricing::new(0.10, 0.40));
+    m.insert(("gemini", "gemini-2.0-flash-lite"), ModelPricing::new(0.075, 0.30));
     m.insert(("gemini", "gemini-2.0-flash-exp"), ModelPricing::new(0.00, 0.00)); // Free during preview
 
     // Gemini 1.5 models
@@ -154,6 +193,12 @@ static PRICING: Lazy<HashMap<(&'static str, &'static str), ModelPricing>> = Lazy
     // https://aws.amazon.com/bedrock/pricing/
     // Prices are for US East (N. Virginia) region
     // ============================================================================
+
+    // Claude 4.x via Bedrock (cross-region inference profiles)
+    m.insert(("bedrock", "us.anthropic.claude-haiku-4-5-20251001-v1:0"), ModelPricing::new(1.00, 5.00));
+    m.insert(("bedrock", "us.anthropic.claude-sonnet-4-5-20250929-v1:0"), ModelPricing::new(3.00, 15.00));
+    m.insert(("bedrock", "anthropic.claude-haiku-4-5-20251001-v1:0"), ModelPricing::new(1.00, 5.00));
+    m.insert(("bedrock", "anthropic.claude-sonnet-4-5-20250929-v1:0"), ModelPricing::new(3.00, 15.00));
 
     // Claude 3.5 via Bedrock
     m.insert(("bedrock", "anthropic.claude-3-5-sonnet-20241022-v2:0"), ModelPricing::new(3.00, 15.00));
@@ -213,11 +258,11 @@ pub fn get_pricing_by_str(provider: &str, model: &str) -> Option<ModelPricing> {
 /// Get the default model pricing for a provider
 pub fn get_default_pricing(provider: Provider) -> Option<ModelPricing> {
     let model = match provider {
-        Provider::OpenAI => "gpt-4-turbo",
-        Provider::Anthropic => "claude-3-opus-20240229",
-        Provider::Gemini => "gemini-1.5-pro",
-        Provider::Groq => "llama3-70b-8192",
-        Provider::Bedrock => "anthropic.claude-3-haiku-20240307-v1:0",
+        Provider::OpenAI => crate::model_client::openai::DEFAULT_OPENAI_MODEL,
+        Provider::Anthropic => crate::model_client::anthropic::DEFAULT_ANTHROPIC_MODEL,
+        Provider::Gemini => crate::model_client::gemini::DEFAULT_GEMINI_MODEL,
+        Provider::Groq => crate::model_client::groq::DEFAULT_GROQ_MODEL,
+        Provider::Bedrock => crate::model_client::bedrock::DEFAULT_BEDROCK_MODEL,
     };
     get_pricing(provider, model)
 }
@@ -227,11 +272,11 @@ pub fn get_default_pricing(provider: Provider) -> Option<ModelPricing> {
 // ============================================================================
 
 /// Cached tokenizer instances for performance
-static CL100K_TOKENIZER: Lazy<CoreBPE> = Lazy::new(|| {
+static CL100K_TOKENIZER: LazyLock<CoreBPE> = LazyLock::new(|| {
     cl100k_base().expect("Failed to load cl100k_base tokenizer")
 });
 
-static O200K_TOKENIZER: Lazy<CoreBPE> = Lazy::new(|| {
+static O200K_TOKENIZER: LazyLock<CoreBPE> = LazyLock::new(|| {
     o200k_base().expect("Failed to load o200k_base tokenizer")
 });
 
@@ -248,10 +293,13 @@ pub enum TokenizerType {
 pub fn get_tokenizer_type(model: &str) -> TokenizerType {
     let model_lower = model.to_lowercase();
 
-    // o200k_base models (GPT-4o family, o1 family)
+    // o200k_base models (GPT-4o, GPT-4.1, GPT-5 families and o-series)
     if model_lower.contains("gpt-4o")
+        || model_lower.contains("gpt-4.1")
+        || model_lower.contains("gpt-5")
         || model_lower.starts_with("o1")
-        || model_lower.contains("o1-")
+        || model_lower.starts_with("o3")
+        || model_lower.starts_with("o4")
     {
         return TokenizerType::O200kBase;
     }

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -2,19 +2,13 @@
 use crate::utils::*;
 use crate::model_client::{Provider, Message};
 use crate::cost;
-use once_cell::sync::Lazy;
 use polars::prelude::*;
-use polars_core::prelude::CompatLevel;
 use polars_core::chunked_array::builder::ListPrimitiveChunkedBuilder;
 use pyo3_polars::derive::polars_expr;
 use serde::Deserialize;
 use std::borrow::Cow;
-use tokio::runtime::Runtime;
 use std::str::FromStr;
 use polars::datatypes::DataType;
-
-// Initialize a global runtime for all async operations
-static RT: Lazy<Runtime> = Lazy::new(|| Runtime::new().expect("Failed to create Tokio runtime"));
 
 // Helper function to run async operations in a way that allows true parallelization
 // Instead of directly blocking on async work, we spawn it as a task and then block on the handle
@@ -47,12 +41,27 @@ fn parse_provider(provider_str: &str) -> Option<Provider> {
 /// Get default model for a given provider
 fn get_default_model(provider: Provider) -> &'static str {
     match provider {
-        Provider::OpenAI => "gpt-4-turbo",
-        Provider::Anthropic => "claude-3-opus-20240229",
-        Provider::Gemini => "gemini-1.5-pro",
-        Provider::Groq => "llama3-70b-8192",
-        Provider::Bedrock => "anthropic.claude-3-haiku-20240307-v1:0",
+        Provider::OpenAI => crate::model_client::openai::DEFAULT_OPENAI_MODEL,
+        Provider::Anthropic => crate::model_client::anthropic::DEFAULT_ANTHROPIC_MODEL,
+        Provider::Gemini => crate::model_client::gemini::DEFAULT_GEMINI_MODEL,
+        Provider::Groq => crate::model_client::groq::DEFAULT_GROQ_MODEL,
+        Provider::Bedrock => crate::model_client::bedrock::DEFAULT_BEDROCK_MODEL,
     }
+}
+
+/// Resolve the provider/model pair from kwargs, falling back to OpenAI and
+/// the provider's default model.
+fn resolve_provider_and_model(kwargs: &InferenceKwargs) -> (Provider, String) {
+    let provider = kwargs
+        .provider
+        .as_deref()
+        .and_then(parse_provider)
+        .unwrap_or(Provider::OpenAI);
+    let model = kwargs
+        .model
+        .clone()
+        .unwrap_or_else(|| get_default_model(provider).to_string());
+    (provider, model)
 }
 
 // This polars_expr annotation registers the function with Polars at build time
@@ -60,13 +69,7 @@ fn get_default_model(provider: Provider) -> &'static str {
 fn inference(inputs: &[Series], kwargs: InferenceKwargs) -> PolarsResult<Series> {
     let ca: &StringChunked = inputs[0].str()?;
 
-    // Determine provider and model
-    let provider = match &kwargs.provider {
-        Some(provider_str) => parse_provider(provider_str).unwrap_or(Provider::OpenAI),
-        None => Provider::OpenAI,
-    };
-
-    let model = kwargs.model.unwrap_or_else(|| get_default_model(provider).to_string());
+    let (provider, model) = resolve_provider_and_model(&kwargs);
 
     let out = ca.apply(|opt_value| {
         opt_value.map(|value| {
@@ -83,7 +86,7 @@ fn inference_async(inputs: &[Series], kwargs: InferenceKwargs) -> PolarsResult<S
     let input_series = &inputs[0];
 
     // Handle empty series or null dtype - return empty String series
-    if input_series.is_empty() || input_series.dtype() == &polars::datatypes::DataType::Null {
+    if input_series.is_empty() || input_series.dtype() == &DataType::Null {
         return Ok(StringChunked::from_iter_options(
             input_series.name().clone(),
             std::iter::empty::<Option<String>>(),
@@ -93,134 +96,37 @@ fn inference_async(inputs: &[Series], kwargs: InferenceKwargs) -> PolarsResult<S
     let ca: &StringChunked = input_series.str()?;
 
     // Collect all messages, keeping track of their original indices
-    let mut messages_with_indices: Vec<(usize, String)> = Vec::new();
+    let mut indices: Vec<usize> = Vec::new();
+    let mut messages: Vec<String> = Vec::new();
     for (idx, opt_value) in ca.into_iter().enumerate() {
         if let Some(value) = opt_value {
-            messages_with_indices.push((idx, value.to_owned()));
+            indices.push(idx);
+            messages.push(value.to_owned());
         }
     }
 
-    // Extract just the messages for the API calls
-    let messages: Vec<String> = messages_with_indices.iter().map(|(_, msg)| msg.clone()).collect();
+    let (provider, model) = resolve_provider_and_model(&kwargs);
+    let schema = kwargs.response_schema;
+    let model_name = kwargs.response_model_name;
 
-    // Get results based on provider and model
-    let api_results = if kwargs.response_schema.is_some() {
-        // Use structured output with validation
-        // Clone the strings so we can move them into async blocks
-        let schema_owned = kwargs.response_schema.clone();
-        let model_name_owned = kwargs.response_model_name.clone();
-
-        match (&kwargs.provider, &kwargs.model) {
-            (Some(provider_str), Some(model)) => {
-                // Try to parse provider string to Provider enum
-                if let Some(provider) = parse_provider(provider_str) {
-                    let messages_owned = messages.clone();
-                    let model_owned = model.clone();
-                    let schema = schema_owned.clone();
-                    let model_name = model_name_owned.clone();
-                    run_async(async move {
-                        fetch_data_with_provider_and_schema(&messages_owned, provider, &model_owned, schema.as_deref(), model_name.as_deref()).await
-                    })
-                } else {
-                    let messages_owned = messages.clone();
-                    let model_owned = model.clone();
-                    let schema = schema_owned.clone();
-                    let model_name = model_name_owned.clone();
-                    run_async(async move {
-                        fetch_data_with_provider_and_schema(&messages_owned, Provider::OpenAI, &model_owned, schema.as_deref(), model_name.as_deref()).await
-                    })
-                }
-            },
-            (Some(provider_str), None) => {
-                if let Some(provider) = parse_provider(provider_str) {
-                    let default_model = get_default_model(provider);
-                    let messages_owned = messages.clone();
-                    let schema = schema_owned.clone();
-                    let model_name = model_name_owned.clone();
-                    run_async(async move {
-                        fetch_data_with_provider_and_schema(&messages_owned, provider, default_model, schema.as_deref(), model_name.as_deref()).await
-                    })
-                } else {
-                    let default_model = get_default_model(Provider::OpenAI);
-                    let messages_owned = messages.clone();
-                    let schema = schema_owned.clone();
-                    let model_name = model_name_owned.clone();
-                    run_async(async move {
-                        fetch_data_with_provider_and_schema(&messages_owned, Provider::OpenAI, default_model, schema.as_deref(), model_name.as_deref()).await
-                    })
-                }
-            },
-            (None, Some(model)) => {
-                let messages_owned = messages.clone();
-                let model_owned = model.clone();
-                let schema = schema_owned.clone();
-                let model_name = model_name_owned.clone();
-                run_async(async move {
-                    fetch_data_with_provider_and_schema(&messages_owned, Provider::OpenAI, &model_owned, schema.as_deref(), model_name.as_deref()).await
-                })
-            },
-            (None, None) => {
-                let default_model = get_default_model(Provider::OpenAI);
-                let messages_owned = messages.clone();
-                let schema = schema_owned.clone();
-                let model_name = model_name_owned.clone();
-                run_async(async move {
-                    fetch_data_with_provider_and_schema(&messages_owned, Provider::OpenAI, default_model, schema.as_deref(), model_name.as_deref()).await
-                })
-            },
+    let api_results = run_async(async move {
+        if schema.is_some() {
+            fetch_data_with_provider_and_schema(
+                &messages,
+                provider,
+                &model,
+                schema.as_deref(),
+                model_name.as_deref(),
+            ).await
+        } else {
+            fetch_data_with_provider(&messages, provider, &model).await
         }
-    } else {
-        // Use regular inference without structured output
-        match (&kwargs.provider, &kwargs.model) {
-            (Some(provider_str), Some(model)) => {
-                if let Some(provider) = parse_provider(provider_str) {
-                    let messages_owned = messages.clone();
-                    let model_owned = model.clone();
-                    run_async(async move {
-                        fetch_data_with_provider(&messages_owned, provider, &model_owned).await
-                    })
-                } else {
-                    let messages_owned = messages.clone();
-                    let model_owned = model.clone();
-                    run_async(async move {
-                        fetch_data_with_provider(&messages_owned, Provider::OpenAI, &model_owned).await
-                    })
-                }
-            },
-            (Some(provider_str), None) => {
-                if let Some(provider) = parse_provider(provider_str) {
-                    let default_model = get_default_model(provider);
-                    let messages_owned = messages.clone();
-                    run_async(async move {
-                        fetch_data_with_provider(&messages_owned, provider, default_model).await
-                    })
-                } else {
-                    let messages_owned = messages.clone();
-                    run_async(async move {
-                        fetch_data(&messages_owned).await
-                    })
-                }
-            },
-            (None, Some(model)) => {
-                let messages_owned = messages.clone();
-                let model_owned = model.clone();
-                run_async(async move {
-                    fetch_data_with_provider(&messages_owned, Provider::OpenAI, &model_owned).await
-                })
-            },
-            (None, None) => {
-                let messages_owned = messages.clone();
-                run_async(async move {
-                    fetch_data(&messages_owned).await
-                })
-            },
-        }
-    };
+    });
 
     // Map results back to original positions
     let mut results: Vec<Option<String>> = vec![None; ca.len()];
-    for ((idx, _), result) in messages_with_indices.iter().zip(api_results.iter()) {
-        results[*idx] = result.clone();
+    for (idx, result) in indices.into_iter().zip(api_results) {
+        results[idx] = result;
     }
 
     let out = StringChunked::from_iter_options(ca.name().clone(), results.into_iter());
@@ -257,7 +163,7 @@ fn inference_messages(inputs: &[Series], kwargs: InferenceKwargs) -> PolarsResul
     let input_series = &inputs[0];
 
     // Handle empty series or null dtype - return empty String series
-    if input_series.is_empty() || input_series.dtype() == &polars::datatypes::DataType::Null {
+    if input_series.is_empty() || input_series.dtype() == &DataType::Null {
         return Ok(StringChunked::from_iter_options(
             input_series.name().clone(),
             std::iter::empty::<Option<String>>(),
@@ -267,134 +173,38 @@ fn inference_messages(inputs: &[Series], kwargs: InferenceKwargs) -> PolarsResul
     let ca: &StringChunked = input_series.str()?;
 
     // Collect message arrays, keeping track of their original indices
-    let mut arrays_with_indices: Vec<(usize, Vec<Message>)> = Vec::new();
+    let mut indices: Vec<usize> = Vec::new();
+    let mut message_arrays: Vec<Vec<Message>> = Vec::new();
     for (idx, opt) in ca.into_iter().enumerate() {
         if let Some(s) = opt {
             // Parse the JSON string into a vector of Messages
-            let messages = crate::utils::parse_message_json(s).unwrap_or_default();
-            arrays_with_indices.push((idx, messages));
+            indices.push(idx);
+            message_arrays.push(crate::utils::parse_message_json(s).unwrap_or_default());
         }
     }
 
-    // Extract just the message arrays for the API calls
-    let message_arrays: Vec<Vec<Message>> = arrays_with_indices.iter().map(|(_, arr)| arr.clone()).collect();
+    let (provider, model) = resolve_provider_and_model(&kwargs);
+    let schema = kwargs.response_schema;
+    let model_name = kwargs.response_model_name;
 
-    // Get results based on provider and model
-    let api_results = if kwargs.response_schema.is_some() {
-        // Use structured output with validation
-        // Clone the strings so we can move them into async blocks
-        let schema_owned = kwargs.response_schema.clone();
-        let model_name_owned = kwargs.response_model_name.clone();
-
-        match (&kwargs.provider, &kwargs.model) {
-            (Some(provider_str), Some(model)) => {
-                if let Some(provider) = parse_provider(provider_str) {
-                    let arrays_owned = message_arrays.clone();
-                    let model_owned = model.clone();
-                    let schema = schema_owned.clone();
-                    let model_name = model_name_owned.clone();
-                    run_async(async move {
-                        crate::utils::fetch_data_message_arrays_with_provider_and_schema(&arrays_owned, provider, &model_owned, schema.as_deref(), model_name.as_deref()).await
-                    })
-                } else {
-                    let arrays_owned = message_arrays.clone();
-                    let model_owned = model.clone();
-                    let schema = schema_owned.clone();
-                    let model_name = model_name_owned.clone();
-                    run_async(async move {
-                        crate::utils::fetch_data_message_arrays_with_provider_and_schema(&arrays_owned, Provider::OpenAI, &model_owned, schema.as_deref(), model_name.as_deref()).await
-                    })
-                }
-            },
-            (Some(provider_str), None) => {
-                if let Some(provider) = parse_provider(provider_str) {
-                    let default_model = get_default_model(provider);
-                    let arrays_owned = message_arrays.clone();
-                    let schema = schema_owned.clone();
-                    let model_name = model_name_owned.clone();
-                    run_async(async move {
-                        crate::utils::fetch_data_message_arrays_with_provider_and_schema(&arrays_owned, provider, default_model, schema.as_deref(), model_name.as_deref()).await
-                    })
-                } else {
-                    let default_model = get_default_model(Provider::OpenAI);
-                    let arrays_owned = message_arrays.clone();
-                    let schema = schema_owned.clone();
-                    let model_name = model_name_owned.clone();
-                    run_async(async move {
-                        crate::utils::fetch_data_message_arrays_with_provider_and_schema(&arrays_owned, Provider::OpenAI, default_model, schema.as_deref(), model_name.as_deref()).await
-                    })
-                }
-            },
-            (None, Some(model)) => {
-                let arrays_owned = message_arrays.clone();
-                let model_owned = model.clone();
-                let schema = schema_owned.clone();
-                let model_name = model_name_owned.clone();
-                run_async(async move {
-                    crate::utils::fetch_data_message_arrays_with_provider_and_schema(&arrays_owned, Provider::OpenAI, &model_owned, schema.as_deref(), model_name.as_deref()).await
-                })
-            },
-            (None, None) => {
-                let default_model = get_default_model(Provider::OpenAI);
-                let arrays_owned = message_arrays.clone();
-                let schema = schema_owned.clone();
-                let model_name = model_name_owned.clone();
-                run_async(async move {
-                    crate::utils::fetch_data_message_arrays_with_provider_and_schema(&arrays_owned, Provider::OpenAI, default_model, schema.as_deref(), model_name.as_deref()).await
-                })
-            },
+    let api_results = run_async(async move {
+        if schema.is_some() {
+            crate::utils::fetch_data_message_arrays_with_provider_and_schema(
+                &message_arrays,
+                provider,
+                &model,
+                schema.as_deref(),
+                model_name.as_deref(),
+            ).await
+        } else {
+            crate::utils::fetch_data_message_arrays_with_provider(&message_arrays, provider, &model).await
         }
-    } else {
-        // Use regular inference without structured output
-        match (&kwargs.provider, &kwargs.model) {
-            (Some(provider_str), Some(model)) => {
-                if let Some(provider) = parse_provider(provider_str) {
-                    let arrays_owned = message_arrays.clone();
-                    let model_owned = model.clone();
-                    run_async(async move {
-                        crate::utils::fetch_data_message_arrays_with_provider(&arrays_owned, provider, &model_owned).await
-                    })
-                } else {
-                    let arrays_owned = message_arrays.clone();
-                    run_async(async move {
-                        crate::utils::fetch_data_message_arrays(&arrays_owned).await
-                    })
-                }
-            },
-            (Some(provider_str), None) => {
-                if let Some(provider) = parse_provider(provider_str) {
-                    let default_model = get_default_model(provider);
-                    let arrays_owned = message_arrays.clone();
-                    run_async(async move {
-                        crate::utils::fetch_data_message_arrays_with_provider(&arrays_owned, provider, default_model).await
-                    })
-                } else {
-                    let arrays_owned = message_arrays.clone();
-                    run_async(async move {
-                        crate::utils::fetch_data_message_arrays(&arrays_owned).await
-                    })
-                }
-            },
-            (None, Some(model)) => {
-                let arrays_owned = message_arrays.clone();
-                let model_owned = model.clone();
-                run_async(async move {
-                    crate::utils::fetch_data_message_arrays_with_provider(&arrays_owned, Provider::OpenAI, &model_owned).await
-                })
-            },
-            (None, None) => {
-                let arrays_owned = message_arrays.clone();
-                run_async(async move {
-                    crate::utils::fetch_data_message_arrays(&arrays_owned).await
-                })
-            },
-        }
-    };
+    });
 
     // Map results back to original positions
     let mut results: Vec<Option<String>> = vec![None; ca.len()];
-    for ((idx, _), result) in arrays_with_indices.iter().zip(api_results.iter()) {
-        results[*idx] = result.clone();
+    for (idx, result) in indices.into_iter().zip(api_results) {
+        results[idx] = result;
     }
 
     let out = StringChunked::from_iter_options(ca.name().clone(), results.into_iter());
@@ -412,10 +222,14 @@ fn combine_messages(inputs: &[Series]) -> PolarsResult<Series> {
         ));
     }
 
-    // Get the first input to determine length and name
-    let first_ca = inputs[0].str()?;
-    let name = first_ca.name().clone();
-    let len = first_ca.len();
+    // Cast all inputs to string columns once, instead of once per row
+    let columns: Vec<&StringChunked> = inputs
+        .iter()
+        .map(|s| s.str())
+        .collect::<PolarsResult<Vec<_>>>()?;
+
+    let name = columns[0].name().clone();
+    let len = columns[0].len();
 
     // Create a vector to store the results for each row
     let mut result_values = Vec::with_capacity(len);
@@ -426,28 +240,27 @@ fn combine_messages(inputs: &[Series]) -> PolarsResult<Series> {
         let mut first = true;
 
         // Process each input column for this row
-        for input in inputs {
-            let ca = input.str()?;
+        for ca in &columns {
             if let Some(msg_str) = ca.get(i) {
                 // Skip empty messages
                 if msg_str.is_empty() {
                     continue;
                 }
-                
+
                 // Add comma if not the first message
                 if !first {
                     combined_messages.push(',');
                 }
-                
+
                 // Determine if this is a single message or an array of messages
-                if msg_str.starts_with("[") && msg_str.ends_with("]") {
+                if msg_str.starts_with('[') && msg_str.ends_with(']') {
                     // This is already an array, so remove the brackets
                     let inner = &msg_str[1..msg_str.len() - 1];
                     if !inner.is_empty() {
                         combined_messages.push_str(inner);
                         first = false;
                     }
-                } else if msg_str.starts_with("{") && msg_str.ends_with("}") {
+                } else if msg_str.starts_with('{') && msg_str.ends_with('}') {
                     // This is a single message, just append it
                     combined_messages.push_str(msg_str);
                     first = false;
@@ -462,9 +275,10 @@ fn combine_messages(inputs: &[Series]) -> PolarsResult<Series> {
                         },
                         Err(_) => {
                             // It's not valid JSON, wrap it as a user message
+                            let escaped = serde_json::to_string(msg_str)
+                                .unwrap_or_else(|_| "\"\"".to_string());
                             combined_messages.push_str(&format!(
-                                "{{\"role\": \"user\", \"content\": \"{}\"}}",
-                                msg_str.replace("\"", "\\\"")
+                                "{{\"role\": \"user\", \"content\": {escaped}}}"
                             ));
                             first = false;
                         }
@@ -472,10 +286,10 @@ fn combine_messages(inputs: &[Series]) -> PolarsResult<Series> {
                 }
             }
         }
-        
+
         // Close the array
         combined_messages.push(']');
-        
+
         // Add to results
         result_values.push(Some(combined_messages));
     }
@@ -527,15 +341,14 @@ fn embedding_async(inputs: &[Series], kwargs: EmbeddingKwargs) -> PolarsResult<S
     let ca: &StringChunked = input_series.str()?;
 
     // Collect all texts, keeping track of their original indices
-    let mut texts_with_indices: Vec<(usize, String)> = Vec::new();
+    let mut indices: Vec<usize> = Vec::new();
+    let mut texts: Vec<String> = Vec::new();
     for (idx, opt_value) in ca.into_iter().enumerate() {
         if let Some(value) = opt_value {
-            texts_with_indices.push((idx, value.to_owned()));
+            indices.push(idx);
+            texts.push(value.to_owned());
         }
     }
-
-    // Extract just the texts for the API calls
-    let texts: Vec<String> = texts_with_indices.iter().map(|(_, text)| text.clone()).collect();
 
     // Determine provider and model
     let provider = match &kwargs.provider {
@@ -548,17 +361,14 @@ fn embedding_async(inputs: &[Series], kwargs: EmbeddingKwargs) -> PolarsResult<S
         .unwrap_or_else(|| get_default_embedding_model(provider).to_string());
 
     // Fetch embeddings in parallel using spawn for true parallelization
-    // Clone data for 'static lifetime requirement of spawn
-    let texts_owned = texts.clone();
-    let model_owned = model.clone();
     let api_results = run_async(async move {
-        fetch_embeddings_with_provider(&texts_owned, provider, &model_owned).await
+        fetch_embeddings_with_provider(&texts, provider, &model).await
     });
 
     // Map results back to original positions
     let mut results: Vec<Option<Vec<f64>>> = vec![None; ca.len()];
-    for ((idx, _), result) in texts_with_indices.iter().zip(api_results.iter()) {
-        results[*idx] = result.clone();
+    for (idx, result) in indices.into_iter().zip(api_results) {
+        results[idx] = result;
     }
 
     // Convert Vec<Option<Vec<f64>>> to a Series with List<Float64> dtype
@@ -592,9 +402,19 @@ fn embedding_output_type(_input_fields: &[Field]) -> PolarsResult<Field> {
 // Vector Similarity Operations
 // ============================================================================
 
-/// Calculate cosine similarity between two embedding vectors
-#[polars_expr(output_type=Float64)]
-fn cosine_similarity(inputs: &[Series]) -> PolarsResult<Series> {
+/// Apply a binary metric over two List[Float64] columns element-wise.
+///
+/// Uses the contiguous-slice fast path when both vectors have no nulls
+/// (the common case for embeddings), falling back to a null-skipping
+/// element-wise iteration otherwise.
+fn binary_embedding_metric<F>(
+    inputs: &[Series],
+    metric_name: &str,
+    compute: F,
+) -> PolarsResult<Series>
+where
+    F: Fn(&[f64], &[f64]) -> f64,
+{
     let vec1 = inputs[0].list()?;
     let vec2 = inputs[1].list()?;
 
@@ -609,29 +429,24 @@ fn cosine_similarity(inputs: &[Series]) -> PolarsResult<Series> {
 
                     if arr1.len() != arr2.len() {
                         return Err(PolarsError::ComputeError(
-                            "Vectors must have the same length for cosine similarity".into()
+                            format!("Vectors must have the same length for {metric_name}").into()
                         ));
                     }
 
-                    let mut dot_product = 0.0;
-                    let mut norm1 = 0.0;
-                    let mut norm2 = 0.0;
-
-                    for i in 0..arr1.len() {
-                        if let (Some(a), Some(b)) = (arr1.get(i), arr2.get(i)) {
-                            dot_product += a * b;
-                            norm1 += a * a;
-                            norm2 += b * b;
+                    match (arr1.cont_slice(), arr2.cont_slice()) {
+                        (Ok(s1), Ok(s2)) => Ok(Some(compute(s1, s2))),
+                        _ => {
+                            // Null-aware fallback: skip positions where either side is null
+                            let mut s1 = Vec::with_capacity(arr1.len());
+                            let mut s2 = Vec::with_capacity(arr2.len());
+                            for (a, b) in arr1.iter().zip(arr2.iter()) {
+                                if let (Some(a), Some(b)) = (a, b) {
+                                    s1.push(a);
+                                    s2.push(b);
+                                }
+                            }
+                            Ok(Some(compute(&s1, &s2)))
                         }
-                    }
-
-                    norm1 = norm1.sqrt();
-                    norm2 = norm2.sqrt();
-
-                    if norm1 == 0.0 || norm2 == 0.0 {
-                        Ok(Some(0.0))
-                    } else {
-                        Ok(Some(dot_product / (norm1 * norm2)))
                     }
                 },
                 _ => Ok(None),
@@ -640,85 +455,51 @@ fn cosine_similarity(inputs: &[Series]) -> PolarsResult<Series> {
         .collect::<PolarsResult<Float64Chunked>>()?;
 
     Ok(out.into_series())
+}
+
+/// Calculate cosine similarity between two embedding vectors
+#[polars_expr(output_type=Float64)]
+fn cosine_similarity(inputs: &[Series]) -> PolarsResult<Series> {
+    binary_embedding_metric(inputs, "cosine similarity", |s1, s2| {
+        let mut dot_product = 0.0;
+        let mut norm1 = 0.0;
+        let mut norm2 = 0.0;
+        for (a, b) in s1.iter().zip(s2.iter()) {
+            dot_product += a * b;
+            norm1 += a * a;
+            norm2 += b * b;
+        }
+        norm1 = norm1.sqrt();
+        norm2 = norm2.sqrt();
+        if norm1 == 0.0 || norm2 == 0.0 {
+            0.0
+        } else {
+            dot_product / (norm1 * norm2)
+        }
+    })
 }
 
 /// Calculate dot product between two embedding vectors
 #[polars_expr(output_type=Float64)]
 fn dot_product(inputs: &[Series]) -> PolarsResult<Series> {
-    let vec1 = inputs[0].list()?;
-    let vec2 = inputs[1].list()?;
-
-    let out: Float64Chunked = vec1
-        .amortized_iter()
-        .zip(vec2.amortized_iter())
-        .map(|(opt_v1, opt_v2)| {
-            match (opt_v1, opt_v2) {
-                (Some(v1), Some(v2)) => {
-                    let arr1 = v1.as_ref().f64()?;
-                    let arr2 = v2.as_ref().f64()?;
-
-                    if arr1.len() != arr2.len() {
-                        return Err(PolarsError::ComputeError(
-                            "Vectors must have the same length for dot product".into()
-                        ));
-                    }
-
-                    let mut result = 0.0;
-
-                    for i in 0..arr1.len() {
-                        if let (Some(a), Some(b)) = (arr1.get(i), arr2.get(i)) {
-                            result += a * b;
-                        }
-                    }
-
-                    Ok(Some(result))
-                },
-                _ => Ok(None),
-            }
-        })
-        .collect::<PolarsResult<Float64Chunked>>()?;
-
-    Ok(out.into_series())
+    binary_embedding_metric(inputs, "dot product", |s1, s2| {
+        s1.iter().zip(s2.iter()).map(|(a, b)| a * b).sum()
+    })
 }
 
 /// Calculate Euclidean distance between two embedding vectors
 #[polars_expr(output_type=Float64)]
 fn euclidean_distance(inputs: &[Series]) -> PolarsResult<Series> {
-    let vec1 = inputs[0].list()?;
-    let vec2 = inputs[1].list()?;
-
-    let out: Float64Chunked = vec1
-        .amortized_iter()
-        .zip(vec2.amortized_iter())
-        .map(|(opt_v1, opt_v2)| {
-            match (opt_v1, opt_v2) {
-                (Some(v1), Some(v2)) => {
-                    let arr1 = v1.as_ref().f64()?;
-                    let arr2 = v2.as_ref().f64()?;
-
-                    if arr1.len() != arr2.len() {
-                        return Err(PolarsError::ComputeError(
-                            "Vectors must have the same length for Euclidean distance".into()
-                        ));
-                    }
-
-                    let mut sum_squared_diff = 0.0;
-
-                    for i in 0..arr1.len() {
-                        if let (Some(a), Some(b)) = (arr1.get(i), arr2.get(i)) {
-                            let diff = a - b;
-                            sum_squared_diff += diff * diff;
-                        }
-                    }
-
-                    Ok(Some(sum_squared_diff.sqrt()))
-                },
-                _ => Ok(None),
-            }
-        })
-        .collect::<PolarsResult<Float64Chunked>>()?;
-
-    Ok(out.into_series())
+    binary_embedding_metric(inputs, "Euclidean distance", |s1, s2| {
+        s1.iter()
+            .zip(s2.iter())
+            .map(|(a, b)| {
+                let diff = a - b;
+                diff * diff
+            })
+            .sum::<f64>()
+            .sqrt()
+    })
 }
 
 // ============================================================================
@@ -771,11 +552,11 @@ fn knn_hnsw(inputs: &[Series], kwargs: KnnKwargs) -> PolarsResult<Series> {
     let index = crate::ann::build_hnsw_index(ref_vecs);
 
     // Search for k-nearest neighbors for each query
-    let mut builder = polars_core::chunked_array::builder::ListPrimitiveChunkedBuilder::<polars_core::datatypes::Int64Type>::new(
+    let mut builder = ListPrimitiveChunkedBuilder::<Int64Type>::new(
         query_embeddings.name().clone(),
         query_embeddings.len(),
-        k * 2, // indices + distances
-        polars::datatypes::DataType::Int64,
+        k,
+        DataType::Int64,
     );
 
     for i in 0..query_embeddings.len() {
@@ -828,7 +609,7 @@ fn default_token_model() -> String {
 /// Count the number of tokens in each text string.
 ///
 /// Uses tiktoken tokenizers:
-/// - o200k_base for GPT-4o and o1 models
+/// - o200k_base for GPT-4o, GPT-4.1, GPT-5, and o-series models
 /// - cl100k_base for all other models (GPT-4, GPT-3.5, Claude, Llama, etc.)
 ///
 /// # Arguments
@@ -840,11 +621,14 @@ fn default_token_model() -> String {
 #[polars_expr(output_type=UInt64)]
 fn count_tokens(inputs: &[Series], kwargs: TokenCountKwargs) -> PolarsResult<Series> {
     let ca: &StringChunked = inputs[0].str()?;
-    let model = &kwargs.model;
+    // Resolve the tokenizer once per batch instead of once per row
+    let tokenizer_type = cost::get_tokenizer_type(&kwargs.model);
 
     let out: UInt64Chunked = ca
         .into_iter()
-        .map(|opt_value| opt_value.map(|value| cost::count_tokens(value, model) as u64))
+        .map(|opt_value| {
+            opt_value.map(|value| cost::count_tokens_with_tokenizer(value, tokenizer_type) as u64)
+        })
         .collect();
 
     Ok(out.into_series())
@@ -865,7 +649,7 @@ fn default_cost_provider() -> String {
 }
 
 fn default_cost_model() -> String {
-    "gpt-4-turbo".to_string()
+    "gpt-4o".to_string()
 }
 
 /// Calculate the input cost in USD for each text string based on token count.
@@ -876,8 +660,8 @@ fn default_cost_model() -> String {
 /// # Arguments
 /// * `provider` - The provider name: "openai", "anthropic", "gemini", "groq", or "bedrock".
 ///                Defaults to "openai".
-/// * `model` - The model name for pricing lookup (e.g., "gpt-4o", "claude-3-opus-20240229").
-///             Defaults to "gpt-4-turbo".
+/// * `model` - The model name for pricing lookup (e.g., "gpt-4o", "claude-opus-4-8").
+///             Defaults to "gpt-4o".
 ///
 /// # Returns
 /// A Float64 series with input costs in USD for each row.
@@ -903,15 +687,16 @@ fn calculate_input_cost(inputs: &[Series], kwargs: CostKwargs) -> PolarsResult<S
     // Parse provider
     let provider = parse_provider(provider_str).unwrap_or(Provider::OpenAI);
 
-    // Get pricing for this provider/model combination
+    // Resolve pricing and tokenizer once per batch
     let pricing = cost::get_pricing(provider, model);
+    let tokenizer_type = cost::get_tokenizer_type(model);
 
     let out: Float64Chunked = ca
         .into_iter()
         .map(|opt_value| {
             opt_value.and_then(|value| {
                 pricing.map(|p| {
-                    let token_count = cost::count_tokens(value, model);
+                    let token_count = cost::count_tokens_with_tokenizer(value, tokenizer_type);
                     p.calculate_input_cost(token_count)
                 })
             })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,19 +61,14 @@ fn register_expressions(_py: Python<'_>) -> PyResult<&'static str> {
 }
 
 #[pymodule]
-fn polar_llama(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
+fn polar_llama(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.setattr("__version__", env!("CARGO_PKG_VERSION"))?;
-    
+
     // Add the PyProvider class to the module
     m.add_class::<PyProvider>()?;
-    
+
     // Add the register_expressions function to the module
     m.add_function(wrap_pyfunction!(register_expressions, m)?)?;
-    
-    // Display a message in Python's stdout when the module is loaded
-    py.import("builtins")?.getattr("print")?.call1((
-        "polar_llama module loaded successfully. Polars expressions should be available.",
-    ))?;
-    
+
     Ok(())
 }

--- a/src/model_client/anthropic.rs
+++ b/src/model_client/anthropic.rs
@@ -2,7 +2,16 @@ use serde_json::{json, Value};
 use async_trait::async_trait;
 use super::{ModelClient, ModelClientError, Message, Provider};
 use serde::Deserialize;
-use reqwest::Client;
+
+/// Default Anthropic model
+pub const DEFAULT_ANTHROPIC_MODEL: &str = "claude-opus-4-8";
+
+/// Anthropic Messages API version header value
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+
+/// Maximum tokens to generate. The Messages API requires this parameter;
+/// 4096 is supported by every Claude model.
+const DEFAULT_MAX_TOKENS: u32 = 4096;
 
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
@@ -28,30 +37,16 @@ pub struct AnthropicClient {
 }
 
 impl AnthropicClient {
-    // Kept for backward compatibility but marked as deprecated
-    #[deprecated(since = "0.2.0", note = "Use new_with_model instead")]
-    pub fn new() -> Self {
-        Self {
-            model: "claude-3-opus-20240229".to_string(),
-        }
-    }
-    
     pub fn new_with_model(model: &str) -> Self {
         Self {
             model: model.to_string(),
         }
     }
-    
-    // Renamed to new_with_model, kept for backwards compatibility
-    #[deprecated(since = "0.2.0", note = "Use new_with_model instead")]
-    pub fn with_model(model: &str) -> Self {
-        Self::new_with_model(model)
-    }
 }
 
 impl Default for AnthropicClient {
     fn default() -> Self {
-        Self::new_with_model("claude-3-opus-20240229")
+        Self::new_with_model(DEFAULT_ANTHROPIC_MODEL)
     }
 }
 
@@ -60,73 +55,66 @@ impl ModelClient for AnthropicClient {
     fn provider(&self) -> Provider {
         Provider::Anthropic
     }
-    
+
     fn api_endpoint(&self) -> String {
-        "https://api.anthropic.com/v1/messages".to_string()
+        let base = std::env::var("ANTHROPIC_BASE_URL")
+            .unwrap_or_else(|_| "https://api.anthropic.com".to_string());
+        format!("{}/v1/messages", base.trim_end_matches('/'))
     }
-    
+
     fn model_name(&self) -> &str {
         &self.model
     }
-    
+
+    fn apply_auth(&self, request: reqwest::RequestBuilder, api_key: &str) -> reqwest::RequestBuilder {
+        request
+            .header("x-api-key", api_key)
+            .header("anthropic-version", ANTHROPIC_VERSION)
+    }
+
     fn format_messages(&self, messages: &[Message]) -> Value {
-        // Anthropic doesn't support system messages directly in the messages array
-        // We need to find a system message and extract it for the system parameter
-        let mut system_prompt = None;
-        let mut formatted_messages = Vec::new();
-        
-        for msg in messages {
-            match msg.role.as_str() {
-                "system" => {
-                    // Store the first system message encountered 
-                    if system_prompt.is_none() {
-                        system_prompt = Some(msg.content.clone());
-                    }
-                    // Don't add system messages to the regular messages array
-                },
-                "user" | "assistant" => {
-                    // Add user and assistant messages to the messages array
-                    formatted_messages.push(json!({
-                        "role": msg.role,
-                        "content": msg.content
-                    }));
-                },
-                _ => {
+        // The Messages API takes the system prompt as a top-level parameter,
+        // not as a message role; system messages are extracted in
+        // format_request_body and skipped here.
+        let formatted_messages: Vec<Value> = messages
+            .iter()
+            .filter(|msg| msg.role != "system")
+            .map(|msg| {
+                let role = match msg.role.as_str() {
+                    "user" | "assistant" => msg.role.as_str(),
                     // Default other roles to user
-                    formatted_messages.push(json!({
-                        "role": "user",
-                        "content": msg.content
-                    }));
-                }
-            }
-        }
-        
-        // Return the array of messages, system message is handled separately in format_request_body
+                    _ => "user",
+                };
+                json!({
+                    "role": role,
+                    "content": msg.content
+                })
+            })
+            .collect();
+
         json!(formatted_messages)
     }
-    
+
     fn format_request_body(&self, messages: &[Message], schema: Option<&str>, model_name: Option<&str>) -> Value {
-        // Extract system message if present
-        let system = messages.iter()
-            .find(|msg| msg.role == "system")
-            .map(|msg| msg.content.clone());
+        // Extract the first system message if present
+        let system = messages.iter().find(|msg| msg.role == "system");
 
         // Format messages (excluding system)
         let formatted_messages = self.format_messages(messages);
 
-        // Build request with or without system parameter
         let mut request = json!({
             "model": self.model_name(),
             "messages": formatted_messages,
-            "max_tokens": 4096
+            "max_tokens": DEFAULT_MAX_TOKENS
         });
 
         // Add system parameter if we found a system message
-        if let Some(system_content) = system {
-            request["system"] = json!(system_content);
+        if let Some(system_message) = system {
+            request["system"] = json!(system_message.content);
         }
 
-        // Add structured output support using tools if schema is provided
+        // Structured outputs via forced tool use: works across all current
+        // Claude models and the tool input is guaranteed to match the schema.
         if let Some(schema_str) = schema {
             if let Ok(schema_value) = serde_json::from_str::<Value>(schema_str) {
                 request["tools"] = json!([{
@@ -143,84 +131,27 @@ impl ModelClient for AnthropicClient {
 
         request
     }
-    
-    fn parse_response(&self, response_text: &str) -> Result<String, ModelClientError> {
-        match serde_json::from_str::<AnthropicResponse>(response_text) {
-            Ok(response) => {
-                // Check for tool use first (structured outputs)
-                for content in &response.content {
-                    if content.content_type == "tool_use" {
-                        if let Some(input) = &content.input {
-                            // Return the tool input as JSON string
-                            return serde_json::to_string(input)
-                                .map_err(|e| ModelClientError::ParseError(format!("Failed to serialize tool input: {}", e)));
-                        }
-                    }
-                }
 
-                // Fall back to text content
-                for content in &response.content {
-                    if content.content_type == "text" {
-                        if let Some(text) = &content.text {
-                            return Ok(text.clone());
-                        }
-                    }
+    fn parse_response(&self, response_text: &str) -> Result<String, ModelClientError> {
+        let response: AnthropicResponse = serde_json::from_str(response_text)?;
+
+        // Check for tool use first (structured outputs)
+        for content in &response.content {
+            if content.content_type == "tool_use" {
+                if let Some(input) = &content.input {
+                    // Return the tool input as JSON string
+                    return serde_json::to_string(input)
+                        .map_err(|e| ModelClientError::ParseError(format!("Failed to serialize tool input: {e}")));
                 }
-                Err(ModelClientError::ParseError("No text or tool_use content found".to_string()))
-            },
-            Err(err) => {
-                Err(ModelClientError::Serialization(err))
             }
         }
+
+        // Fall back to text content
+        response
+            .content
+            .into_iter()
+            .find(|content| content.content_type == "text")
+            .and_then(|content| content.text)
+            .ok_or_else(|| ModelClientError::ParseError("No text or tool_use content found".to_string()))
     }
-    
-    async fn send_request(&self, client: &Client, messages: &[Message]) -> Result<String, ModelClientError> {
-        let api_key = self.get_api_key();
-        let body = serde_json::to_string(&self.format_request_body(messages, None, None))?;
-
-        let response = client.post(self.api_endpoint())
-            .header("x-api-key", api_key)
-            .header("anthropic-version", "2023-06-01")
-            .header("Content-Type", "application/json")
-            .body(body)
-            .send()
-            .await?;
-
-        let status = response.status();
-        let text = response.text().await?;
-
-        if status.is_success() {
-            self.parse_response(&text)
-        } else {
-            Err(ModelClientError::Http(status.as_u16(), text))
-        }
-    }
-
-    async fn send_request_structured(
-        &self,
-        client: &Client,
-        messages: &[Message],
-        schema: Option<&str>,
-        model_name: Option<&str>
-    ) -> Result<String, ModelClientError> {
-        let api_key = self.get_api_key();
-        let body = serde_json::to_string(&self.format_request_body(messages, schema, model_name))?;
-
-        let response = client.post(self.api_endpoint())
-            .header("x-api-key", api_key)
-            .header("anthropic-version", "2023-06-01")
-            .header("Content-Type", "application/json")
-            .body(body)
-            .send()
-            .await?;
-
-        let status = response.status();
-        let text = response.text().await?;
-
-        if status.is_success() {
-            self.parse_response(&text)
-        } else {
-            Err(ModelClientError::Http(status.as_u16(), text))
-        }
-    }
-} 
+}

--- a/src/model_client/bedrock.rs
+++ b/src/model_client/bedrock.rs
@@ -2,6 +2,8 @@ use serde_json::{json, Value};
 use async_trait::async_trait;
 use super::{ModelClient, ModelClientError, Message, Provider};
 use reqwest::Client;
+use std::collections::HashMap;
+use std::sync::LazyLock;
 use aws_config::BehaviorVersion;
 use aws_sdk_bedrockruntime::{
     types::{
@@ -10,41 +12,54 @@ use aws_sdk_bedrockruntime::{
     Client as AwsBedrockClient,
 };
 
+/// Default Bedrock model (cross-region inference profile for Claude Haiku 4.5)
+pub const DEFAULT_BEDROCK_MODEL: &str = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
+
+/// AWS Bedrock clients cached per region. Loading the AWS config chain is
+/// expensive, so we do it once per region instead of once per request.
+static BEDROCK_CLIENTS: LazyLock<tokio::sync::Mutex<HashMap<String, AwsBedrockClient>>> =
+    LazyLock::new(|| tokio::sync::Mutex::new(HashMap::new()));
+
+async fn bedrock_client_for_region(region: &str) -> AwsBedrockClient {
+    let mut clients = BEDROCK_CLIENTS.lock().await;
+    if let Some(client) = clients.get(region) {
+        return client.clone();
+    }
+    let sdk_config = aws_config::defaults(BehaviorVersion::latest())
+        .region(aws_config::Region::new(region.to_string()))
+        .load()
+        .await;
+    let client = AwsBedrockClient::new(&sdk_config);
+    clients.insert(region.to_string(), client.clone());
+    client
+}
+
+#[derive(Clone)]
 pub struct BedrockClient {
     model: String,
     region: String,
-    bedrock_client: Option<Box<AwsBedrockClient>>,
 }
 
 impl BedrockClient {
     pub fn new_with_model(model: &str) -> Self {
+        let region = std::env::var("AWS_REGION")
+            .or_else(|_| std::env::var("AWS_DEFAULT_REGION"))
+            .unwrap_or_else(|_| "us-east-1".to_string());
         Self {
             model: model.to_string(),
-            region: "us-east-1".to_string(), // Default region
-            bedrock_client: None,
+            region,
         }
     }
-    
+
     pub fn with_region(mut self, region: &str) -> Self {
         self.region = region.to_string();
         self
     }
-    
-    async fn get_bedrock_client(&mut self) -> Result<&AwsBedrockClient, ModelClientError> {
-        if self.bedrock_client.is_none() {
-            let sdk_config = aws_config::defaults(BehaviorVersion::latest())
-                .region(aws_config::Region::new(self.region.clone()))
-                .load()
-                .await;
-            self.bedrock_client = Some(Box::new(AwsBedrockClient::new(&sdk_config)));
-        }
-        Ok(self.bedrock_client.as_ref().unwrap())
-    }
-    
+
     fn convert_messages_to_bedrock(&self, messages: &[Message]) -> (Option<SystemContentBlock>, Vec<BedrockMessage>) {
         let mut system_prompt = None;
         let mut bedrock_messages = Vec::new();
-        
+
         for msg in messages {
             match msg.role.as_str() {
                 "system" => {
@@ -53,28 +68,15 @@ impl BedrockClient {
                         system_prompt = Some(SystemContentBlock::Text(msg.content.clone()));
                     }
                 },
-                "user" => {
+                role => {
+                    let conversation_role = if role == "assistant" {
+                        ConversationRole::Assistant
+                    } else {
+                        // Default other roles to user
+                        ConversationRole::User
+                    };
                     if let Ok(bedrock_msg) = BedrockMessage::builder()
-                        .role(ConversationRole::User)
-                        .content(ContentBlock::Text(msg.content.clone()))
-                        .build()
-                    {
-                        bedrock_messages.push(bedrock_msg);
-                    }
-                },
-                "assistant" => {
-                    if let Ok(bedrock_msg) = BedrockMessage::builder()
-                        .role(ConversationRole::Assistant)
-                        .content(ContentBlock::Text(msg.content.clone()))
-                        .build()
-                    {
-                        bedrock_messages.push(bedrock_msg);
-                    }
-                },
-                _ => {
-                    // Default other roles to user
-                    if let Ok(bedrock_msg) = BedrockMessage::builder()
-                        .role(ConversationRole::User)
+                        .role(conversation_role)
                         .content(ContentBlock::Text(msg.content.clone()))
                         .build()
                     {
@@ -83,14 +85,14 @@ impl BedrockClient {
                 }
             }
         }
-        
+
         (system_prompt, bedrock_messages)
     }
 }
 
 impl Default for BedrockClient {
     fn default() -> Self {
-        Self::new_with_model("anthropic.claude-3-haiku-20240307-v1:0")
+        Self::new_with_model(DEFAULT_BEDROCK_MODEL)
     }
 }
 
@@ -99,32 +101,33 @@ impl ModelClient for BedrockClient {
     fn provider(&self) -> Provider {
         Provider::Bedrock
     }
-    
+
     fn api_endpoint(&self) -> String {
         // Bedrock doesn't use HTTP endpoints directly, but we need to implement this
         format!("https://bedrock-runtime.{}.amazonaws.com", self.region)
     }
-    
+
     fn model_name(&self) -> &str {
         &self.model
     }
-    
+
     fn format_messages(&self, messages: &[Message]) -> Value {
         // Convert to JSON for compatibility with the trait
-        let mut formatted_messages = Vec::new();
-
-        for msg in messages {
-            formatted_messages.push(json!({
-                "role": msg.role,
-                "content": msg.content
-            }));
-        }
+        let formatted_messages: Vec<Value> = messages
+            .iter()
+            .map(|msg| {
+                json!({
+                    "role": msg.role,
+                    "content": msg.content
+                })
+            })
+            .collect();
 
         json!(formatted_messages)
     }
 
     fn format_request_body(&self, messages: &[Message], _schema: Option<&str>, _model_name: Option<&str>) -> Value {
-        // Bedrock uses AWS SDK, not HTTP requests, but we need to implement this for trait compliance
+        // Bedrock uses the AWS SDK, not HTTP requests; implemented for trait compliance
         json!({
             "messages": self.format_messages(messages)
         })
@@ -132,64 +135,59 @@ impl ModelClient for BedrockClient {
 
     fn parse_response(&self, response_text: &str) -> Result<String, ModelClientError> {
         // For Bedrock, this method won't be used as we handle responses directly in send_request
-        // But we need to implement it for trait compliance
         Ok(response_text.to_string())
     }
-    
+
     async fn send_request(&self, _client: &Client, messages: &[Message]) -> Result<String, ModelClientError> {
-        // We don't use the reqwest client for Bedrock, we use the AWS SDK
-        let mut bedrock_client_ref = self.clone();
-        let bedrock_client = bedrock_client_ref.get_bedrock_client().await
-            .map_err(|e| ModelClientError::ParseError(format!("Failed to create Bedrock client: {e}")))?;
-        
+        // We don't use the reqwest client for Bedrock; we use the AWS SDK
+        let bedrock_client = bedrock_client_for_region(&self.region).await;
+
         let (system_prompt, bedrock_messages) = self.convert_messages_to_bedrock(messages);
-        
+
         let mut converse_request = bedrock_client
             .converse()
             .model_id(&self.model)
             .set_messages(Some(bedrock_messages));
-        
+
         if let Some(system) = system_prompt {
             converse_request = converse_request.system(system);
         }
-        
+
         let response = converse_request
             .send()
             .await
             .map_err(|e| ModelClientError::ParseError(format!("Bedrock API error: {e}")))?;
-        
+
         // Extract the response text
         if let Some(output) = response.output {
-            if output.is_message() {
-                if let Ok(message) = output.as_message() {
-                    for content in &message.content {
-                        if content.is_text() {
-                            if let Ok(text) = content.as_text() {
-                                return Ok(text.clone());
-                            }
-                        }
+            if let Ok(message) = output.as_message() {
+                for content in &message.content {
+                    if let Ok(text) = content.as_text() {
+                        return Ok(text.clone());
                     }
                 }
             }
         }
-        
+
         Err(ModelClientError::ParseError("No text content found in Bedrock response".to_string()))
     }
-    
+
+    async fn send_request_structured(
+        &self,
+        client: &Client,
+        messages: &[Message],
+        _schema: Option<&str>,
+        _model_name: Option<&str>
+    ) -> Result<String, ModelClientError> {
+        // Bedrock Converse does not take a JSON schema in this integration;
+        // responses are validated post-hoc by the caller. Delegating here
+        // (instead of inheriting the HTTP default) keeps the structured path
+        // on the AWS SDK.
+        self.send_request(client, messages).await
+    }
+
     fn get_api_key(&self) -> String {
         // Bedrock uses AWS credentials, not API keys
-        // AWS SDK handles authentication automatically
         String::new()
     }
 }
-
-// Implement Clone for BedrockClient to allow cloning for async operations
-impl Clone for BedrockClient {
-    fn clone(&self) -> Self {
-        Self {
-            model: self.model.clone(),
-            region: self.region.clone(),
-            bedrock_client: None, // Don't clone the client, it will be recreated as needed
-        }
-    }
-} 

--- a/src/model_client/gemini.rs
+++ b/src/model_client/gemini.rs
@@ -2,7 +2,9 @@ use serde_json::{json, Value};
 use async_trait::async_trait;
 use super::{ModelClient, ModelClientError, Message, Provider};
 use serde::Deserialize;
-use reqwest::Client;
+
+/// Default Gemini model
+pub const DEFAULT_GEMINI_MODEL: &str = "gemini-2.5-flash";
 
 #[derive(Debug, Deserialize)]
 struct GeminiResponse {
@@ -32,28 +34,13 @@ pub struct GeminiClient {
 }
 
 impl GeminiClient {
-    // Kept for backward compatibility but marked as deprecated
-    #[deprecated(since = "0.2.0", note = "Use new_with_model instead")]
-    pub fn new() -> Self {
-        Self {
-            model: "gemini-1.5-pro".to_string(),
-            api_key: None,
-        }
-    }
-    
     pub fn new_with_model(model: &str) -> Self {
         Self {
             model: model.to_string(),
             api_key: None,
         }
     }
-    
-    // Renamed to new_with_model, kept for backwards compatibility
-    #[deprecated(since = "0.2.0", note = "Use new_with_model instead")]
-    pub fn with_model(model: &str) -> Self {
-        Self::new_with_model(model)
-    }
-    
+
     pub fn with_api_key(mut self, api_key: &str) -> Self {
         self.api_key = Some(api_key.to_string());
         self
@@ -62,7 +49,7 @@ impl GeminiClient {
 
 impl Default for GeminiClient {
     fn default() -> Self {
-        Self::new_with_model("gemini-1.5-pro")
+        Self::new_with_model(DEFAULT_GEMINI_MODEL)
     }
 }
 
@@ -71,113 +58,84 @@ impl ModelClient for GeminiClient {
     fn provider(&self) -> Provider {
         Provider::Gemini
     }
-    
+
     fn api_endpoint(&self) -> String {
-        format!("https://generativelanguage.googleapis.com/v1beta/models/{}/generateContent", self.model)
+        format!("https://generativelanguage.googleapis.com/v1beta/models/{}:generateContent", self.model)
     }
-    
+
     fn model_name(&self) -> &str {
         &self.model
     }
-    
+
+    fn apply_auth(&self, request: reqwest::RequestBuilder, api_key: &str) -> reqwest::RequestBuilder {
+        // Gemini authenticates with the x-goog-api-key header. Using the
+        // header (rather than a ?key= query parameter) keeps the key out of
+        // URLs and logs, and works for both plain and structured requests.
+        request.header("x-goog-api-key", api_key)
+    }
+
     fn format_messages(&self, messages: &[Message]) -> Value {
-        // Check if we need to handle system message specially
-        let system_message = messages.iter().find(|msg| msg.role == "system");
-        
-        // Create formatted messages array
-        let mut formatted_messages = Vec::new();
-        
-        // If system message exists, add it first with special handling
-        if let Some(system) = system_message {
-            formatted_messages.push(json!({
-                "role": "user",
-                "parts": [
-                    {
-                        "text": format!("System instruction: {}", system.content)
-                    }
-                ]
-            }));
-        }
-        
-        // Add remaining non-system messages
-        for msg in messages.iter().filter(|msg| msg.role != "system") {
-            let role = match msg.role.as_str() {
-                "user" => "user",
-                "assistant" => "model", // Gemini uses "model" for assistant messages
-                _ => "user", // Default to user for unknown roles
-            };
-            
-            formatted_messages.push(json!({
-                "role": role,
-                "parts": [
-                    {
-                        "text": msg.content
-                    }
-                ]
-            }));
-        }
-        
+        // System messages are passed via the top-level system_instruction
+        // field (handled in format_request_body) and skipped here.
+        let formatted_messages: Vec<Value> = messages
+            .iter()
+            .filter(|msg| msg.role != "system")
+            .map(|msg| {
+                let role = match msg.role.as_str() {
+                    "assistant" => "model", // Gemini uses "model" for assistant messages
+                    _ => "user",
+                };
+                json!({
+                    "role": role,
+                    "parts": [{ "text": msg.content }]
+                })
+            })
+            .collect();
+
         json!(formatted_messages)
     }
-    
+
     fn format_request_body(&self, messages: &[Message], schema: Option<&str>, _model_name: Option<&str>) -> Value {
         let mut body = json!({
             "contents": self.format_messages(messages),
-            "generationConfig": {
-                "temperature": 0.7,
-                "maxOutputTokens": 1024
-            }
         });
 
-        // Gemini structured output support is limited, we'll use JSON mode and post-validate
-        if schema.is_some() {
-            body["generationConfig"]["response_mime_type"] = json!("application/json");
+        // Use the native system_instruction field for system prompts
+        if let Some(system) = messages.iter().find(|msg| msg.role == "system") {
+            body["system_instruction"] = json!({
+                "parts": [{ "text": system.content }]
+            });
+        }
+
+        // Native structured output: constrain the response to the JSON schema.
+        // Responses are additionally validated post-hoc by the caller.
+        if let Some(schema_str) = schema {
+            let mut generation_config = json!({
+                "response_mime_type": "application/json"
+            });
+            if let Ok(schema_value) = serde_json::from_str::<Value>(schema_str) {
+                generation_config["response_json_schema"] = schema_value;
+            }
+            body["generationConfig"] = generation_config;
         }
 
         body
     }
 
     fn parse_response(&self, response_text: &str) -> Result<String, ModelClientError> {
-        match serde_json::from_str::<GeminiResponse>(response_text) {
-            Ok(response) => {
-                if let Some(candidate) = response.candidates.first() {
-                    if let Some(part) = candidate.content.parts.first() {
-                        return Ok(part.text.clone());
-                    }
-                }
-                Err(ModelClientError::ParseError("No response content".to_string()))
-            },
-            Err(err) => {
-                Err(ModelClientError::Serialization(err))
-            }
-        }
+        let response: GeminiResponse = serde_json::from_str(response_text)?;
+        response
+            .candidates
+            .into_iter()
+            .next()
+            .and_then(|candidate| candidate.content.parts.into_iter().next())
+            .map(|part| part.text)
+            .ok_or_else(|| ModelClientError::ParseError("No response content".to_string()))
     }
 
-    async fn send_request(&self, client: &Client, messages: &[Message]) -> Result<String, ModelClientError> {
-        let api_key = self.get_api_key();
-        let body = serde_json::to_string(&self.format_request_body(messages, None, None))?;
-
-        let url = format!("{}?key={}", self.api_endpoint(), api_key);
-
-        let response = client.post(url)
-            .header("Content-Type", "application/json")
-            .body(body)
-            .send()
-            .await?;
-
-        let status = response.status();
-        let text = response.text().await?;
-
-        if status.is_success() {
-            self.parse_response(&text)
-        } else {
-            Err(ModelClientError::Http(status.as_u16(), text))
-        }
-    }
-    
     fn get_api_key(&self) -> String {
         self.api_key.clone().unwrap_or_else(|| {
             std::env::var("GEMINI_API_KEY").unwrap_or_default()
         })
     }
-} 
+}

--- a/src/model_client/groq.rs
+++ b/src/model_client/groq.rs
@@ -2,7 +2,9 @@ use serde_json::{json, Value};
 use async_trait::async_trait;
 use super::{ModelClient, ModelClientError, Message, Provider};
 use serde::Deserialize;
-use reqwest::Client;
+
+/// Default Groq model (llama3-70b-8192 was decommissioned by Groq)
+pub const DEFAULT_GROQ_MODEL: &str = "llama-3.3-70b-versatile";
 
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
@@ -10,7 +12,6 @@ struct GroqCompletion {
     id: String,
     model: String,
     choices: Vec<GroqChoice>,
-    usage: GroqUsage,
 }
 
 #[derive(Debug, Deserialize)]
@@ -18,22 +19,14 @@ struct GroqCompletion {
 struct GroqChoice {
     index: i32,
     message: GroqMessage,
-    finish_reason: String,
+    finish_reason: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
 struct GroqMessage {
     role: String,
-    content: String,
-}
-
-#[derive(Debug, Deserialize)]
-#[allow(dead_code)]
-struct GroqUsage {
-    prompt_tokens: i32,
-    completion_tokens: i32,
-    total_tokens: i32,
+    content: Option<String>,
 }
 
 pub struct GroqClient {
@@ -41,30 +34,16 @@ pub struct GroqClient {
 }
 
 impl GroqClient {
-    // Kept for backward compatibility but marked as deprecated
-    #[deprecated(since = "0.2.0", note = "Use new_with_model instead")]
-    pub fn new() -> Self {
-        Self {
-            model: "llama3-70b-8192".to_string(),
-        }
-    }
-    
     pub fn new_with_model(model: &str) -> Self {
         Self {
             model: model.to_string(),
         }
     }
-    
-    // Renamed to new_with_model, kept for backwards compatibility
-    #[deprecated(since = "0.2.0", note = "Use new_with_model instead")]
-    pub fn with_model(model: &str) -> Self {
-        Self::new_with_model(model)
-    }
 }
 
 impl Default for GroqClient {
     fn default() -> Self {
-        Self::new_with_model("llama3-70b-8192")
+        Self::new_with_model(DEFAULT_GROQ_MODEL)
     }
 }
 
@@ -73,18 +52,17 @@ impl ModelClient for GroqClient {
     fn provider(&self) -> Provider {
         Provider::Groq
     }
-    
+
     fn api_endpoint(&self) -> String {
         "https://api.groq.com/openai/v1/chat/completions".to_string()
     }
-    
+
     fn model_name(&self) -> &str {
         &self.model
     }
-    
+
     fn format_messages(&self, messages: &[Message]) -> Value {
-        // Groq uses OpenAI-compatible API, so all standard roles work
-        // but we still validate and sanitize the roles
+        // Groq uses an OpenAI-compatible API, so all standard roles work
         let formatted_messages = messages.iter().map(|msg| {
             let role = match msg.role.as_str() {
                 "system" => "system",
@@ -93,23 +71,20 @@ impl ModelClient for GroqClient {
                 // Default unknown roles to user
                 _ => "user",
             };
-            
+
             json!({
                 "role": role,
                 "content": msg.content
             })
         }).collect::<Vec<_>>();
-        
+
         json!(formatted_messages)
     }
-    
+
     fn format_request_body(&self, messages: &[Message], schema: Option<&str>, model_name: Option<&str>) -> Value {
-        // Build a request similar to OpenAI
         let mut body = json!({
             "model": self.model_name(),
             "messages": self.format_messages(messages),
-            "temperature": 0.7,
-            "max_tokens": 1024
         });
 
         // Add structured output support if schema is provided (Groq supports OpenAI format)
@@ -130,38 +105,12 @@ impl ModelClient for GroqClient {
     }
 
     fn parse_response(&self, response_text: &str) -> Result<String, ModelClientError> {
-        match serde_json::from_str::<GroqCompletion>(response_text) {
-            Ok(completion) => {
-                if let Some(choice) = completion.choices.first() {
-                    Ok(choice.message.content.clone())
-                } else {
-                    Err(ModelClientError::ParseError("No response content".to_string()))
-                }
-            },
-            Err(err) => {
-                Err(ModelClientError::Serialization(err))
-            }
-        }
+        let completion: GroqCompletion = serde_json::from_str(response_text)?;
+        completion
+            .choices
+            .into_iter()
+            .next()
+            .and_then(|choice| choice.message.content)
+            .ok_or_else(|| ModelClientError::ParseError("No response content".to_string()))
     }
-
-    async fn send_request(&self, client: &Client, messages: &[Message]) -> Result<String, ModelClientError> {
-        let api_key = self.get_api_key();
-        let body = serde_json::to_string(&self.format_request_body(messages, None, None))?;
-
-        let response = client.post(self.api_endpoint())
-            .bearer_auth(api_key)
-            .header("Content-Type", "application/json")
-            .body(body)
-            .send()
-            .await?;
-
-        let status = response.status();
-        let text = response.text().await?;
-
-        if status.is_success() {
-            self.parse_response(&text)
-        } else {
-            Err(ModelClientError::Http(status.as_u16(), text))
-        }
-    }
-} 
+}

--- a/src/model_client/mod.rs
+++ b/src/model_client/mod.rs
@@ -7,11 +7,38 @@ pub mod bedrock;
 use reqwest::Client;
 use std::error::Error;
 use std::fmt;
+use std::sync::LazyLock;
+use std::time::Duration;
 use serde_json::Value;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
-use futures;
+use futures::StreamExt;
+
+/// Shared HTTP client reused across all requests so connections are pooled
+/// instead of being re-established for every batch.
+static HTTP_CLIENT: LazyLock<Client> = LazyLock::new(|| {
+    Client::builder()
+        .timeout(Duration::from_secs(600))
+        .connect_timeout(Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| Client::new())
+});
+
+/// Access the shared HTTP client.
+pub fn http_client() -> &'static Client {
+    &HTTP_CLIENT
+}
+
+/// Maximum number of concurrent in-flight requests per batch.
+/// Override with the POLAR_LLAMA_MAX_CONCURRENCY environment variable.
+fn max_concurrency() -> usize {
+    std::env::var("POLAR_LLAMA_MAX_CONCURRENCY")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(64)
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Message {
@@ -111,26 +138,15 @@ pub trait ModelClient {
     /// Parse the API response to extract the completion text
     fn parse_response(&self, response_text: &str) -> Result<String, ModelClientError>;
 
+    /// Attach provider-specific authentication to a request.
+    /// Default: OpenAI-style Bearer token.
+    fn apply_auth(&self, request: reqwest::RequestBuilder, api_key: &str) -> reqwest::RequestBuilder {
+        request.bearer_auth(api_key)
+    }
+
     /// Send a request to the API
     async fn send_request(&self, client: &Client, messages: &[Message]) -> Result<String, ModelClientError> {
-        let api_key = self.get_api_key();
-        let body = serde_json::to_string(&self.format_request_body(messages, None, None))?;
-
-        let response = client.post(self.api_endpoint())
-            .bearer_auth(api_key)
-            .header("Content-Type", "application/json")
-            .body(body)
-            .send()
-            .await?;
-
-        let status = response.status();
-        let text = response.text().await?;
-
-        if status.is_success() {
-            self.parse_response(&text)
-        } else {
-            Err(ModelClientError::Http(status.as_u16(), text))
-        }
+        self.send_request_structured(client, messages, None, None).await
     }
 
     /// Send a request with structured output support
@@ -142,12 +158,11 @@ pub trait ModelClient {
         model_name: Option<&str>
     ) -> Result<String, ModelClientError> {
         let api_key = self.get_api_key();
-        let body = serde_json::to_string(&self.format_request_body(messages, schema, model_name))?;
+        let body = self.format_request_body(messages, schema, model_name);
 
-        let response = client.post(self.api_endpoint())
-            .bearer_auth(api_key)
-            .header("Content-Type", "application/json")
-            .body(body)
+        let response = self
+            .apply_auth(client.post(self.api_endpoint()), &api_key)
+            .json(&body)
             .send()
             .await?;
 
@@ -185,8 +200,7 @@ pub trait ModelClient {
                         });
                     },
                     Provider::Anthropic => {
-                        // Anthropic uses a different approach - we'll handle this in the client implementation
-                        // For now, we'll add it as a tool
+                        // Anthropic uses forced tool use for structured outputs
                         body["tools"] = serde_json::json!([{
                             "name": model_name.unwrap_or("response"),
                             "description": "Extract structured data according to the schema",
@@ -258,36 +272,57 @@ pub trait EmbeddingClient {
     }
 }
 
-/// Validate JSON response against a JSON schema
-pub fn validate_json_schema(response: &str, schema_str: &str) -> Result<(), String> {
-    // Parse the response as JSON
-    let response_value: Value = serde_json::from_str(response)
-        .map_err(|e| format!("Failed to parse response as JSON: {}", e))?;
+/// A JSON schema compiled once per batch, instead of once per row.
+enum SchemaCheck {
+    None,
+    Valid(jsonschema::Validator),
+    Invalid(String),
+}
 
-    // Parse the schema
-    let schema: Value = serde_json::from_str(schema_str)
-        .map_err(|e| format!("Failed to parse schema: {}", e))?;
+impl SchemaCheck {
+    fn compile(schema: Option<&str>) -> Self {
+        match schema {
+            None => SchemaCheck::None,
+            Some(schema_str) => {
+                let schema_value: Value = match serde_json::from_str(schema_str) {
+                    Ok(v) => v,
+                    Err(e) => return SchemaCheck::Invalid(format!("Failed to parse schema: {e}")),
+                };
+                match jsonschema::validator_for(&schema_value) {
+                    Ok(validator) => SchemaCheck::Valid(validator),
+                    Err(e) => SchemaCheck::Invalid(format!("Failed to compile schema: {e}")),
+                }
+            }
+        }
+    }
 
-    // Compile the schema
-    let compiled_schema = jsonschema::validator_for(&schema)
-        .map_err(|e| format!("Failed to compile schema: {}", e))?;
+    /// Validate a response against the compiled schema.
+    fn validate(&self, response: &str) -> Result<(), String> {
+        let validator = match self {
+            SchemaCheck::None => return Ok(()),
+            SchemaCheck::Invalid(err) => return Err(err.clone()),
+            SchemaCheck::Valid(v) => v,
+        };
 
-    // Validate the response
-    if compiled_schema.is_valid(&response_value) {
-        Ok(())
-    } else {
-        // Collect validation errors with details
-        let errors: Vec<String> = compiled_schema
+        let response_value: Value = serde_json::from_str(response)
+            .map_err(|e| format!("Failed to parse response as JSON: {e}"))?;
+
+        let errors: Vec<String> = validator
             .iter_errors(&response_value)
-            .map(|e| format!("{} at {}", e, e.instance_path))
+            .map(|e| format!("{} at {}", e, e.instance_path()))
             .collect();
 
         if errors.is_empty() {
-            Err("Response does not match the provided schema".to_string())
+            Ok(())
         } else {
             Err(format!("Schema validation failed: {}", errors.join("; ")))
         }
     }
+}
+
+/// Validate JSON response against a JSON schema
+pub fn validate_json_schema(response: &str, schema_str: &str) -> Result<(), String> {
+    SchemaCheck::compile(Some(schema_str)).validate(response)
 }
 
 /// Create an error response object
@@ -318,36 +353,82 @@ pub fn create_client(provider: Provider, model: &str) -> Box<dyn ModelClient + S
     }
 }
 
+/// Core batch runner: sends all requests concurrently (bounded by
+/// `max_concurrency`) over the shared HTTP client, preserving input order.
+///
+/// When `errors_as_json` is true, request errors are surfaced as structured
+/// error JSON objects; otherwise they map to `None`.
+async fn run_one<T: ModelClient + Sync + ?Sized>(
+    client: &T,
+    messages: &[Message],
+    schema: Option<&str>,
+    model_name: Option<&str>,
+    schema_check: &SchemaCheck,
+    errors_as_json: bool,
+) -> Option<String> {
+    match client.send_request_structured(http_client(), messages, schema, model_name).await {
+        Ok(response) => {
+            match schema_check.validate(&response) {
+                Ok(()) => Some(response),
+                Err(validation_error) => Some(create_error_response(
+                    "validation_failed",
+                    &validation_error,
+                    Some(&response),
+                )),
+            }
+        },
+        Err(e) => {
+            eprintln!("Error fetching from {}: {}", client.provider_name(), e);
+            if errors_as_json {
+                Some(create_error_response("api_error", &e.to_string(), None))
+            } else {
+                None
+            }
+        }
+    }
+}
+
+async fn run_batch<T: ModelClient + Sync + ?Sized>(
+    client: &T,
+    message_arrays: &[Vec<Message>],
+    schema: Option<&str>,
+    model_name: Option<&str>,
+    errors_as_json: bool,
+) -> Vec<Option<String>> {
+    let schema_check = SchemaCheck::compile(schema);
+
+    // Collect the futures eagerly so the stream holds concrete future values;
+    // requests still only run when polled, bounded by `buffered`.
+    let requests: Vec<_> = message_arrays
+        .iter()
+        .map(|messages| run_one(client, messages, schema, model_name, &schema_check, errors_as_json))
+        .collect();
+
+    futures::stream::iter(requests)
+        .buffered(max_concurrency())
+        .collect()
+        .await
+}
+
+fn to_user_message_arrays(messages: &[String]) -> Vec<Vec<Message>> {
+    messages
+        .iter()
+        .map(|content| {
+            vec![Message {
+                role: "user".to_string(),
+                content: content.clone(),
+            }]
+        })
+        .collect()
+}
+
 /// The main function to fetch data from model providers
 pub async fn fetch_data_generic<T: ModelClient + Sync + ?Sized>(
     client: &T,
     messages: &[String]
 ) -> Vec<Option<String>> {
-    let reqwest_client = Client::builder()
-        .danger_accept_invalid_certs(true)
-        .build()
-        .unwrap_or_else(|_| Client::new());
-
-    let fetch_tasks = messages.iter().map(|content| {
-        let formatted_message = Message {
-            role: "user".to_string(),
-            content: content.clone(),
-        };
-        let messages = vec![formatted_message];
-        let reqwest_client = &reqwest_client;
-
-        async move {
-            match client.send_request(reqwest_client, &messages).await {
-                Ok(response) => Some(response),
-                Err(e) => {
-                    eprintln!("Error fetching from {}: {}", client.provider_name(), e);
-                    None
-                }
-            }
-        }
-    }).collect::<Vec<_>>();
-
-    futures::future::join_all(fetch_tasks).await
+    let message_arrays = to_user_message_arrays(messages);
+    run_batch(client, &message_arrays, None, None, false).await
 }
 
 /// Fetch data with structured output support and validation
@@ -357,50 +438,8 @@ pub async fn fetch_data_generic_with_schema<T: ModelClient + Sync + ?Sized>(
     schema: Option<&str>,
     model_name: Option<&str>
 ) -> Vec<Option<String>> {
-    let reqwest_client = Client::builder()
-        .danger_accept_invalid_certs(true)
-        .build()
-        .unwrap_or_else(|_| Client::new());
-
-    let fetch_tasks = messages.iter().map(|content| {
-        let formatted_message = Message {
-            role: "user".to_string(),
-            content: content.clone(),
-        };
-        let messages = vec![formatted_message];
-        let reqwest_client = &reqwest_client;
-        let schema_owned = schema.map(|s| s.to_string());
-        let model_name_owned = model_name.map(|s| s.to_string());
-
-        async move {
-            match client.send_request_structured(
-                reqwest_client,
-                &messages,
-                schema_owned.as_deref(),
-                model_name_owned.as_deref()
-            ).await {
-                Ok(response) => {
-                    // Validate if schema is provided
-                    if let Some(schema_str) = schema_owned.as_deref() {
-                        match validate_json_schema(&response, schema_str) {
-                            Ok(_) => Some(response),
-                            Err(validation_error) => {
-                                Some(create_error_response("validation_failed", &validation_error, Some(&response)))
-                            }
-                        }
-                    } else {
-                        Some(response)
-                    }
-                },
-                Err(e) => {
-                    eprintln!("Error fetching from {}: {}", client.provider_name(), e);
-                    Some(create_error_response("api_error", &e.to_string(), None))
-                }
-            }
-        }
-    }).collect::<Vec<_>>();
-
-    futures::future::join_all(fetch_tasks).await
+    let message_arrays = to_user_message_arrays(messages);
+    run_batch(client, &message_arrays, schema, model_name, true).await
 }
 
 /// Enhanced function to fetch data that supports either single messages or arrays of messages
@@ -408,27 +447,7 @@ pub async fn fetch_data_generic_enhanced<T: ModelClient + Sync + ?Sized>(
     client: &T,
     message_arrays: &[Vec<Message>]
 ) -> Vec<Option<String>> {
-    let reqwest_client = Client::builder()
-        .danger_accept_invalid_certs(true)
-        .build()
-        .unwrap_or_else(|_| Client::new());
-
-    let fetch_tasks = message_arrays.iter().map(|messages| {
-        let messages = messages.clone();
-        let reqwest_client = &reqwest_client;
-
-        async move {
-            match client.send_request(reqwest_client, &messages).await {
-                Ok(response) => Some(response),
-                Err(e) => {
-                    eprintln!("Error fetching from {}: {}", client.provider_name(), e);
-                    None
-                }
-            }
-        }
-    }).collect::<Vec<_>>();
-
-    futures::future::join_all(fetch_tasks).await
+    run_batch(client, message_arrays, None, None, false).await
 }
 
 /// Enhanced function with schema validation for message arrays
@@ -438,57 +457,13 @@ pub async fn fetch_data_generic_enhanced_with_schema<T: ModelClient + Sync + ?Si
     schema: Option<&str>,
     model_name: Option<&str>
 ) -> Vec<Option<String>> {
-    let reqwest_client = Client::builder()
-        .danger_accept_invalid_certs(true)
-        .build()
-        .unwrap_or_else(|_| Client::new());
-
-    let fetch_tasks = message_arrays.iter().map(|messages| {
-        let messages = messages.clone();
-        let reqwest_client = &reqwest_client;
-        let schema_owned = schema.map(|s| s.to_string());
-        let model_name_owned = model_name.map(|s| s.to_string());
-
-        async move {
-            match client.send_request_structured(
-                reqwest_client,
-                &messages,
-                schema_owned.as_deref(),
-                model_name_owned.as_deref()
-            ).await {
-                Ok(response) => {
-                    // Validate if schema is provided
-                    if let Some(schema_str) = schema_owned.as_deref() {
-                        match validate_json_schema(&response, schema_str) {
-                            Ok(_) => Some(response),
-                            Err(validation_error) => {
-                                Some(create_error_response("validation_failed", &validation_error, Some(&response)))
-                            }
-                        }
-                    } else {
-                        Some(response)
-                    }
-                },
-                Err(e) => {
-                    eprintln!("Error fetching from {}: {}", client.provider_name(), e);
-                    Some(create_error_response("api_error", &e.to_string(), None))
-                }
-            }
-        }
-    }).collect::<Vec<_>>();
-
-    futures::future::join_all(fetch_tasks).await
+    run_batch(client, message_arrays, schema, model_name, true).await
 }
 
 /// Example function showing how to use the different model clients with specific models
 pub async fn example_usage(messages: &[String], provider_str: &str, model: &str) -> Vec<Option<String>> {
-    // Parse provider string to Provider enum
     let provider = Provider::from_str(provider_str).unwrap_or(Provider::OpenAI);
-    
-    // Create appropriate client with specified model
     let client = create_client(provider, model);
-    
-    // Use client with generic fetch function
     fetch_data_generic(&*client, messages).await
 }
 
@@ -498,44 +473,35 @@ pub async fn example_usage_enhanced(
     provider_str: &str,
     model: &str
 ) -> Vec<Option<String>> {
-    // Parse provider string to Provider enum
     let provider = Provider::from_str(provider_str).unwrap_or(Provider::OpenAI);
-
-    // Create appropriate client with specified model
     let client = create_client(provider, model);
-
-    // Use client with enhanced generic fetch function
     fetch_data_generic_enhanced(&*client, message_arrays).await
 }
 
-/// Parallel embedding generation function
-/// Uses futures::join_all for memory-efficient parallel processing
+async fn embed_one<T: EmbeddingClient + Sync + ?Sized>(
+    client: &T,
+    text: &String,
+) -> Option<Vec<f64>> {
+    match client.generate_embeddings(http_client(), std::slice::from_ref(text)).await {
+        Ok(embeddings) => embeddings.into_iter().next(),
+        Err(e) => {
+            eprintln!("Error generating embedding from {}: {}", client.provider_name(), e);
+            None
+        }
+    }
+}
+
+/// Parallel embedding generation function with bounded concurrency
 pub async fn fetch_embeddings_generic<T: EmbeddingClient + Sync + ?Sized>(
     client: &T,
     texts: &[String]
 ) -> Vec<Option<Vec<f64>>> {
-    let reqwest_client = Client::builder()
-        .danger_accept_invalid_certs(true)
-        .build()
-        .unwrap_or_else(|_| Client::new());
+    let requests: Vec<_> = texts.iter().map(|text| embed_one(client, text)).collect();
 
-    // Process each text individually for parallelization
-    let fetch_tasks = texts.iter().map(|text| {
-        let text_batch = vec![text.clone()];
-        let reqwest_client = &reqwest_client;
-
-        async move {
-            match client.generate_embeddings(reqwest_client, &text_batch).await {
-                Ok(embeddings) => embeddings.into_iter().next(),
-                Err(e) => {
-                    eprintln!("Error generating embedding from {}: {}", client.provider_name(), e);
-                    None
-                }
-            }
-        }
-    }).collect::<Vec<_>>();
-
-    futures::future::join_all(fetch_tasks).await
+    futures::stream::iter(requests)
+        .buffered(max_concurrency())
+        .collect()
+        .await
 }
 
 /// Create an embedding client for the given provider and model
@@ -545,4 +511,4 @@ pub fn create_embedding_client(provider: Provider, model: &str) -> Box<dyn Embed
         // Other providers can be added here as they're implemented
         _ => Box::new(openai::OpenAIEmbeddingClient::new_with_model(model)),
     }
-} 
+}

--- a/src/model_client/openai.rs
+++ b/src/model_client/openai.rs
@@ -4,15 +4,15 @@ use super::{ModelClient, ModelClientError, Message, Provider, EmbeddingClient};
 use serde::{Deserialize, Serialize};
 use reqwest::Client;
 
+/// Default OpenAI chat model
+pub const DEFAULT_OPENAI_MODEL: &str = "gpt-4o-mini";
+
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
 struct OpenAICompletion {
     id: String,
-    object: String,
-    created: i64,
     model: String,
     choices: Vec<OpenAIChoice>,
-    usage: OpenAIUsage,
 }
 
 #[derive(Debug, Deserialize)]
@@ -20,22 +20,14 @@ struct OpenAICompletion {
 struct OpenAIChoice {
     index: i32,
     message: OpenAIMessage,
-    finish_reason: String,
+    finish_reason: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
 struct OpenAIMessage {
     role: String,
-    content: String,
-}
-
-#[derive(Debug, Deserialize)]
-#[allow(dead_code)]
-struct OpenAIUsage {
-    prompt_tokens: i32,
-    completion_tokens: i32,
-    total_tokens: i32,
+    content: Option<String>,
 }
 
 pub struct OpenAIClient {
@@ -43,30 +35,16 @@ pub struct OpenAIClient {
 }
 
 impl OpenAIClient {
-    // Kept for backward compatibility but marked as deprecated
-    #[deprecated(since = "0.2.0", note = "Use new_with_model instead")]
-    pub fn new() -> Self {
-        Self {
-            model: "gpt-4-turbo".to_string(),
-        }
-    }
-    
     pub fn new_with_model(model: &str) -> Self {
         Self {
             model: model.to_string(),
         }
     }
-    
-    // Renamed to new_with_model, kept for backwards compatibility
-    #[deprecated(since = "0.2.0", note = "Use new_with_model instead")]
-    pub fn with_model(model: &str) -> Self {
-        Self::new_with_model(model)
-    }
 }
 
 impl Default for OpenAIClient {
     fn default() -> Self {
-        Self::new_with_model("gpt-4o-mini")
+        Self::new_with_model(DEFAULT_OPENAI_MODEL)
     }
 }
 
@@ -75,15 +53,17 @@ impl ModelClient for OpenAIClient {
     fn provider(&self) -> Provider {
         Provider::OpenAI
     }
-    
+
     fn api_endpoint(&self) -> String {
-        "https://api.openai.com/v1/chat/completions".to_string()
+        let base = std::env::var("OPENAI_BASE_URL")
+            .unwrap_or_else(|_| "https://api.openai.com".to_string());
+        format!("{}/v1/chat/completions", base.trim_end_matches('/'))
     }
-    
+
     fn model_name(&self) -> &str {
         &self.model
     }
-    
+
     fn format_messages(&self, messages: &[Message]) -> Value {
         // OpenAI supports standard system, user, and assistant roles
         let formatted_messages = messages.iter().map(|msg| {
@@ -91,27 +71,27 @@ impl ModelClient for OpenAIClient {
                 "system" => "system",
                 "user" => "user",
                 "assistant" => "assistant",
-                "function" => "function", // Support function role for function calling
+                "tool" => "tool",
                 // Default unknown roles to user
                 _ => "user",
             };
-            
+
             json!({
                 "role": role,
                 "content": msg.content
             })
         }).collect::<Vec<_>>();
-        
+
         json!(formatted_messages)
     }
-    
+
     fn format_request_body(&self, messages: &[Message], schema: Option<&str>, model_name: Option<&str>) -> Value {
-        // Default OpenAI request parameters
+        // Note: no hardcoded temperature/max_tokens — newer OpenAI models
+        // (o-series, gpt-5 family) reject those parameters, so we rely on
+        // provider defaults for maximum compatibility.
         let mut body = json!({
             "model": self.model_name(),
             "messages": self.format_messages(messages),
-            "temperature": 0.7,
-            "max_tokens": 1024
         });
 
         // Add structured output support if schema is provided
@@ -132,39 +112,13 @@ impl ModelClient for OpenAIClient {
     }
 
     fn parse_response(&self, response_text: &str) -> Result<String, ModelClientError> {
-        match serde_json::from_str::<OpenAICompletion>(response_text) {
-            Ok(completion) => {
-                if let Some(choice) = completion.choices.first() {
-                    Ok(choice.message.content.clone())
-                } else {
-                    Err(ModelClientError::ParseError("No response content".to_string()))
-                }
-            },
-            Err(err) => {
-                Err(ModelClientError::Serialization(err))
-            }
-        }
-    }
-
-    async fn send_request(&self, client: &Client, messages: &[Message]) -> Result<String, ModelClientError> {
-        let api_key = self.get_api_key();
-        let body = serde_json::to_string(&self.format_request_body(messages, None, None))?;
-
-        let response = client.post(self.api_endpoint())
-            .bearer_auth(api_key)
-            .header("Content-Type", "application/json")
-            .body(body)
-            .send()
-            .await?;
-
-        let status = response.status();
-        let text = response.text().await?;
-
-        if status.is_success() {
-            self.parse_response(&text)
-        } else {
-            Err(ModelClientError::Http(status.as_u16(), text))
-        }
+        let completion: OpenAICompletion = serde_json::from_str(response_text)?;
+        completion
+            .choices
+            .into_iter()
+            .next()
+            .and_then(|choice| choice.message.content)
+            .ok_or_else(|| ModelClientError::ParseError("No response content".to_string()))
     }
 }
 
@@ -173,11 +127,10 @@ impl ModelClient for OpenAIClient {
 // ============================================================================
 
 #[derive(Debug, Serialize)]
-struct OpenAIEmbeddingRequest {
-    input: Vec<String>,
-    model: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    encoding_format: Option<String>,
+struct OpenAIEmbeddingRequest<'a> {
+    input: &'a [String],
+    model: &'a str,
+    encoding_format: &'a str,
 }
 
 #[derive(Debug, Deserialize)]
@@ -186,7 +139,6 @@ struct OpenAIEmbeddingResponse {
     object: String,
     data: Vec<OpenAIEmbeddingData>,
     model: String,
-    usage: OpenAIEmbeddingUsage,
 }
 
 #[derive(Debug, Deserialize)]
@@ -197,13 +149,6 @@ struct OpenAIEmbeddingData {
     embedding: Vec<f64>,
 }
 
-#[derive(Debug, Deserialize)]
-#[allow(dead_code)]
-struct OpenAIEmbeddingUsage {
-    prompt_tokens: i32,
-    total_tokens: i32,
-}
-
 pub struct OpenAIEmbeddingClient {
     model: String,
     dimensions: usize,
@@ -211,10 +156,7 @@ pub struct OpenAIEmbeddingClient {
 
 impl OpenAIEmbeddingClient {
     pub fn new() -> Self {
-        Self {
-            model: "text-embedding-3-small".to_string(),
-            dimensions: 1536,
-        }
+        Self::new_with_model("text-embedding-3-small")
     }
 
     pub fn new_with_model(model: &str) -> Self {
@@ -265,18 +207,15 @@ impl EmbeddingClient for OpenAIEmbeddingClient {
         let api_key = self.get_api_key();
 
         let request_body = OpenAIEmbeddingRequest {
-            input: texts.to_vec(),
-            model: self.model.clone(),
-            encoding_format: Some("float".to_string()),
+            input: texts,
+            model: &self.model,
+            encoding_format: "float",
         };
-
-        let body = serde_json::to_string(&request_body)?;
 
         let response = client
             .post(self.embedding_endpoint())
             .bearer_auth(api_key)
-            .header("Content-Type", "application/json")
-            .body(body)
+            .json(&request_body)
             .send()
             .await?;
 
@@ -296,4 +235,4 @@ impl EmbeddingClient for OpenAIEmbeddingClient {
             Err(ModelClientError::Http(status.as_u16(), text))
         }
     }
-} 
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,14 @@
 use polars::prelude::*;
-use serde_json::json;
+use std::sync::LazyLock;
+use tokio::runtime::Runtime;
 use crate::model_client::{self, Provider, create_client, create_embedding_client, Message, ModelClientError};
 
 // Remove duplicate error type - use ModelClientError from model_client instead
 pub type FetchError = ModelClientError;
+
+/// Global Tokio runtime shared by all blocking entry points.
+pub(crate) static RT: LazyLock<Runtime> =
+    LazyLock::new(|| Runtime::new().expect("Failed to create Tokio runtime"));
 
 // This function is useful for writing functions which
 // accept pairs of List columns. Delete if unneded.
@@ -28,9 +33,7 @@ where
 }
 
 pub async fn fetch_data(messages: &[String]) -> Vec<Option<String>> {
-    // Default to OpenAI with gpt-4-turbo
-    let client = create_client(Provider::OpenAI, "gpt-4-turbo");
-    model_client::fetch_data_generic(&*client, messages).await
+    fetch_data_with_provider(messages, Provider::OpenAI, crate::model_client::openai::DEFAULT_OPENAI_MODEL).await
 }
 
 pub async fn fetch_data_with_provider(messages: &[String], provider: Provider, model: &str) -> Vec<Option<String>> {
@@ -40,15 +43,17 @@ pub async fn fetch_data_with_provider(messages: &[String], provider: Provider, m
 
 // New function to support message arrays with OpenAI default
 pub async fn fetch_data_message_arrays(message_arrays: &[Vec<Message>]) -> Vec<Option<String>> {
-    // Default to OpenAI with gpt-4-turbo
-    let client = create_client(Provider::OpenAI, "gpt-4-turbo");
-    model_client::fetch_data_generic_enhanced(&*client, message_arrays).await
+    fetch_data_message_arrays_with_provider(
+        message_arrays,
+        Provider::OpenAI,
+        crate::model_client::openai::DEFAULT_OPENAI_MODEL,
+    ).await
 }
 
 // New function to support message arrays with specific provider
 pub async fn fetch_data_message_arrays_with_provider(
-    message_arrays: &[Vec<Message>], 
-    provider: Provider, 
+    message_arrays: &[Vec<Message>],
+    provider: Provider,
     model: &str
 ) -> Vec<Option<String>> {
     let client = create_client(provider, model);
@@ -62,7 +67,7 @@ pub fn parse_message_json(json_str: &str) -> Result<Vec<Message>, serde_json::Er
     if let Ok(message) = single_message {
         return Ok(vec![message]);
     }
-    
+
     // If that fails, try parsing as an array of messages
     serde_json::from_str(json_str)
 }
@@ -73,207 +78,18 @@ pub fn fetch_api_response_sync(msg: &str, model: &str) -> Result<String, FetchEr
     fetch_api_response_sync_with_provider(msg, model, Provider::OpenAI)
 }
 
-// New sync function with provider support
+// Sync entry point: blocks on the shared async client, so the request logic
+// (auth, formatting, parsing) lives in exactly one place per provider.
 pub fn fetch_api_response_sync_with_provider(msg: &str, model: &str, provider: Provider) -> Result<String, FetchError> {
-    let agent = ureq::agent();
-    let message_obj = json!({"role": "user", "content": msg});
+    let client = create_client(provider, model);
+    let messages = vec![Message {
+        role: "user".to_string(),
+        content: msg.to_string(),
+    }];
 
-    match provider {
-        Provider::OpenAI => {
-            let body = json!({
-                "model": model,
-                "messages": [message_obj],
-                "temperature": 0.7,
-                "max_tokens": 1024
-            }).to_string();
-
-            let api_key = std::env::var("OPENAI_API_KEY").unwrap_or_default();
-            let auth = format!("Bearer {api_key}");
-
-            let response = agent.post("https://api.openai.com/v1/chat/completions")
-                .set("Authorization", auth.as_str())
-                .set("Content-Type", "application/json")
-                .send_string(&body);
-
-            match response {
-                Ok(resp) => {
-                    let response_text = resp.into_string()
-                        .map_err(|e| ModelClientError::ParseError(format!("Failed to read response body: {e}")))?;
-                    parse_openai_response(&response_text)
-                },
-                Err(ureq::Error::Status(code, resp)) => {
-                    let error_text = resp.into_string()
-                        .unwrap_or_else(|_| "Unknown error".to_string());
-                    Err(ModelClientError::Http(code, error_text))
-                },
-                Err(e) => {
-                    Err(ModelClientError::Http(0, format!("HTTP Error: {e}")))
-                }
-            }
-        },
-        Provider::Anthropic => {
-            let body = json!({
-                "model": model,
-                "messages": [message_obj],
-                "max_tokens": 1024
-            }).to_string();
-
-            let api_key = std::env::var("ANTHROPIC_API_KEY").unwrap_or_default();
-
-            let response = agent.post("https://api.anthropic.com/v1/messages")
-                .set("x-api-key", api_key.as_str())
-                .set("anthropic-version", "2023-06-01")
-                .set("Content-Type", "application/json")
-                .send_string(&body);
-
-            match response {
-                Ok(resp) => {
-                    let response_text = resp.into_string()
-                        .map_err(|e| ModelClientError::ParseError(format!("Failed to read response body: {e}")))?;
-                    parse_anthropic_response(&response_text)
-                },
-                Err(ureq::Error::Status(code, resp)) => {
-                    let error_text = resp.into_string()
-                        .unwrap_or_else(|_| "Unknown error".to_string());
-                    Err(ModelClientError::Http(code, error_text))
-                },
-                Err(e) => {
-                    Err(ModelClientError::Http(0, format!("HTTP Error: {e}")))
-                }
-            }
-        },
-        Provider::Gemini => {
-            let body = json!({
-                "contents": [{
-                    "role": "user",
-                    "parts": [{"text": msg}]
-                }],
-                "generationConfig": {
-                    "temperature": 0.7,
-                    "maxOutputTokens": 1024
-                }
-            }).to_string();
-
-            let api_key = std::env::var("GEMINI_API_KEY").unwrap_or_default();
-            let url = format!("https://generativelanguage.googleapis.com/v1beta/models/{model}/generateContent?key={api_key}");
-
-            let response = agent.post(&url)
-                .set("Content-Type", "application/json")
-                .send_string(&body);
-
-            match response {
-                Ok(resp) => {
-                    let response_text = resp.into_string()
-                        .map_err(|e| ModelClientError::ParseError(format!("Failed to read response body: {e}")))?;
-                    parse_gemini_response(&response_text)
-                },
-                Err(ureq::Error::Status(code, resp)) => {
-                    let error_text = resp.into_string()
-                        .unwrap_or_else(|_| "Unknown error".to_string());
-                    Err(ModelClientError::Http(code, error_text))
-                },
-                Err(e) => {
-                    Err(ModelClientError::Http(0, format!("HTTP Error: {e}")))
-                }
-            }
-        },
-        Provider::Groq => {
-            let body = json!({
-                "model": model,
-                "messages": [message_obj],
-                "temperature": 0.7,
-                "max_tokens": 1024
-            }).to_string();
-
-            let api_key = std::env::var("GROQ_API_KEY").unwrap_or_default();
-            let auth = format!("Bearer {api_key}");
-
-            let response = agent.post("https://api.groq.com/openai/v1/chat/completions")
-                .set("Authorization", auth.as_str())
-                .set("Content-Type", "application/json")
-                .send_string(&body);
-
-            match response {
-                Ok(resp) => {
-                    let response_text = resp.into_string()
-                        .map_err(|e| ModelClientError::ParseError(format!("Failed to read response body: {e}")))?;
-                    parse_openai_response(&response_text) // Groq uses OpenAI-compatible format
-                },
-                Err(ureq::Error::Status(code, resp)) => {
-                    let error_text = resp.into_string()
-                        .unwrap_or_else(|_| "Unknown error".to_string());
-                    Err(ModelClientError::Http(code, error_text))
-                },
-                Err(e) => {
-                    Err(ModelClientError::Http(0, format!("HTTP Error: {e}")))
-                }
-            }
-        },
-        Provider::Bedrock => {
-            // Bedrock requires AWS SDK and cannot be used synchronously via HTTP
-            Err(ModelClientError::ParseError(
-                "Bedrock provider is not supported in synchronous mode. Please use inference_async instead.".to_string()
-            ))
-        }
-    }
-}
-
-// Simplified OpenAI response parsing using model_client error types
-fn parse_openai_response(response_text: &str) -> Result<String, ModelClientError> {
-    // Use a simple JSON parsing approach since we only need the content
-    let json: serde_json::Value = serde_json::from_str(response_text)?;
-
-    if let Some(choices) = json.get("choices").and_then(|c| c.as_array()) {
-        if let Some(first_choice) = choices.first() {
-            if let Some(message) = first_choice.get("message") {
-                if let Some(content) = message.get("content").and_then(|c| c.as_str()) {
-                    return Ok(content.to_string());
-                }
-            }
-        }
-    }
-
-    Err(ModelClientError::ParseError("No response content found".to_string()))
-}
-
-// Parse Anthropic API response
-fn parse_anthropic_response(response_text: &str) -> Result<String, ModelClientError> {
-    let json: serde_json::Value = serde_json::from_str(response_text)?;
-
-    if let Some(content_array) = json.get("content").and_then(|c| c.as_array()) {
-        for content_item in content_array {
-            if let Some(content_type) = content_item.get("type").and_then(|t| t.as_str()) {
-                if content_type == "text" {
-                    if let Some(text) = content_item.get("text").and_then(|t| t.as_str()) {
-                        return Ok(text.to_string());
-                    }
-                }
-            }
-        }
-    }
-
-    Err(ModelClientError::ParseError("No text content found in Anthropic response".to_string()))
-}
-
-// Parse Gemini API response
-fn parse_gemini_response(response_text: &str) -> Result<String, ModelClientError> {
-    let json: serde_json::Value = serde_json::from_str(response_text)?;
-
-    if let Some(candidates) = json.get("candidates").and_then(|c| c.as_array()) {
-        if let Some(first_candidate) = candidates.first() {
-            if let Some(content) = first_candidate.get("content") {
-                if let Some(parts) = content.get("parts").and_then(|p| p.as_array()) {
-                    if let Some(first_part) = parts.first() {
-                        if let Some(text) = first_part.get("text").and_then(|t| t.as_str()) {
-                            return Ok(text.to_string());
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    Err(ModelClientError::ParseError("No response content found in Gemini response".to_string()))
+    RT.block_on(async move {
+        client.send_request(model_client::http_client(), &messages).await
+    })
 }
 
 // New functions supporting structured outputs with validation

--- a/tests/model_client_tests.rs
+++ b/tests/model_client_tests.rs
@@ -28,10 +28,10 @@ fn is_provider_configured(provider: Provider) -> bool {
 fn get_configured_providers() -> Vec<(Provider, &'static str)> {
     let providers = vec![
         (Provider::OpenAI, "gpt-4o-mini"),
-        (Provider::Anthropic, "claude-3-haiku-20240307"),
-        (Provider::Gemini, "gemini-1.5-flash"),
+        (Provider::Anthropic, "claude-haiku-4-5"),
+        (Provider::Gemini, "gemini-2.5-flash"),
         (Provider::Groq, "llama-3.1-8b-instant"),
-        (Provider::Bedrock, "anthropic.claude-3-haiku-20240307-v1:0"),
+        (Provider::Bedrock, "us.anthropic.claude-haiku-4-5-20251001-v1:0"),
     ];
 
     providers

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -1,0 +1,249 @@
+"""Tests for the DSPy-style prompt optimization engine.
+
+These tests use an injected ``inference_fn`` so they run without API keys
+or network access.
+"""
+
+import json
+
+import polars as pl
+import pytest
+
+from polar_llama import (
+    BootstrapFewShot,
+    InstructionOptimizer,
+    OutputField,
+    Predict,
+    Signature,
+    evaluate,
+)
+
+
+def make_echo_backend(answers):
+    """Inference backend that returns canned answers in order, cycling."""
+
+    calls = []
+
+    def backend(messages, output_model):
+        calls.append(messages)
+        return [json.dumps({"answer": answers[i % len(answers)]}) for i in range(len(messages))]
+
+    backend.calls = calls
+    return backend
+
+
+def uppercase_backend(messages, output_model):
+    """Deterministic backend: answers with the uppercased question."""
+    out = []
+    for raw in messages:
+        convo = json.loads(raw)
+        user = [m for m in convo if m["role"] == "user"][-1]
+        question = user["content"].split("question: ", 1)[-1]
+        out.append(json.dumps({"answer": question.upper()}))
+    return out
+
+
+def exact_match(example, prediction):
+    return float(example["answer"] == prediction["answer"])
+
+
+class TestSignature:
+    def test_shorthand_parsing(self):
+        sig = Signature("context, question -> answer")
+        assert list(sig.inputs) == ["context", "question"]
+        assert list(sig.outputs) == ["answer"]
+
+    def test_invalid_shorthand(self):
+        with pytest.raises(ValueError):
+            Signature("no arrow here")
+
+    def test_missing_fields(self):
+        with pytest.raises(ValueError):
+            Signature(" -> answer")
+
+    def test_system_prompt_contains_fields_and_instructions(self):
+        sig = Signature(
+            "question -> answer",
+            instructions="Be terse.",
+            outputs={"answer": OutputField(desc="the final answer")},
+        )
+        prompt = sig.system_prompt()
+        assert "Be terse." in prompt
+        assert "question" in prompt
+        assert "the final answer" in prompt
+        assert "JSON" in prompt
+
+    def test_with_instructions_returns_new_signature(self):
+        sig = Signature("question -> answer", instructions="old")
+        new = sig.with_instructions("new")
+        assert sig.instructions == "old"
+        assert new.instructions == "new"
+        assert new.inputs.keys() == sig.inputs.keys()
+
+    def test_output_model_is_pydantic(self):
+        sig = Signature("question -> answer, confidence",
+                        outputs={"confidence": OutputField(dtype=float)})
+        model = sig.output_model()
+        instance = model(answer="x", confidence=0.5)
+        assert instance.answer == "x"
+        assert instance.confidence == 0.5
+
+
+class TestPredict:
+    def test_predict_adds_prediction_columns(self):
+        module = Predict("question -> answer", inference_fn=uppercase_backend)
+        df = pl.DataFrame({"question": ["abc", "def"]})
+        result = module(df)
+        assert result.get_column("pred_answer").to_list() == ["ABC", "DEF"]
+        # Original columns preserved
+        assert result.get_column("question").to_list() == ["abc", "def"]
+
+    def test_demos_are_included_in_messages(self):
+        backend = make_echo_backend(["x"])
+        module = Predict("question -> answer", inference_fn=backend).with_demos(
+            [{"question": "1+1?", "answer": "2"}]
+        )
+        module(pl.DataFrame({"question": ["2+2?"]}))
+
+        convo = json.loads(backend.calls[0][0])
+        roles = [m["role"] for m in convo]
+        assert roles == ["system", "user", "assistant", "user"]
+        assert json.loads(convo[2]["content"]) == {"answer": "2"}
+
+    def test_accepts_signature_shorthand(self):
+        module = Predict("question -> answer", inference_fn=make_echo_backend(["ok"]))
+        assert isinstance(module.signature, Signature)
+
+    def test_handles_invalid_json_responses(self):
+        def bad_backend(messages, output_model):
+            return ["not json"] * len(messages)
+
+        module = Predict("question -> answer", inference_fn=bad_backend)
+        result = module(pl.DataFrame({"question": ["q"]}))
+        assert result.get_column("pred_answer").to_list() == [None]
+
+    def test_handles_none_responses(self):
+        def none_backend(messages, output_model):
+            return [None] * len(messages)
+
+        module = Predict("question -> answer", inference_fn=none_backend)
+        result = module(pl.DataFrame({"question": ["q"]}))
+        assert result.get_column("pred_answer").to_list() == [None]
+
+
+class TestEvaluate:
+    def test_perfect_score(self):
+        module = Predict("question -> answer", inference_fn=uppercase_backend)
+        dataset = pl.DataFrame({"question": ["ab"], "answer": ["AB"]})
+        result = evaluate(module, dataset, exact_match)
+        assert result.score == 1.0
+
+    def test_partial_score(self):
+        module = Predict("question -> answer", inference_fn=uppercase_backend)
+        dataset = pl.DataFrame(
+            {"question": ["ab", "cd"], "answer": ["AB", "wrong"]}
+        )
+        result = evaluate(module, dataset, exact_match)
+        assert result.score == 0.5
+        assert result.scores == (1.0, 0.0)
+
+    def test_failed_predictions_score_zero(self):
+        def none_backend(messages, output_model):
+            return [None] * len(messages)
+
+        module = Predict("question -> answer", inference_fn=none_backend)
+        dataset = pl.DataFrame({"question": ["q"], "answer": ["a"]})
+        result = evaluate(module, dataset, exact_match)
+        assert result.score == 0.0
+
+    def test_metric_exception_scores_zero(self):
+        def broken_metric(example, prediction):
+            raise RuntimeError("boom")
+
+        module = Predict("question -> answer", inference_fn=uppercase_backend)
+        dataset = pl.DataFrame({"question": ["ab"], "answer": ["AB"]})
+        result = evaluate(module, dataset, broken_metric)
+        assert result.score == 0.0
+
+
+class TestBootstrapFewShot:
+    def test_collects_passing_demos(self):
+        module = Predict("question -> answer", inference_fn=uppercase_backend)
+        trainset = pl.DataFrame(
+            {"question": ["ab", "cd", "ef"], "answer": ["AB", "nope", "EF"]}
+        )
+        compiled = BootstrapFewShot(metric=exact_match, max_demos=4).compile(module, trainset)
+        # Only the two rows the module got right become demos
+        assert len(compiled.demos) == 2
+        assert compiled.demos[0] == {"question": "ab", "answer": "AB"}
+        assert compiled.demos[1] == {"question": "ef", "answer": "EF"}
+
+    def test_max_demos_cap(self):
+        module = Predict("question -> answer", inference_fn=uppercase_backend)
+        trainset = pl.DataFrame(
+            {"question": ["a", "b", "c"], "answer": ["A", "B", "C"]}
+        )
+        compiled = BootstrapFewShot(metric=exact_match, max_demos=1).compile(module, trainset)
+        assert len(compiled.demos) == 1
+
+    def test_gold_outputs_option(self):
+        # Backend always answers "X"; with use_gold_outputs and threshold 0.0
+        # the demos carry the gold labels rather than the predictions.
+        module = Predict("question -> answer", inference_fn=make_echo_backend(["X"]))
+        trainset = pl.DataFrame({"question": ["q1"], "answer": ["gold"]})
+        compiled = BootstrapFewShot(
+            metric=exact_match, max_demos=1, threshold=0.0, use_gold_outputs=True
+        ).compile(module, trainset)
+        assert compiled.demos[0]["answer"] == "gold"
+
+    def test_original_module_unchanged(self):
+        module = Predict("question -> answer", inference_fn=uppercase_backend)
+        trainset = pl.DataFrame({"question": ["ab"], "answer": ["AB"]})
+        BootstrapFewShot(metric=exact_match).compile(module, trainset)
+        assert module.demos == ()
+
+
+class TestInstructionOptimizer:
+    def test_keeps_best_candidate(self):
+        # Backend rewards the instruction "SHOUT": it only answers correctly
+        # when the system prompt contains it.
+        def instruction_sensitive_backend(messages, output_model):
+            out = []
+            for raw in messages:
+                convo = json.loads(raw)
+                system = convo[0]["content"]
+                question = convo[-1]["content"].split("question: ", 1)[-1]
+                if "SHOUT" in system:
+                    out.append(json.dumps({"answer": question.upper()}))
+                else:
+                    out.append(json.dumps({"answer": question}))
+            return out
+
+        module = Predict(
+            "question -> answer",
+            inference_fn=instruction_sensitive_backend,
+        ).with_instructions("answer politely")
+
+        trainset = pl.DataFrame({"question": ["ab"], "answer": ["AB"]})
+
+        optimizer = InstructionOptimizer(
+            metric=exact_match,
+            proposer_fn=lambda prompt: ["please SHOUT the answer", "whisper it"],
+        )
+        compiled = optimizer.compile(module, trainset)
+
+        assert "SHOUT" in compiled.signature.instructions
+        assert evaluate(compiled, trainset, exact_match).score == 1.0
+        # The trace records every evaluated candidate
+        assert len(optimizer.history) == 3
+
+    def test_keeps_original_when_no_candidate_improves(self):
+        module = Predict("question -> answer", inference_fn=uppercase_backend)
+        trainset = pl.DataFrame({"question": ["ab"], "answer": ["AB"]})
+
+        optimizer = InstructionOptimizer(
+            metric=exact_match,
+            proposer_fn=lambda prompt: ["candidate one", "candidate two"],
+        )
+        compiled = optimizer.compile(module, trainset)
+        assert compiled.signature.instructions == module.signature.instructions

--- a/tests/test_parallel_inference.py
+++ b/tests/test_parallel_inference.py
@@ -61,10 +61,10 @@ def get_configured_providers():
     """Get list of providers that have API keys configured."""
     providers = [
         ('openai', Provider.OPENAI, 'gpt-4o-mini'),
-        ('anthropic', Provider.ANTHROPIC, 'claude-3-haiku-20240307'),
-        ('gemini', Provider.GEMINI, 'gemini-1.5-flash'),
+        ('anthropic', Provider.ANTHROPIC, 'claude-haiku-4-5'),
+        ('gemini', Provider.GEMINI, 'gemini-2.5-flash'),
         ('groq', Provider.GROQ, 'llama-3.1-8b-instant'),
-        ('bedrock', Provider.BEDROCK, 'anthropic.claude-3-haiku-20240307-v1:0'),
+        ('bedrock', Provider.BEDROCK, 'us.anthropic.claude-haiku-4-5-20251001-v1:0'),
     ]
 
     configured = [


### PR DESCRIPTION
## Summary

This PR introduces a DSPy-inspired prompt optimization framework for polar-llama, refactors the async runtime management to use `LazyLock` instead of `once_cell`, updates all provider default models to current versions, and improves the overall architecture for better code reuse and maintainability.

## Key Changes

### New DSPy-Style Optimization Engine (`polar_llama/optimize.py`)
- **`Signature`**: Declarative task specifications with shorthand syntax (`"question -> answer"`) or explicit `InputField`/`OutputField` definitions with types and descriptions
- **`Predict`**: Executable LLM module that runs one parallel, batched inference per DataFrame and returns `pred_<field>` columns
- **`evaluate()`**: Metric-based scoring of modules against labeled DataFrames
- **`BootstrapFewShot`**: Mines few-shot demonstrations from training rows the module already answers correctly (akin to `dspy.BootstrapFewShot`)
- **`InstructionOptimizer`**: Proposes and evaluates improved instruction variants (akin to `dspy.COPRO`)
- Comprehensive test suite in `tests/test_optimize.py`

### Runtime & Architecture Improvements
- Replaced `once_cell::sync::Lazy` with `std::sync::LazyLock` (Rust 1.80+) for better maintainability
- Moved global Tokio runtime from `expressions.rs` to `utils.rs` as `RT` for centralized management
- Introduced shared HTTP client (`HTTP_CLIENT`) in `model_client/mod.rs` with connection pooling and configurable timeouts
- Added `max_concurrency()` function with `POLAR_LLAMA_MAX_CONCURRENCY` environment variable support (default: 64)
- Refactored `resolve_provider_and_model()` helper to eliminate duplicated provider/model resolution logic

### Provider Updates & Defaults
- **OpenAI**: Updated default from `gpt-4-turbo` to `gpt-4o-mini`; added `DEFAULT_OPENAI_MODEL` constant
- **Anthropic**: Updated default from `claude-3-opus-20240229` to `claude-opus-4-8`; added `DEFAULT_ANTHROPIC_MODEL` constant; improved auth headers (`x-api-key`, `anthropic-version`)
- **Gemini**: Updated default from `gemini-1.5-pro` to `gemini-2.5-flash`; added `DEFAULT_GEMINI_MODEL` constant; fixed API endpoint format
- **Groq**: Updated default from `llama3-70b-8192` (decommissioned) to `llama-3.3-70b-versatile`; added `DEFAULT_GROQ_MODEL` constant
- **Bedrock**: Updated default to `us.anthropic.claude-haiku-4-5-20251001-v1:0`; added `DEFAULT_BEDROCK_MODEL` constant; implemented region-aware client caching

### ModelClient Trait Improvements
- Added `apply_auth()` method to `ModelClient` trait for provider-specific authentication (default: Bearer token)
- Refactored `send_request()` to delegate to `send_request_structured()` for code reuse
- Changed `format_request_body()` to return `serde_json::Value` instead of `String` for better composability
- Introduced `SchemaCheck` enum for compile-once-per-batch JSON schema validation instead of per-row
- Improved error handling and response parsing with optional fields

### Code Quality & Cleanup
- Removed deprecated constructor methods from all provider clients
- Simplified `inference_async()` by separating indices and messages vectors
- Fixed imports and removed unused dependencies (`once_cell`, unused `tokio::runtime::Runtime` in expressions)
- Updated Python kwargs handling to always include all keys (with `None` values) for proper Polars serialization
- Improved warning messages in `polar_llama/expressions.py` using `warnings` module

### Documentation & Testing
- Updated README with prompt optimization feature description
- Added comprehensive CHANGELOG entry for v0.

https://claude.ai/code/session_01Qtuzxq4mttgXrzqmcM6aTE