### PR TITLE
Tool use / MCP integration: design doc + implementation (Phases 0–1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Tool use / MCP integration** (Phases 0–1 of `docs/design/MCP_TOOL_INTEGRATION.md`):
+  - `tools_to_response_model` — build a strict-mode-safe Pydantic emission schema
+    from tool definitions (MCP, Anthropic, OpenAI-function dicts, or Pydantic models),
+    so the LLM emits tool calls as ordinary structured output
+  - `mcp_tools` — introspect tool definitions from an MCP server (`tools/list`)
+    over streamable HTTP or stdio
+  - `execute_tool_calls` — execute a column of emitted tool calls batch-parallel
+    on the Rust async runtime against an MCP server (`tools/call`), or via a
+    Python `executor` callable for non-MCP targets; per-call failures are data
+    (`is_error`, `_error`), arguments are validated against each tool's input
+    schema before execution
+  - `tool_results_to_message` — render a results column as a message for the
+    synthesis turn
+  - `.llama.execute_tool_calls()` and `.llama.tool_results_to_message()` namespace methods
+  - New guide: `docs/TOOL_USE.md`; example: `examples/tool_use_calorie_tracker.py`
+
 ## [0.2.2] - 2025-12-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2154,7 +2154,7 @@ dependencies = [
 
 [[package]]
 name = "polar-llama"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Polar Llama is a Python library designed to enhance the efficiency of making par
 - **Structured Outputs**: Define response schemas using Pydantic models for type-safe, validated LLM outputs returned as Polars Structs with direct field access.
 - **Vector Similarity**: Rust-powered similarity metrics (cosine, dot product, Euclidean distance) for high-performance vector operations.
 - **Approximate Nearest Neighbor Search**: HNSW algorithm for fast semantic search and recommendations at scale.
+- **Tool Use / MCP**: Dataframe-native tool calling — LLMs emit tool calls as structured output, and `execute_tool_calls` runs every call of every row in parallel against an MCP server or a Python callable. See [docs/TOOL_USE.md](docs/TOOL_USE.md).
 
 #### Installation
 
@@ -386,6 +387,39 @@ query = query.with_columns(
 
 See `docs/VECTOR_SIMILARITY_AND_ANN.md` for complete documentation and advanced examples.
 
+#### Tool Use and MCP
+
+Polar Llama supports tool calling without hiding an agent loop inside your rows. The loop is unrolled into the dataframe: the LLM *emits* tool calls as structured output, `execute_tool_calls` runs every call of every row concurrently (against an MCP server or any Python callable), and a second inference pass synthesizes the results — every intermediate step is an ordinary column.
+
+```python
+from polar_llama import (
+    mcp_tools, tools_to_response_model, execute_tool_calls,
+    tool_results_to_message, combine_messages, inference_messages, Provider,
+)
+
+tools = mcp_tools("http://localhost:8811/mcp")     # tools/list introspection
+ToolCalls = tools_to_response_model(tools)          # emission schema
+
+df = (
+    df
+    # 1. Emit: the LLM parameterizes N calls per row (structured output)
+    .with_columns(calls=pl.col("meal").llama.inference_async(
+        provider=Provider.OPENAI, model="gpt-4o-mini", response_model=ToolCalls))
+    # 2. Execute: all calls across all rows, in parallel, errors as data
+    .with_columns(results=execute_tool_calls(
+        pl.col("calls"), transport="http://localhost:8811/mcp", tools=tools))
+    # 3. Synthesize: fold results back through a second inference pass
+    .with_columns(answer=inference_messages(
+        combine_messages(
+            pl.col("meal").llama.to_message(role="user"),
+            tool_results_to_message(pl.col("results")),
+        ),
+        provider=Provider.OPENAI, model="gpt-4o-mini"))
+)
+```
+
+See [docs/TOOL_USE.md](docs/TOOL_USE.md) for the full guide and [docs/design/MCP_TOOL_INTEGRATION.md](docs/design/MCP_TOOL_INTEGRATION.md) for the design rationale.
+
 #### Benefits
 
 - **Speed**: Processes multiple queries in parallel, drastically reducing the time required for bulk query handling.
@@ -437,4 +471,5 @@ Polar Llama is released under the MIT license. For more details, see the LICENSE
 - [x] **Multi-Message Support**: Support for multi-message conversations to maintain context.
 - [x] **Multiple Provider Support**: Support for different LLM providers (OpenAI, Anthropic, Gemini, Groq, AWS Bedrock).
 - [x] **Structured Data Outputs**: Add support for structured data outputs using Pydantic models with type validation and Polars Struct returns.
+- [x] **Tool Use / MCP**: Batch-parallel tool-call emission and execution with MCP support (see [docs/TOOL_USE.md](docs/TOOL_USE.md)).
 - [ ] **Streaming Responses**: Support for streaming responses from LLM providers.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -70,6 +70,8 @@ Polar Llama registers a `.llama` namespace on Polars expressions, providing a fl
 | `.llama.cosine_similarity(other)` | Calculate cosine similarity between vectors |
 | `.llama.dot_product(other)` | Calculate dot product between vectors |
 | `.llama.euclidean_distance(other)` | Calculate Euclidean distance between vectors |
+| `.llama.execute_tool_calls(...)` | Execute emitted tool calls batch-parallel (MCP or Python executor) |
+| `.llama.tool_results_to_message(role='user')` | Render tool results as a message for synthesis |
 
 ### Examples
 
@@ -1016,6 +1018,75 @@ df = df.with_columns(
         provider=Provider.OPENAI,
         model="text-embedding-3-small"
     )
+)
+```
+
+---
+
+### Tool Use (MCP)
+
+Dataframe-native tool calling: emission is structured output, execution is a
+batch-parallel expression, and every intermediate turn is a column. Full
+guide: [TOOL_USE.md](TOOL_USE.md); design rationale:
+[design/MCP_TOOL_INTEGRATION.md](design/MCP_TOOL_INTEGRATION.md).
+
+#### mcp_tools
+
+```python
+mcp_tools(transport: str, *, timeout_s: float = 30.0) -> list[dict]
+```
+
+Fetch tool definitions from an MCP server (`tools/list`). `transport` is a
+streamable-HTTP endpoint (`"http://host:port/mcp"`) or a stdio command
+(`"stdio:my-server --flag"`). Returns normalized specs
+`{name, description, input_schema}`.
+
+#### tools_to_response_model
+
+```python
+tools_to_response_model(tools, *, model_name: str = "ToolCalls") -> Type[BaseModel]
+```
+
+Build a Pydantic emission schema from tool definitions (MCP entries,
+Anthropic/OpenAI-style dicts, or Pydantic models). Pass the result as
+`response_model=` to any inference function; the LLM emits
+`{"calls": [{"tool_name", "arguments"}]}` as ordinary structured output.
+Nothing is executed at this step.
+
+#### execute_tool_calls
+
+```python
+execute_tool_calls(
+    expr,
+    *,
+    transport: str | None = None,     # MCP streamable-HTTP endpoint
+    executor: Callable | None = None, # or a Python callable (tool_name, args) -> content
+    tools: Sequence | None = None,    # optional: validate args against tool schemas
+    concurrency: int = 32,
+    timeout_s: int = 30,
+) -> pl.Expr
+```
+
+Execute a column of emitted tool calls, all calls of all rows in parallel.
+Returns `List[Struct{tool_name, arguments, content, is_error, _error}]`.
+Per-call failures are data, never exceptions; only an unreachable transport
+raises. Exactly one of `transport` / `executor` must be given.
+
+#### tool_results_to_message
+
+```python
+tool_results_to_message(expr, *, role: str = "user") -> pl.Expr
+```
+
+Render a results column as a message for the synthesis turn, ready for
+`combine_messages` + `inference_messages`.
+
+**Using .llama namespace:**
+```python
+df = df.with_columns(
+    results=pl.col("calls").llama.execute_tool_calls(transport="http://localhost:8811/mcp")
+).with_columns(
+    msg=pl.col("results").llama.tool_results_to_message()
 )
 ```
 

--- a/docs/TOOL_USE.md
+++ b/docs/TOOL_USE.md
@@ -1,0 +1,192 @@
+# Tool Use and MCP Integration
+
+Polar Llama supports tool use in a dataframe-native way. Instead of running
+an opaque agent loop inside each row, the loop is **unrolled into the
+dataframe**: one "turn" is one `with_columns` pass, and every intermediate is
+an ordinary column you can inspect, explode, filter, cache, and resume.
+
+```
+row text ──► emit calls ──► execute (parallel) ──► synthesize ──► answer
+ (col)         (col)             (col)                (col)
+```
+
+The rationale and trade-offs are documented in
+[docs/design/MCP_TOOL_INTEGRATION.md](design/MCP_TOOL_INTEGRATION.md).
+
+## The three primitives
+
+| Function | What it does |
+|---|---|
+| `tools_to_response_model(tools)` | Builds a Pydantic emission schema from tool definitions — the LLM *emits* tool calls as ordinary structured output; nothing is executed. |
+| `execute_tool_calls(expr, transport=... \| executor=...)` | Executes a column of emitted calls — every call of every row in parallel. Failures are data (`is_error`, `_error`), not exceptions. |
+| `tool_results_to_message(expr)` | Renders a results column as a message for the synthesis turn (`combine_messages` + `inference_messages`). |
+
+Plus one introspection helper:
+
+| Function | What it does |
+|---|---|
+| `mcp_tools(transport)` | Fetches tool definitions from an MCP server (`tools/list`). Supports streamable HTTP (`"http://host:port/mcp"`) and stdio (`"stdio:my-server --flag"`). |
+
+MCP's role is deliberately narrow: it is a **schema source and a call target**
+(`tools/list` + `tools/call`) — a registry, not a runtime. Sessions, sampling,
+and per-row server state are out of scope by design.
+
+## Quick start
+
+```python
+import json
+import polars as pl
+from polar_llama import (
+    Provider, mcp_tools, tools_to_response_model,
+    execute_tool_calls, tool_results_to_message,
+    combine_messages, inference_messages,
+)
+
+# 1. Get tool definitions — from an MCP server, or plain dicts / Pydantic models
+tools = mcp_tools("http://localhost:8811/mcp")
+
+# 2. Emission: the LLM parameterizes zero or more calls per row.
+#    This is ordinary structured output — nothing is executed.
+ToolCalls = tools_to_response_model(tools)
+
+df = pl.DataFrame({"meal": [
+    "two eggs, sourdough toast with butter, black coffee",
+    "chipotle chicken bowl, no rice, extra guac",
+]})
+
+df = df.with_columns(
+    calls=pl.col("meal").llama.inference_async(
+        provider=Provider.OPENAI, model="gpt-4o-mini",
+        response_model=ToolCalls,
+    )
+)
+
+# 3. Execution: all calls across all rows run concurrently on the Rust
+#    async runtime. Arguments are validated against each tool's own input
+#    schema before any network call; invalid calls fail fast as data.
+df = df.with_columns(
+    results=execute_tool_calls(
+        pl.col("calls"),
+        transport="http://localhost:8811/mcp",
+        tools=tools,           # optional: enables pre-execution validation
+        concurrency=64,
+        timeout_s=30,
+    )
+)
+
+# 4. Synthesis: fold results back through a second inference pass.
+df = df.with_columns(
+    answer=inference_messages(
+        combine_messages(
+            pl.col("meal").llama.to_message(role="user"),
+            tool_results_to_message(pl.col("results")),
+        ),
+        provider=Provider.OPENAI, model="gpt-4o-mini",
+    )
+)
+```
+
+Want another round of tool calls? Repeat steps 2–3. That repetition *is* the
+agent loop — visible, bounded by construction, and resumable from any column.
+
+## Tool definitions
+
+`tools_to_response_model`, `execute_tool_calls(tools=...)`, and `mcp_tools`
+all speak the same normalized form: `{name, description, input_schema}`.
+Accepted inputs:
+
+- MCP `tools/list` entries (`inputSchema`) — including the output of `mcp_tools`
+- Anthropic-style dicts (`input_schema`)
+- OpenAI function-style dicts (`parameters`, with or without the
+  `{"type": "function", "function": {...}}` wrapper)
+- Pydantic `BaseModel` subclasses (class name = tool name, docstring =
+  description, model schema = input schema)
+
+## The emission format
+
+The generated response model is the strict-mode-safe tagged union:
+
+```json
+{"calls": [{"tool_name": "search_food_db",
+            "arguments": "{\"query\": \"eggs\", \"database\": \"usda\"}"}]}
+```
+
+`tool_name` is constrained to an enum of your tool names. `arguments` is a
+JSON-encoded string because strict structured-output modes handle it reliably
+where open `anyOf` unions are not; each tool's input schema is embedded in the
+field description so the model generates against the tool's real contract,
+and `execute_tool_calls(tools=...)` re-validates every call against the
+selected tool's schema **before** it is sent. Validation failures cost no
+network call and land in `_error`.
+
+As a column, the emission is a regular struct:
+
+```python
+df.select(pl.col("calls").struct.field("calls").list.len())   # calls per row
+df.filter(pl.col("calls").struct.field("_error").is_not_null())  # emission failures
+```
+
+## The results format
+
+`execute_tool_calls` returns
+`List[Struct{tool_name, arguments, content, is_error, _error}]` — one entry
+per emitted call, order preserved within each row:
+
+- `content` — text returned by the tool (text blocks concatenated;
+  `structuredContent` serialized as JSON)
+- `is_error` — the tool itself reported failure (MCP `isError`), or the call
+  never completed
+- `_error` — transport/validation error detail, `null` for clean calls
+
+Failures never throw mid-batch. Audit and retry with ordinary dataframe ops:
+
+```python
+failed = df.filter(
+    pl.col("results").list.eval(pl.element().struct.field("is_error")).list.any()
+)
+```
+
+The one exception: an unreachable or misconfigured `transport` raises
+immediately — a typo'd URL failing silently into 10,000 error rows would be
+worse.
+
+## Non-MCP targets
+
+Anything callable from Python can be a tool target via the `executor` escape
+hatch — a database, an internal API, a local function. It runs on a thread
+pool with the same errors-as-data semantics (at the cost of the GIL):
+
+```python
+def executor(tool_name: str, arguments: dict):
+    if tool_name == "search_food_db":
+        return my_db.search(**arguments)      # str or JSON-serializable
+    raise ValueError(f"unknown tool {tool_name}")
+
+df = df.with_columns(
+    results=execute_tool_calls(pl.col("calls"), executor=executor, concurrency=16)
+)
+```
+
+Return a `(content, is_error)` tuple to signal a tool-level failure without
+raising.
+
+## Namespace API
+
+Both steps are available on the `.llama` namespace:
+
+```python
+df = df.with_columns(
+    results=pl.col("calls").llama.execute_tool_calls(transport="http://localhost:8811/mcp"),
+).with_columns(
+    msg=pl.col("results").llama.tool_results_to_message(),
+)
+```
+
+## What is deliberately not here
+
+- **No per-row agent loop.** Multi-turn pipelines are written as explicit
+  emit → execute passes. See the design doc for the acceptance criteria a
+  future `agent_async` would have to meet.
+- **No MCP sessions/state per row.** Rows are independent; one MCP session
+  serves the whole batch.
+- **No planners, memory, or graphs.** Polar Llama's lane is batch.

--- a/docs/design/MCP_TOOL_INTEGRATION.md
+++ b/docs/design/MCP_TOOL_INTEGRATION.md
@@ -1,0 +1,384 @@
+# Design Proposal: MCP / Tool Use in Polar Llama
+
+**Status:** Proposal — not accepted
+**Author:** drafted for discussion
+**Date:** 2026-07-03
+
+---
+
+## 0. Summary
+
+This document evaluates whether Polar Llama should support tool use (and MCP
+specifically), and proposes a design that resolves the core ergonomic tension.
+
+The recommendation, in one sentence:
+
+> **Do not put an agent loop inside a row. Unroll the loop into the
+> dataframe: tool-call *emission* is a structured output (which we already
+> have), tool-call *execution* is a new batch-parallel expression, and every
+> intermediate "turn" is an ordinary column.**
+
+This gives us tool use that composes with dataframe semantics instead of
+fighting them, reuses ~90% of existing machinery (structured outputs, the
+Tokio runtime, the async fan-out), and leaves the genuinely speculative part —
+a multi-turn ReAct loop — explicitly deferred until there is demonstrated
+demand.
+
+---
+
+## 1. The honest framing: is this hype?
+
+Tool use / MCP is unambiguously riding a hype cycle. That is not itself a
+reason to build it or to refuse to build it. The question is whether it
+survives a filter that has nothing to do with the hype:
+
+**The filter: a feature belongs in Polar Llama if and only if it (a) is a
+row-wise or batch-wise data transformation, (b) benefits from massively
+parallel async execution, and (c) produces output that is usable as a column
+without leaving the dataframe.**
+
+Everything currently in the library passes this filter: inference, structured
+outputs, embeddings, similarity, ANN search, taxonomy tagging. They are all
+"columns in → column out, N rows in flight at once."
+
+Applied to tool use, the filter splits the feature into three parts with very
+different verdicts:
+
+| Capability | Passes the filter? | Verdict |
+|---|---|---|
+| LLM **emits** tool calls (parameterizes a call from row text) | Yes — it is literally structured output | Build (mostly exists) |
+| Harness **executes** tool calls in parallel across rows | Yes — batch async I/O fan-out, our core competency | Build |
+| LLM runs an **agentic ReAct loop** per row (hidden multi-turn state) | No — hidden per-row state, unbounded latency/cost, opaque intermediaries | Defer / likely never |
+
+The hype cycle is selling the third row. The durable value for a dataframe
+library is in the first two. Most "agent framework" libraries have no story
+for *"execute this tool call for 100,000 rows concurrently"* — we do, for
+free, because it is the same shape as `inference_async`. That is the
+genuine, non-clout-chasing gain.
+
+---
+
+## 2. The objections, taken seriously
+
+The arguments against integration (raised in the issue prompting this doc)
+are the right ones. Each is addressed by the design in §3, but stated fairly
+first:
+
+### 2.1 "It defeats the core purpose"
+
+Polar Llama's premise is that *the LLM itself* is the transformation — text
+in, transformed text/struct out. A tool loop inverts that: the LLM becomes a
+controller of external side effects, and the dataframe becomes an
+afterthought.
+
+**Accepted, with a boundary.** This is a decisive argument against the ReAct
+loop, and it is why the loop is deferred. It is *not* an argument against
+emission + execution: "parameterize a lookup from messy text" is exactly the
+kind of textual transformation the library exists for, and "run the lookup
+10,000× concurrently" is exactly the kind of parallelism it exists for.
+
+### 2.2 "Who makes the call — the LLM mid-loop, or the harness?"
+
+If the LLM calls tools inside a session/row (ReAct), the intermediaries are
+trapped inside an opaque per-row transcript: not inspectable, not cacheable,
+not resumable, not joinable. If the harness makes the call, then the LLM's
+output is just a structured object — so why is that different from what
+`response_model` gives us today, plus some `apply`?
+
+**Accepted — and this is the crux.** The answer is: it *isn't* meaningfully
+different, and we should stop pretending otherwise. The design below embraces
+the second horn of the dilemma. Emission **is** structured output. What we
+add is not a new inference mode but:
+
+1. **Schema plumbing** — deriving the emission schema *from* a tool's own
+   `inputSchema` (MCP or otherwise) so users don't hand-transcribe it, and so
+   the output is guaranteed to be in the shape the tool accepts (this answers
+   "how would the LLM reformat per the MCP" — it never has to; the schema it
+   generates against *is* the MCP schema).
+2. **A parallel executor** — because the naive alternative ("some sort of
+   apply") is a serial Python `map_elements` loop doing blocking I/O, which
+   throws away the entire point of the library. `execute_tool_calls` is to
+   `apply` what `inference_async` is to `openai.chat.completions.create` in a
+   for-loop.
+
+The intermediaries question answers itself under this design: **every
+intermediate is a column.** Emitted calls: a column. Tool results: a column.
+The follow-up synthesis: a column. Nothing is hidden; everything can be
+filtered, exploded, joined, cached to parquet, and resumed.
+
+### 2.3 "Can strict formats even support multiple tools?"
+
+Strict structured-output modes (OpenAI strict mode, etc.) dislike open unions,
+and a multi-tool schema is a tagged union: *"either a `search_food(query,
+db)` call or a `convert_units(qty, from, to)` call."*
+
+**Real, but solvable — and we already own the solution surface.** We already
+maintain schema-lowering logic (`_pydantic_to_json_schema`,
+`_validate_strict_mode_schema`, `anyOf` handling for `Optional`). The design
+handles multi-tool as follows:
+
+- The emission dtype is `List[Struct{ tool_name: Utf8, arguments: Utf8 }]` —
+  a list of calls, arguments carried as a JSON string.
+- For providers with robust union support, we generate a proper
+  `anyOf`-of-tool-schemas and serialize `arguments` after the fact.
+- For strict-mode providers, we generate the degenerate-but-reliable form
+  (`tool_name` as an enum, `arguments` as a JSON-encoded string) and
+  **validate `arguments` against the selected tool's `inputSchema` in Rust**
+  (the `jsonschema` crate is already a dependency). Invalid calls surface in
+  the same `_error` / `_details` / `_raw` convention structured outputs use
+  today — the failure mode is a filterable column, not an exception.
+
+This also answers "how would a user utilize the output effectively": the
+same way they use any struct column today — `.list.explode()`,
+`.struct.field(...)`, filter on `_error`, join results back.
+
+---
+
+## 3. Proposed design: the unrolled loop
+
+### 3.1 Mental model
+
+A ReAct loop is:
+
+```
+while not done:
+    llm_output = llm(context)            # may contain tool calls
+    tool_results = run(llm_output.calls)
+    context += tool_results
+```
+
+In a dataframe, each iteration of that loop is a `with_columns` pass. One
+"turn" = one column. The user decides how many turns their pipeline has,
+statically, by writing them — exactly like every other multi-step Polar
+Llama pipeline (see the embedding → tag → filter → knn pattern in the
+README). The loop is unrolled, visible, and bounded by construction.
+
+```
+row text ──► emit calls ──► execute (parallel) ──► synthesize ──► answer
+ (col)         (col)             (col)                (col)
+```
+
+### 3.2 API surface
+
+#### Phase 0 — Tool-call emission (pure Python, no new core code)
+
+```python
+from polar_llama import tools_to_response_model, Provider
+
+# Tools defined as plain dicts (OpenAI-function-style / MCP inputSchema),
+# introspected from a live MCP server, or given as Pydantic models.
+tools = [
+    {
+        "name": "search_food_db",
+        "description": "Search a nutrition database for a food item",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query":    {"type": "string"},
+                "database": {"type": "string", "enum": ["usda", "openfoodfacts"]},
+            },
+            "required": ["query", "database"],
+        },
+    },
+    # ... more tools
+]
+
+ToolCalls = tools_to_response_model(tools)   # -> a generated Pydantic model
+
+df = df.with_columns(
+    calls=pl.col("meal_description").llama.inference_async(
+        provider=Provider.OPENAI,
+        model="gpt-4o-mini",
+        response_model=ToolCalls,            # existing machinery, unchanged
+    )
+)
+# df["calls"] : Struct{ calls: List[Struct{tool_name, arguments}], _error, ... }
+```
+
+`tools_to_response_model` is ~100 lines of schema transformation sitting on
+top of code paths that already exist. It also ships with an MCP flavor:
+
+```python
+from polar_llama import mcp_tools
+
+tools = mcp_tools("stdio:nutrition-server")   # tools/list via MCP handshake
+# or: mcp_tools("http://localhost:8811/mcp")
+```
+
+MCP's role in this design is deliberately narrow: **it is a schema source and
+a call target — a registry, not a runtime.** We take `tools/list` and
+`tools/call`; we do not take sessions, sampling, or roots.
+
+#### Phase 1 — Batch-parallel execution (new Rust expression)
+
+```python
+from polar_llama import execute_tool_calls
+
+df = df.with_columns(
+    results=execute_tool_calls(
+        pl.col("calls"),
+        transport="http://localhost:8811/mcp",   # MCP server
+        concurrency=64,                           # per-batch cap
+        timeout_s=30,
+    )
+)
+# df["results"] : List[Struct{ tool_name, arguments, content: Utf8,
+#                              is_error: Boolean, _error: Utf8 }]
+```
+
+Implementation notes:
+
+- Same skeleton as `inference_async` in `src/expressions.rs`: iterate rows,
+  `tokio::spawn` per call, `join_all`, collect into a Series. The MCP
+  `tools/call` request over streamable HTTP is a small JSON-RPC client on
+  `reqwest`, which we already depend on; stdio transport can come later.
+- Per-call failures are **data**, not exceptions (`is_error`, `_error`),
+  consistent with structured-output error handling.
+- A `python_tool_executor` escape hatch (`execute_tool_calls(...,
+  executor=my_callable)`) lets users target non-MCP things (a database, an
+  internal API) with the same parallel machinery, at the cost of the GIL —
+  this keeps MCP optional rather than load-bearing.
+
+#### Phase 1.5 — Synthesis (nothing new needed)
+
+Folding results back into a final answer is composition of existing
+primitives:
+
+```python
+df = df.with_columns(
+    answer=inference_messages(
+        combine_messages(
+            pl.col("meal_description").llama.to_message(role="user"),
+            tool_results_to_message(pl.col("results")),   # thin formatter
+        ),
+        provider=Provider.OPENAI,
+        model="gpt-4o-mini",
+        response_model=NutritionSummary,
+    )
+)
+```
+
+`tool_results_to_message` is a small helper that renders the results column
+as a message (analogous to `string_to_message`). Users who want a second
+round of tool calls simply repeat the emit → execute pair — that is the
+unrolled loop.
+
+#### Phase 2 — `agent_async` (explicitly deferred)
+
+A bounded in-row loop (`max_turns=N`, full trace returned as a
+`List[Struct]` transcript column) is sketched but **not proposed for
+implementation**. It only becomes worth revisiting if, after Phases 0–1
+ship, users demonstrably chain 3+ emit/execute rounds and the column
+bookkeeping is the bottleneck. Acceptance criteria before building it:
+
+1. At least a handful of real users/issues showing multi-round unrolled
+   pipelines in the wild.
+2. A design for surfacing per-turn intermediaries that is as inspectable as
+   columns (a transcript struct column, not a log file).
+3. Hard bounds: `max_turns`, per-row timeout, per-row cost ceiling (the
+   `cost.rs` machinery gives us the hooks).
+
+If those are never met, Phase 2 is never built, and that outcome is fine —
+it would confirm that the loop was the hype and the batch executor was the
+substance.
+
+### 3.3 What is explicitly out of scope
+
+- **MCP sessions/state per row.** Rows are independent; anything requiring a
+  stateful server session per row breaks batch semantics and is rejected.
+- **MCP sampling / elicitation / roots.** We are an MCP *client* for
+  `tools/list` + `tools/call` only.
+- **Streaming tool interactions.** Orthogonal; tracked by the existing
+  streaming roadmap item.
+- **Being an agent framework.** No planners, no memory, no graphs. Users who
+  want that should use an agent framework and call it per row; our lane is
+  batch.
+
+---
+
+## 4. Worked example: the calorie tracker
+
+The motivating "genuinely helpful" case: a column of free-text meal logs;
+each row implies *N* food items that must be searched across *M* nutrition
+databases, then reconciled.
+
+```python
+import polars as pl
+from polar_llama import (
+    Provider, mcp_tools, tools_to_response_model,
+    execute_tool_calls, inference_messages, combine_messages,
+    tool_results_to_message,
+)
+
+tools = mcp_tools("http://localhost:8811/mcp")        # search_usda, search_off, ...
+FoodSearches = tools_to_response_model(tools)
+
+meals = pl.DataFrame({"meal": [
+    "two eggs, sourdough toast with butter, black coffee",
+    "chipotle chicken bowl, no rice, extra guac",
+]})
+
+result = (
+    meals
+    # Turn 1a: LLM parameterizes N searches per row (pure structured output)
+    .with_columns(
+        calls=pl.col("meal").llama.inference_async(
+            provider=Provider.OPENAI, model="gpt-4o-mini",
+            response_model=FoodSearches,
+        )
+    )
+    # Turn 1b: all searches across all rows execute concurrently
+    .with_columns(
+        results=execute_tool_calls(
+            pl.col("calls"), transport="http://localhost:8811/mcp",
+        )
+    )
+    # Turn 2: reconcile results into a typed summary
+    .with_columns(
+        nutrition=inference_messages(
+            combine_messages(
+                pl.col("meal").llama.to_message(role="user"),
+                tool_results_to_message(pl.col("results")),
+            ),
+            provider=Provider.OPENAI, model="gpt-4o-mini",
+            response_model=NutritionSummary,
+        )
+    )
+)
+```
+
+Properties worth noticing:
+
+- With 10,000 meal logs averaging 4 food items, turn 1b is ~40,000 concurrent
+  lookups through the existing Tokio fan-out. This is the step no agent
+  framework does well and the step that justifies the feature's existence.
+- Every intermediate (`calls`, `results`) is a real column: the user can
+  `explode` it, audit which DB was chosen per item, filter rows where a
+  search errored and re-run *only those* — the batch-processing answers to
+  "how does the user get the intermediary."
+- Deleting `execute_tool_calls` from this pipeline leaves valid Polar Llama
+  code. Tool use is an *addition to* the algebra, not a new paradigm.
+
+---
+
+## 5. Decision summary
+
+| Question raised | Answer under this design |
+|---|---|
+| ReAct loop or harness-executed? | Harness-executed, single-shot per turn; the loop is unrolled into columns. |
+| Why not just structured outputs + apply? | It *is* structured outputs; the additions are schema derivation from tool/MCP definitions and a parallel executor, because serial `apply` forfeits the library's reason to exist. |
+| How does the user get intermediaries? | They are columns. |
+| How does the LLM reformat per the MCP? | It doesn't — emission is generated against the tool's own `inputSchema`, and Rust-side validation catches drift as `_error` data. |
+| Multiple tools under strict formats? | `List[Struct{tool_name: enum, arguments: json-str}]` with post-hoc per-tool validation; native `anyOf` where the provider supports it. |
+| Does it defeat the core purpose? | The loop would; the loop is deferred behind evidence-based criteria. Emission + batch execution *extend* the core purpose. |
+| Hype or substance? | The per-row agent is the hype; batch-parallel tool fan-out over dataframes is the substance nobody else offers. |
+
+## 6. Proposed sequencing
+
+1. **Phase 0** (small PR, Python only): `tools_to_response_model`,
+   `mcp_tools` (introspection only), docs + calorie-tracker example.
+   De-risks nothing in the core; immediately useful.
+2. **Phase 1** (Rust PR): `execute_tool_calls` over MCP streamable-HTTP +
+   Python-callable executor; error-as-data semantics; concurrency/timeout
+   controls; `.llama` namespace parity.
+3. **Re-evaluate** with real usage before any Phase 2 discussion.

--- a/docs/design/MCP_TOOL_INTEGRATION.md
+++ b/docs/design/MCP_TOOL_INTEGRATION.md
@@ -1,6 +1,6 @@
 # Design Proposal: MCP / Tool Use in Polar Llama
 
-**Status:** Proposal — not accepted
+**Status:** Accepted — Phases 0–1 implemented (see `docs/TOOL_USE.md`); Phase 2 remains deferred
 **Author:** drafted for discussion
 **Date:** 2026-07-03
 

--- a/examples/tool_use_calorie_tracker.py
+++ b/examples/tool_use_calorie_tracker.py
@@ -1,0 +1,115 @@
+"""
+Tool use, unrolled into the dataframe: the calorie-tracker example from
+docs/design/MCP_TOOL_INTEGRATION.md.
+
+Each meal log implies N food items that must be searched in a nutrition
+database and reconciled. The pipeline is three explicit turns, each a column:
+
+    meal text -> emit searches -> execute in parallel -> synthesize summary
+
+Run with an OpenAI key in the environment. The "database" here is a local
+Python executor so the example needs no MCP server; swap `executor=` for
+`transport="http://localhost:8811/mcp"` to target a real one.
+"""
+import json
+
+import dotenv
+import polars as pl
+from pydantic import BaseModel
+
+from polar_llama import (
+    Provider,
+    combine_messages,
+    execute_tool_calls,
+    inference_messages,
+    tool_results_to_message,
+    tools_to_response_model,
+)
+
+dotenv.load_dotenv()
+
+# ---------------------------------------------------------------------------
+# 1. Tool definitions (could equally come from mcp_tools("http://...")).
+# ---------------------------------------------------------------------------
+TOOLS = [
+    {
+        "name": "search_food_db",
+        "description": "Search a nutrition database for one food item and portion.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "The food item, singular"},
+                "portion": {"type": "string", "description": "Portion as stated, e.g. 'two eggs'"},
+            },
+            "required": ["query", "portion"],
+        },
+    }
+]
+
+# A stand-in nutrition "database" the executor targets.
+FAKE_DB = {
+    "egg": 78, "sourdough toast": 120, "butter": 102, "black coffee": 2,
+    "chicken bowl": 510, "guacamole": 230, "rice": 200,
+}
+
+
+def nutrition_executor(tool_name: str, arguments: dict):
+    query = arguments["query"].lower()
+    for food, calories in FAKE_DB.items():
+        if food in query or query in food:
+            return json.dumps({"food": food, "calories_per_serving": calories,
+                               "portion": arguments["portion"]})
+    return json.dumps({"food": query, "error": "not found"}), True
+
+
+# ---------------------------------------------------------------------------
+# 2. The pipeline.
+# ---------------------------------------------------------------------------
+class NutritionSummary(BaseModel):
+    total_calories: int
+    items: list[str]
+    notes: str
+
+
+meals = pl.DataFrame({"meal": [
+    "two eggs, sourdough toast with butter, black coffee",
+    "chipotle chicken bowl, no rice, extra guac",
+]})
+
+FoodSearches = tools_to_response_model(TOOLS)
+
+result = (
+    meals
+    # Turn 1a: the LLM parameterizes N searches per row (structured output).
+    .with_columns(
+        calls=pl.col("meal").llama.inference_async(
+            provider=Provider.OPENAI, model="gpt-4o-mini",
+            response_model=FoodSearches,
+        )
+    )
+    # Turn 1b: all searches across all rows execute concurrently.
+    .with_columns(
+        results=execute_tool_calls(pl.col("calls"), executor=nutrition_executor, tools=TOOLS)
+    )
+    # Turn 2: reconcile results into a typed summary.
+    .with_columns(
+        nutrition=inference_messages(
+            combine_messages(
+                pl.col("meal").llama.to_message(role="user"),
+                tool_results_to_message(pl.col("results")),
+            ),
+            provider=Provider.OPENAI, model="gpt-4o-mini",
+            response_model=NutritionSummary,
+        )
+    )
+)
+
+print(result.select("meal", "nutrition"))
+print("\nEvery intermediate is a column:")
+print(result.select(
+    searches=pl.col("calls").struct.field("calls").list.len(),
+    failed_lookups=pl.col("results").list.eval(
+        pl.element().struct.field("is_error")
+    ).list.sum(),
+    total_calories=pl.col("nutrition").struct.field("total_calories"),
+))

--- a/polar_llama/__init__.py
+++ b/polar_llama/__init__.py
@@ -1060,6 +1060,19 @@ def tag_taxonomy(
 
 
 # ============================================================================
+# Tool Use (MCP) — see docs/design/MCP_TOOL_INTEGRATION.md
+# ============================================================================
+
+from polar_llama.tools import (
+    TOOL_RESULT_DTYPE,
+    execute_tool_calls,
+    mcp_tools,
+    tool_results_to_message,
+    tools_to_response_model,
+)
+
+
+# ============================================================================
 # Polars Namespace Accessor
 # ============================================================================
 
@@ -1265,6 +1278,35 @@ class LlamaNamespace:
             List of indices of the k nearest neighbors
         """
         return knn_hnsw(self._expr, reference, k=k)
+
+    def execute_tool_calls(
+        self,
+        *,
+        transport: Optional[str] = None,
+        executor=None,
+        tools=None,
+        concurrency: int = 32,
+        timeout_s: int = 30,
+    ) -> pl.Expr:
+        """
+        Execute a column of emitted tool calls in parallel.
+        See ``polar_llama.execute_tool_calls``.
+        """
+        return execute_tool_calls(
+            self._expr,
+            transport=transport,
+            executor=executor,
+            tools=tools,
+            concurrency=concurrency,
+            timeout_s=timeout_s,
+        )
+
+    def tool_results_to_message(self, *, role: str = "user") -> pl.Expr:
+        """
+        Render a tool-results column as a message for the synthesis turn.
+        See ``polar_llama.tool_results_to_message``.
+        """
+        return tool_results_to_message(self._expr, role=role)
 
 
 # ============================================================================

--- a/polar_llama/tools.py
+++ b/polar_llama/tools.py
@@ -1,0 +1,709 @@
+"""
+Tool use for Polar Llama: emission schemas, MCP introspection, and
+batch-parallel execution.
+
+Design: docs/design/MCP_TOOL_INTEGRATION.md. The ReAct loop is unrolled into
+the dataframe — tool-call *emission* is ordinary structured output generated
+against the tool's own input schema, tool-call *execution* is a
+batch-parallel expression, and every intermediate turn is a column.
+
+MCP's role is deliberately narrow: it is a schema source (``tools/list``)
+and a call target (``tools/call``) — a registry, not a runtime.
+"""
+from __future__ import annotations
+
+import json
+import shlex
+import subprocess
+import urllib.request
+import urllib.error
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Sequence, Type, Union
+
+import polars as pl
+
+from polar_llama.utils import parse_into_expr, register_plugin
+
+if TYPE_CHECKING:
+    from polars.type_aliases import IntoExpr
+    from pydantic import BaseModel
+
+MCP_PROTOCOL_VERSION = "2025-03-26"
+
+# Dtype of one executed tool call; execute_tool_calls returns a List of these
+# per row. Failures are data (`is_error`, `_error`), not exceptions, matching
+# the structured-output error convention.
+TOOL_RESULT_STRUCT = pl.Struct([
+    pl.Field("tool_name", pl.Utf8),
+    pl.Field("arguments", pl.Utf8),
+    pl.Field("content", pl.Utf8),
+    pl.Field("is_error", pl.Boolean),
+    pl.Field("_error", pl.Utf8),
+])
+TOOL_RESULT_DTYPE = pl.List(TOOL_RESULT_STRUCT)
+
+
+# ============================================================================
+# Tool spec normalization
+# ============================================================================
+
+def _normalize_tool(tool: Any) -> Dict[str, Any]:
+    """Normalize a tool definition to {name, description, input_schema}.
+
+    Accepts:
+    - dicts in MCP form ({name, description, inputSchema}),
+      Anthropic form ({name, description, input_schema}),
+      or OpenAI function form ({name, description, parameters} or
+      {"type": "function", "function": {...}})
+    - Pydantic BaseModel subclasses (class name / docstring / model schema)
+    """
+    try:
+        from pydantic import BaseModel
+        if isinstance(tool, type) and issubclass(tool, BaseModel):
+            return {
+                "name": tool.__name__,
+                "description": (tool.__doc__ or "").strip(),
+                "input_schema": tool.model_json_schema(),
+            }
+    except ImportError:
+        pass
+
+    if not isinstance(tool, dict):
+        raise TypeError(
+            f"Tool must be a dict or a Pydantic BaseModel subclass, got {type(tool)!r}"
+        )
+
+    # OpenAI tool-list wrapper: {"type": "function", "function": {...}}
+    if tool.get("type") == "function" and isinstance(tool.get("function"), dict):
+        tool = tool["function"]
+
+    name = tool.get("name")
+    if not name:
+        raise ValueError(f"Tool definition is missing a name: {tool!r}")
+
+    schema = (
+        tool.get("input_schema")
+        or tool.get("inputSchema")
+        or tool.get("parameters")
+        or {"type": "object", "properties": {}}
+    )
+
+    return {
+        "name": name,
+        "description": tool.get("description", "") or "",
+        "input_schema": schema,
+    }
+
+
+def _normalize_tools(tools: Sequence[Any]) -> List[Dict[str, Any]]:
+    specs = [_normalize_tool(t) for t in tools]
+    if not specs:
+        raise ValueError("At least one tool is required")
+    seen = set()
+    for spec in specs:
+        if spec["name"] in seen:
+            raise ValueError(f"Duplicate tool name: {spec['name']!r}")
+        seen.add(spec["name"])
+    return specs
+
+
+# ============================================================================
+# Emission: tools -> response model (Phase 0)
+# ============================================================================
+
+def tools_to_response_model(
+    tools: Sequence[Any],
+    *,
+    model_name: str = "ToolCalls",
+) -> Type["BaseModel"]:
+    """
+    Build a Pydantic response model for tool-call *emission*.
+
+    Pass the result as ``response_model=`` to ``inference_async`` /
+    ``inference_messages``: the LLM then emits zero or more tool calls per
+    row as ordinary structured output. Nothing is executed — execution is a
+    separate, explicit step (``execute_tool_calls``).
+
+    The generated shape is the strict-mode-safe tagged union::
+
+        {"calls": [{"tool_name": "<enum of tool names>",
+                    "arguments": "<JSON-encoded object>"}, ...]}
+
+    ``arguments`` is carried as a JSON-encoded string because strict
+    structured-output modes handle it reliably where open ``anyOf`` unions
+    are not; each tool's input schema is embedded in the field description
+    so the model generates against the tool's own contract, and
+    ``execute_tool_calls`` re-validates arguments against the selected
+    tool's schema before any call is made.
+
+    Parameters
+    ----------
+    tools : sequence of dict or Pydantic BaseModel
+        Tool definitions (MCP ``tools/list`` entries, Anthropic/OpenAI-style
+        dicts, or the output of ``mcp_tools``).
+    model_name : str
+        Name for the generated root model.
+
+    Returns
+    -------
+    Type[pydantic.BaseModel]
+        Root model with a single ``calls`` field. The normalized tool specs
+        are attached as ``__polar_llama_tools__`` so ``execute_tool_calls``
+        can validate against them.
+    """
+    try:
+        from pydantic import Field, create_model
+    except ImportError:
+        raise ImportError(
+            "Pydantic is required for tool use. Install with: pip install pydantic>=2.0.0"
+        )
+
+    specs = _normalize_tools(tools)
+    names = tuple(spec["name"] for spec in specs)
+
+    tool_menu = "\n".join(
+        f"- {spec['name']}: {spec['description']}".rstrip(": ") for spec in specs
+    )
+    schema_menu = json.dumps(
+        {spec["name"]: spec["input_schema"] for spec in specs}, indent=None
+    )
+
+    tool_call_model = create_model(
+        "ToolCall",
+        tool_name=(
+            Literal[names],  # type: ignore[valid-type]
+            Field(..., description=f"The tool to call. Available tools:\n{tool_menu}"),
+        ),
+        arguments=(
+            str,
+            Field(
+                ...,
+                description=(
+                    "JSON-encoded object of arguments for the selected tool, "
+                    "matching that tool's input schema exactly. "
+                    f"Input schemas by tool name: {schema_menu}"
+                ),
+            ),
+        ),
+    )
+
+    response_model = create_model(
+        model_name,
+        calls=(
+            List[tool_call_model],  # type: ignore[valid-type]
+            Field(
+                ...,
+                description=(
+                    "The tool calls needed to fulfil the request, in order. "
+                    "Return an empty list if no tool call is needed."
+                ),
+            ),
+        ),
+    )
+    response_model.__polar_llama_tools__ = specs
+    return response_model
+
+
+# ============================================================================
+# MCP introspection: tools/list (Phase 0)
+# ============================================================================
+
+def mcp_tools(transport: str, *, timeout_s: float = 30.0) -> List[Dict[str, Any]]:
+    """
+    Fetch tool definitions from an MCP server via ``tools/list``.
+
+    Parameters
+    ----------
+    transport : str
+        Either a streamable-HTTP endpoint (``"http://host:port/mcp"``) or a
+        stdio command prefixed with ``stdio:`` (``"stdio:my-server --flag"``).
+    timeout_s : float
+        Timeout for each protocol request.
+
+    Returns
+    -------
+    list of dict
+        Normalized tool specs ``{name, description, input_schema}``, ready
+        for ``tools_to_response_model`` and ``execute_tool_calls(tools=...)``.
+    """
+    session = _open_mcp_session(transport, timeout_s)
+    try:
+        tools: List[Dict[str, Any]] = []
+        cursor: Optional[str] = None
+        while True:
+            params: Dict[str, Any] = {"cursor": cursor} if cursor else {}
+            result = session.request("tools/list", params)
+            tools.extend(_normalize_tool(t) for t in result.get("tools", []))
+            cursor = result.get("nextCursor")
+            if not cursor:
+                break
+        return tools
+    finally:
+        session.close()
+
+
+def _open_mcp_session(transport: str, timeout_s: float) -> "_McpSession":
+    if transport.startswith("stdio:"):
+        session: _McpSession = _McpStdioSession(transport[len("stdio:"):], timeout_s)
+    elif transport.startswith(("http://", "https://")):
+        session = _McpHttpSession(transport, timeout_s)
+    else:
+        raise ValueError(
+            f"Unsupported MCP transport {transport!r}: expected an http(s) URL "
+            "or a 'stdio:<command>' string"
+        )
+    session.initialize()
+    return session
+
+
+class _McpSession:
+    """Minimal MCP client session: initialize + request/notify."""
+
+    def initialize(self) -> None:
+        result = self.request(
+            "initialize",
+            {
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "polar-llama", "version": "0"},
+            },
+        )
+        if not isinstance(result, dict):
+            raise RuntimeError("MCP initialize returned no result")
+        self.notify("notifications/initialized", {})
+
+    def request(self, method: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        raise NotImplementedError
+
+    def notify(self, method: str, params: Dict[str, Any]) -> None:
+        raise NotImplementedError
+
+    def close(self) -> None:
+        pass
+
+
+class _McpHttpSession(_McpSession):
+    def __init__(self, endpoint: str, timeout_s: float):
+        self.endpoint = endpoint
+        self.timeout_s = timeout_s
+        self.session_id: Optional[str] = None
+        self._next_id = 1
+
+    def request(self, method: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        message_id = self._next_id
+        self._next_id += 1
+        body = {"jsonrpc": "2.0", "id": message_id, "method": method, "params": params}
+        payload = self._post(body)
+        if payload is None:
+            raise RuntimeError(f"MCP server returned no response for {method}")
+        if "error" in payload:
+            raise RuntimeError(f"MCP error for {method}: {payload['error']}")
+        return payload.get("result", {})
+
+    def notify(self, method: str, params: Dict[str, Any]) -> None:
+        self._post({"jsonrpc": "2.0", "method": method, "params": params})
+
+    def _post(self, body: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        }
+        if self.session_id:
+            headers["Mcp-Session-Id"] = self.session_id
+        request = urllib.request.Request(
+            self.endpoint,
+            data=json.dumps(body).encode("utf-8"),
+            headers=headers,
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout_s) as response:
+                self.session_id = response.headers.get("Mcp-Session-Id", self.session_id)
+                content_type = response.headers.get("Content-Type", "")
+                text = response.read().decode("utf-8")
+        except urllib.error.HTTPError as e:
+            raise RuntimeError(
+                f"MCP HTTP request failed: {e.code} {e.reason}: "
+                f"{e.read().decode('utf-8', errors='replace')[:500]}"
+            ) from e
+
+        if not text.strip():
+            return None
+        if content_type.startswith("text/event-stream"):
+            return _parse_sse_response(text)
+        return json.loads(text)
+
+
+def _parse_sse_response(body: str) -> Optional[Dict[str, Any]]:
+    """Extract the JSON-RPC response (the event carrying an id) from an SSE body."""
+    response = None
+    for line in body.splitlines():
+        line = line.strip()
+        if line.startswith("data:"):
+            try:
+                value = json.loads(line[len("data:"):].strip())
+            except json.JSONDecodeError:
+                continue
+            if isinstance(value, dict) and "id" in value and ("result" in value or "error" in value):
+                response = value
+    return response
+
+
+class _McpStdioSession(_McpSession):
+    def __init__(self, command: str, timeout_s: float):
+        self.timeout_s = timeout_s
+        self._next_id = 1
+        self.process = subprocess.Popen(
+            shlex.split(command),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+
+    def request(self, method: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        message_id = self._next_id
+        self._next_id += 1
+        self._write({"jsonrpc": "2.0", "id": message_id, "method": method, "params": params})
+        # Read newline-delimited JSON until our response arrives, skipping
+        # any server-initiated notifications.
+        while True:
+            line = self.process.stdout.readline()
+            if not line:
+                raise RuntimeError(f"MCP stdio server exited before responding to {method}")
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if payload.get("id") == message_id:
+                if "error" in payload:
+                    raise RuntimeError(f"MCP error for {method}: {payload['error']}")
+                return payload.get("result", {})
+
+    def notify(self, method: str, params: Dict[str, Any]) -> None:
+        self._write({"jsonrpc": "2.0", "method": method, "params": params})
+
+    def _write(self, body: Dict[str, Any]) -> None:
+        self.process.stdin.write(json.dumps(body) + "\n")
+        self.process.stdin.flush()
+
+    def close(self) -> None:
+        try:
+            self.process.terminate()
+            self.process.wait(timeout=5)
+        except Exception:
+            self.process.kill()
+
+
+# ============================================================================
+# Execution (Phase 1)
+# ============================================================================
+
+def execute_tool_calls(
+    expr: "IntoExpr",
+    *,
+    transport: Optional[str] = None,
+    executor: Optional[Callable[[str, Dict[str, Any]], Any]] = None,
+    tools: Optional[Sequence[Any]] = None,
+    concurrency: int = 32,
+    timeout_s: int = 30,
+) -> pl.Expr:
+    """
+    Execute a column of emitted tool calls, in parallel across all calls of
+    all rows.
+
+    The input column is the output of an emission step (a struct with a
+    ``calls`` field, as produced by ``response_model=tools_to_response_model(...)``),
+    or directly a ``List[Struct{tool_name, arguments}]`` column, or a Utf8
+    column of JSON arrays.
+
+    Exactly one of ``transport`` / ``executor`` must be given:
+
+    - ``transport``: an MCP streamable-HTTP endpoint. Calls run on the Rust
+      async runtime — the same fan-out as ``inference_async`` — so 10k rows
+      x 4 calls each is 40k concurrent-capped requests, not a serial loop.
+    - ``executor``: a Python callable ``(tool_name, arguments_dict) -> content``
+      for non-MCP targets (a database, an internal API). Runs on a thread
+      pool; return a string (or any JSON-serializable value), or a
+      ``(content, is_error)`` tuple. Raising marks that call failed.
+
+    Per-call failures are **data** (``is_error``, ``_error`` fields in the
+    result), never exceptions — filter and re-run failed rows instead of
+    losing the batch. Only an unreachable/misconfigured transport raises.
+
+    Parameters
+    ----------
+    expr
+        The emitted-calls column.
+    transport : str, optional
+        MCP streamable-HTTP endpoint (e.g. ``"http://localhost:8811/mcp"``).
+    executor : callable, optional
+        Python fallback executor for non-MCP targets.
+    tools : sequence, optional
+        Tool definitions (e.g. from ``mcp_tools``). When provided, each
+        call's arguments are validated against the selected tool's input
+        schema *before* execution; invalid calls fail fast as data.
+    concurrency : int
+        Maximum in-flight calls across the whole batch (default 32).
+    timeout_s : int
+        Per-call timeout in seconds (default 30).
+
+    Returns
+    -------
+    polars.Expr
+        ``List[Struct{tool_name, arguments, content, is_error, _error}]``,
+        one entry per emitted call, order preserved within each row.
+    """
+    if (transport is None) == (executor is None):
+        raise ValueError("Provide exactly one of `transport` or `executor`")
+
+    expr = parse_into_expr(expr)
+    calls_json = expr.map_batches(_serialize_calls_batch, return_dtype=pl.Utf8)
+
+    tool_schemas: Optional[Dict[str, Any]] = None
+    if tools is not None:
+        tool_schemas = {
+            spec["name"]: spec["input_schema"] for spec in _normalize_tools(tools)
+        }
+
+    if executor is not None:
+        return calls_json.map_batches(
+            lambda s: _execute_batch_python(s, executor, tool_schemas, concurrency, timeout_s),
+            return_dtype=TOOL_RESULT_DTYPE,
+        )
+
+    from polar_llama.expressions import get_lib_path
+
+    kwargs: Dict[str, Any] = {
+        "transport": transport,
+        "concurrency": int(concurrency),
+        "timeout_s": int(timeout_s),
+    }
+    if tool_schemas is not None:
+        kwargs["tool_schemas"] = json.dumps(tool_schemas)
+
+    result = register_plugin(
+        args=[calls_json],
+        symbol="execute_tool_calls",
+        is_elementwise=True,
+        lib=get_lib_path(),
+        kwargs=kwargs,
+    )
+    return result.map_batches(
+        lambda s: s.str.json_decode(dtype=TOOL_RESULT_DTYPE),
+        return_dtype=TOOL_RESULT_DTYPE,
+    )
+
+
+def _serialize_calls_batch(series: pl.Series) -> pl.Series:
+    """Serialize an emitted-calls column to one JSON array string per row."""
+    out: List[Optional[str]] = []
+    for row in series.to_list():
+        if row is None:
+            out.append(None)
+            continue
+        calls = row
+        if isinstance(row, dict):
+            # Structured-output root struct: {"calls": [...], "_error": ...}.
+            # An emission error means no calls; the error stays visible in
+            # the emission column itself.
+            calls = row.get("calls")
+        if calls is None:
+            calls = []
+        if isinstance(calls, str):
+            out.append(calls)
+            continue
+        normalized = []
+        for call in calls:
+            if call is None:
+                continue
+            normalized.append({
+                "tool_name": call.get("tool_name"),
+                "arguments": call.get("arguments"),
+            })
+        out.append(json.dumps(normalized))
+    return pl.Series(series.name, out, dtype=pl.Utf8)
+
+
+def _execute_batch_python(
+    series: pl.Series,
+    executor: Callable[[str, Dict[str, Any]], Any],
+    tool_schemas: Optional[Dict[str, Any]],
+    concurrency: int,
+    timeout_s: int,
+) -> pl.Series:
+    rows: List[Optional[List[Dict[str, Any]]]] = []
+    for value in series.to_list():
+        rows.append(None if value is None else json.loads(value))
+
+    flat = [
+        (row_idx, call_idx, call)
+        for row_idx, row in enumerate(rows)
+        if row is not None
+        for call_idx, call in enumerate(row)
+    ]
+
+    results: Dict[tuple, Dict[str, Any]] = {}
+    if flat:
+        with ThreadPoolExecutor(max_workers=max(1, concurrency)) as pool:
+            futures = {
+                pool.submit(_run_one_python_call, executor, call, tool_schemas): (row_idx, call_idx)
+                for row_idx, call_idx, call in flat
+            }
+            for future, key in futures.items():
+                row_idx, call_idx = key
+                call = rows[row_idx][call_idx]
+                try:
+                    results[key] = future.result(timeout=timeout_s)
+                except Exception as e:  # includes TimeoutError
+                    results[key] = _tool_result(call, None, True, f"{type(e).__name__}: {e}")
+
+    out: List[Optional[List[Dict[str, Any]]]] = []
+    for row_idx, row in enumerate(rows):
+        if row is None:
+            out.append(None)
+        else:
+            out.append([results[(row_idx, call_idx)] for call_idx in range(len(row))])
+    return pl.Series(series.name, out, dtype=TOOL_RESULT_DTYPE)
+
+
+def _run_one_python_call(
+    executor: Callable[[str, Dict[str, Any]], Any],
+    call: Dict[str, Any],
+    tool_schemas: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    tool_name = call.get("tool_name")
+    raw_arguments = call.get("arguments")
+
+    try:
+        arguments = _parse_arguments(raw_arguments)
+    except ValueError as e:
+        return _tool_result(call, None, True, str(e))
+
+    if tool_schemas is not None:
+        if tool_name not in tool_schemas:
+            return _tool_result(call, None, True, f"unknown tool: {tool_name!r}")
+        error = _validate_arguments(arguments, tool_schemas[tool_name])
+        if error:
+            return _tool_result(call, None, True, f"argument validation failed: {error}")
+
+    try:
+        value = executor(tool_name, arguments)
+    except Exception as e:
+        return _tool_result(call, None, True, f"{type(e).__name__}: {e}")
+
+    is_error = False
+    if isinstance(value, tuple) and len(value) == 2:
+        value, is_error = value
+    content = value if isinstance(value, str) else json.dumps(value)
+    return _tool_result(call, content, bool(is_error), None)
+
+
+def _parse_arguments(raw: Any) -> Dict[str, Any]:
+    if raw is None or raw == "":
+        return {}
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"arguments is not valid JSON: {e}")
+        if not isinstance(parsed, dict):
+            raise ValueError("arguments must be a JSON object")
+        return parsed
+    if isinstance(raw, dict):
+        return raw
+    raise ValueError(f"arguments must be a JSON object or JSON-encoded string, got {type(raw)!r}")
+
+
+def _validate_arguments(arguments: Dict[str, Any], schema: Dict[str, Any]) -> Optional[str]:
+    """Validate with the `jsonschema` package when available; otherwise only
+    check required keys (the Rust path always validates fully)."""
+    try:
+        import jsonschema as _jsonschema  # type: ignore
+
+        validator_cls = _jsonschema.validators.validator_for(schema)
+        errors = [
+            f"{e.message} at /{'/'.join(str(p) for p in e.absolute_path)}"
+            for e in validator_cls(schema).iter_errors(arguments)
+        ]
+        return "; ".join(errors) if errors else None
+    except ImportError:
+        missing = [
+            key for key in schema.get("required", []) if key not in arguments
+        ]
+        if missing:
+            return f"missing required argument(s): {', '.join(missing)}"
+        return None
+
+
+def _tool_result(
+    call: Dict[str, Any],
+    content: Optional[str],
+    is_error: bool,
+    error: Optional[str],
+) -> Dict[str, Any]:
+    raw_arguments = call.get("arguments")
+    if raw_arguments is not None and not isinstance(raw_arguments, str):
+        raw_arguments = json.dumps(raw_arguments)
+    return {
+        "tool_name": call.get("tool_name"),
+        "arguments": raw_arguments,
+        "content": content,
+        "is_error": is_error,
+        "_error": error,
+    }
+
+
+# ============================================================================
+# Synthesis helper: results -> message
+# ============================================================================
+
+def tool_results_to_message(expr: "IntoExpr", *, role: str = "user") -> pl.Expr:
+    """
+    Render an ``execute_tool_calls`` results column as a message, ready for
+    ``combine_messages`` + ``inference_messages`` (the synthesis turn).
+
+    Parameters
+    ----------
+    expr
+        Results column (``List[Struct{tool_name, arguments, content, is_error, _error}]``).
+    role : str
+        Message role, default ``"user"``.
+
+    Returns
+    -------
+    polars.Expr
+        JSON message expression, same shape as ``string_to_message`` output.
+    """
+    expr = parse_into_expr(expr)
+    text = expr.map_batches(_format_results_batch, return_dtype=pl.Utf8)
+    # Imported lazily to avoid a circular import at module load time.
+    from polar_llama import string_to_message
+
+    return string_to_message(text, message_type=role)
+
+
+def _format_results_batch(series: pl.Series) -> pl.Series:
+    out: List[Optional[str]] = []
+    for row in series.to_list():
+        if row is None:
+            out.append(None)
+            continue
+        lines = ["Tool results:"]
+        if not row:
+            lines.append("(no tool calls were made)")
+        for i, result in enumerate(row, start=1):
+            result = result or {}
+            name = result.get("tool_name") or "<unknown tool>"
+            arguments = result.get("arguments") or "{}"
+            lines.append(f"{i}. {name}({arguments})")
+            if result.get("is_error"):
+                reason = result.get("_error") or result.get("content") or "unknown error"
+                lines.append(f"   ERROR: {reason}")
+            else:
+                lines.append(f"   -> {result.get('content')}")
+        out.append("\n".join(lines))
+    return pl.Series(series.name, out, dtype=pl.Utf8)

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -1134,7 +1134,7 @@ fn execute_tool_calls(inputs: &[Series], kwargs: ExecuteToolCallsKwargs) -> Pola
                         Some(validator) if !validator.is_valid(&args) => {
                             let errors: Vec<String> = validator
                                 .iter_errors(&args)
-                                .map(|e| format!("{} at {}", e, e.instance_path))
+                                .map(|e| format!("{} at {}", e, e.instance_path()))
                                 .collect();
                             Prepared::Invalid(format!(
                                 "argument validation failed: {}",

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -810,6 +810,289 @@ fn knn_output_type(_input_fields: &[Field]) -> PolarsResult<Field> {
 }
 
 // ============================================================================
+// Tool Call Execution (MCP)
+// ============================================================================
+
+#[derive(Debug, Deserialize)]
+pub struct ExecuteToolCallsKwargs {
+    /// MCP streamable-HTTP endpoint, e.g. "http://localhost:8811/mcp"
+    transport: String,
+    /// Max in-flight tool calls across the whole batch
+    #[serde(default = "default_tool_concurrency")]
+    concurrency: usize,
+    /// Per-call timeout in seconds
+    #[serde(default = "default_tool_timeout")]
+    timeout_s: u64,
+    /// Optional JSON object mapping tool name -> input JSON schema.
+    /// When present, arguments are validated before any network call.
+    #[serde(default)]
+    tool_schemas: Option<String>,
+}
+
+fn default_tool_concurrency() -> usize {
+    32
+}
+
+fn default_tool_timeout() -> u64 {
+    30
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ToolCallSpec {
+    tool_name: String,
+    /// Arguments either as a JSON-encoded string (strict-mode emission form)
+    /// or as an inline JSON object.
+    #[serde(default)]
+    arguments: serde_json::Value,
+}
+
+/// Parse one row's JSON array of tool calls.
+fn parse_tool_calls_row(row: &str) -> Result<Vec<ToolCallSpec>, String> {
+    let value: serde_json::Value =
+        serde_json::from_str(row).map_err(|e| format!("invalid tool call JSON: {e}"))?;
+    match value {
+        serde_json::Value::Array(items) => items
+            .into_iter()
+            .map(|item| {
+                serde_json::from_value::<ToolCallSpec>(item)
+                    .map_err(|e| format!("invalid tool call object: {e}"))
+            })
+            .collect(),
+        serde_json::Value::Object(_) => {
+            // Accept a bare single call for convenience
+            serde_json::from_value::<ToolCallSpec>(value)
+                .map(|c| vec![c])
+                .map_err(|e| format!("invalid tool call object: {e}"))
+        }
+        serde_json::Value::Null => Ok(vec![]),
+        _ => Err("expected a JSON array of tool calls".to_string()),
+    }
+}
+
+/// Normalize arguments: emission carries them as a JSON-encoded string
+/// (the strict-mode-safe form); accept inline objects too.
+fn normalize_arguments(raw: &serde_json::Value) -> Result<serde_json::Value, String> {
+    match raw {
+        serde_json::Value::String(s) => {
+            if s.trim().is_empty() {
+                return Ok(serde_json::json!({}));
+            }
+            serde_json::from_str::<serde_json::Value>(s)
+                .map_err(|e| format!("arguments is not valid JSON: {e}"))
+        }
+        serde_json::Value::Null => Ok(serde_json::json!({})),
+        other => Ok(other.clone()),
+    }
+}
+
+fn tool_result_json(
+    spec: &ToolCallSpec,
+    content: Option<String>,
+    is_error: bool,
+    error: Option<String>,
+) -> serde_json::Value {
+    let arguments_str = match &spec.arguments {
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
+    };
+    serde_json::json!({
+        "tool_name": spec.tool_name,
+        "arguments": arguments_str,
+        "content": content,
+        "is_error": is_error,
+        "_error": error,
+    })
+}
+
+/// Execute a column of emitted tool calls against an MCP server, in parallel
+/// across every call of every row. Input: Utf8 rows containing JSON arrays of
+/// {tool_name, arguments}. Output: Utf8 rows containing JSON arrays of
+/// {tool_name, arguments, content, is_error, _error}. Per-call failures are
+/// data, not exceptions; only an unreachable/misconfigured transport raises.
+#[polars_expr(output_type=String)]
+fn execute_tool_calls(inputs: &[Series], kwargs: ExecuteToolCallsKwargs) -> PolarsResult<Series> {
+    let input_series = &inputs[0];
+
+    if input_series.is_empty() || input_series.dtype() == &DataType::Null {
+        return Ok(StringChunked::from_iter_options(
+            input_series.name().clone(),
+            std::iter::empty::<Option<String>>(),
+        )
+        .into_series());
+    }
+
+    let ca: &StringChunked = input_series.str()?;
+
+    // Compile per-tool argument validators up front (config errors fail fast).
+    let validators: std::collections::HashMap<String, jsonschema::Validator> =
+        match &kwargs.tool_schemas {
+            Some(schemas_json) => {
+                let schemas: serde_json::Value = serde_json::from_str(schemas_json)
+                    .map_err(|e| {
+                        PolarsError::ComputeError(format!("invalid tool_schemas JSON: {e}").into())
+                    })?;
+                let obj = schemas.as_object().ok_or_else(|| {
+                    PolarsError::ComputeError("tool_schemas must be a JSON object".into())
+                })?;
+                let mut map = std::collections::HashMap::new();
+                for (name, schema) in obj {
+                    let validator = jsonschema::validator_for(schema).map_err(|e| {
+                        PolarsError::ComputeError(
+                            format!("invalid schema for tool '{name}': {e}").into(),
+                        )
+                    })?;
+                    map.insert(name.clone(), validator);
+                }
+                map
+            }
+            None => std::collections::HashMap::new(),
+        };
+
+    // Parse every row, flattening calls to (row, position) so all calls in
+    // the batch share one concurrency pool.
+    let mut rows: Vec<Option<Vec<ToolCallSpec>>> = Vec::with_capacity(ca.len());
+    let mut row_errors: Vec<Option<String>> = vec![None; ca.len()];
+    for (idx, opt_value) in ca.into_iter().enumerate() {
+        match opt_value {
+            Some(value) => match parse_tool_calls_row(value) {
+                Ok(calls) => rows.push(Some(calls)),
+                Err(e) => {
+                    row_errors[idx] = Some(e);
+                    rows.push(Some(vec![]));
+                }
+            },
+            None => rows.push(None),
+        }
+    }
+
+    // Pre-resolve each call: validated + normalized arguments, or an
+    // immediate validation error that skips the network entirely.
+    enum Prepared {
+        Ready(serde_json::Value),
+        Invalid(String),
+    }
+    let mut flat: Vec<(usize, usize, ToolCallSpec, Prepared)> = Vec::new();
+    for (row_idx, row) in rows.iter().enumerate() {
+        if let Some(calls) = row {
+            for (call_idx, spec) in calls.iter().enumerate() {
+                let prepared = match normalize_arguments(&spec.arguments) {
+                    Ok(args) => match validators.get(&spec.tool_name) {
+                        Some(validator) if !validator.is_valid(&args) => {
+                            let errors: Vec<String> = validator
+                                .iter_errors(&args)
+                                .map(|e| format!("{} at {}", e, e.instance_path))
+                                .collect();
+                            Prepared::Invalid(format!(
+                                "argument validation failed: {}",
+                                errors.join("; ")
+                            ))
+                        }
+                        _ => Prepared::Ready(args),
+                    },
+                    Err(e) => Prepared::Invalid(e),
+                };
+                flat.push((row_idx, call_idx, spec.clone(), prepared));
+            }
+        }
+    }
+
+    let transport = kwargs.transport.clone();
+    let timeout = std::time::Duration::from_secs(kwargs.timeout_s.max(1));
+    let concurrency = kwargs.concurrency.max(1);
+
+    // One handshake per batch; an unreachable transport is a config error.
+    let client = run_async(async move { crate::mcp::McpHttpClient::connect(&transport, timeout).await })
+        .map_err(|e| {
+            PolarsError::ComputeError(
+                format!("failed to connect to MCP server '{}': {e}", kwargs.transport).into(),
+            )
+        })?;
+
+    // Fan out every ready call through a shared semaphore.
+    let outcomes: Vec<(usize, usize, serde_json::Value)> = {
+        let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(concurrency));
+        let mut handles = Vec::with_capacity(flat.len());
+
+        for (row_idx, call_idx, spec, prepared) in flat {
+            match prepared {
+                Prepared::Invalid(msg) => {
+                    handles.push(TaskOrReady::Ready((
+                        row_idx,
+                        call_idx,
+                        tool_result_json(&spec, None, true, Some(msg)),
+                    )));
+                }
+                Prepared::Ready(args) => {
+                    let client = client.clone();
+                    let semaphore = semaphore.clone();
+                    handles.push(TaskOrReady::Task(RT.spawn(async move {
+                        let _permit = semaphore.acquire().await.expect("semaphore closed");
+                        let outcome = client.call_tool(&spec.tool_name, &args).await;
+                        (
+                            row_idx,
+                            call_idx,
+                            tool_result_json(&spec, outcome.content, outcome.is_error, outcome.error),
+                        )
+                    })));
+                }
+            }
+        }
+
+        run_async(async move {
+            let mut results = Vec::with_capacity(handles.len());
+            for handle in handles {
+                match handle {
+                    TaskOrReady::Ready(r) => results.push(r),
+                    TaskOrReady::Task(t) => results.push(t.await.expect("tool call task panicked")),
+                }
+            }
+            results
+        })
+    };
+
+    // Reassemble per-row JSON arrays, preserving emission order within rows.
+    let mut per_row: Vec<Option<Vec<(usize, serde_json::Value)>>> = rows
+        .iter()
+        .map(|r| r.as_ref().map(|calls| Vec::with_capacity(calls.len())))
+        .collect();
+    for (row_idx, call_idx, result) in outcomes {
+        if let Some(Some(row)) = per_row.get_mut(row_idx) {
+            row.push((call_idx, result));
+        }
+    }
+
+    let results: Vec<Option<String>> = per_row
+        .into_iter()
+        .enumerate()
+        .map(|(idx, opt_row)| {
+            opt_row.map(|mut row| {
+                row.sort_by_key(|(call_idx, _)| *call_idx);
+                let mut values: Vec<serde_json::Value> =
+                    row.into_iter().map(|(_, v)| v).collect();
+                if let Some(parse_err) = &row_errors[idx] {
+                    values.push(serde_json::json!({
+                        "tool_name": null,
+                        "arguments": null,
+                        "content": null,
+                        "is_error": true,
+                        "_error": parse_err,
+                    }));
+                }
+                serde_json::Value::Array(values).to_string()
+            })
+        })
+        .collect();
+
+    let out = StringChunked::from_iter_options(ca.name().clone(), results.into_iter());
+    Ok(out.into_series())
+}
+
+enum TaskOrReady {
+    Task(tokio::task::JoinHandle<(usize, usize, serde_json::Value)>),
+    Ready((usize, usize, serde_json::Value)),
+}
+
+// ============================================================================
 // Cost Calculation Operations
 // ============================================================================
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod utils;
 pub mod model_client;
 pub mod ann;
 pub mod cost;
+pub mod mcp;
 
 #[cfg(target_os = "linux")]
 use jemallocator::Jemalloc;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,0 +1,265 @@
+//! Minimal MCP (Model Context Protocol) client for batch tool execution.
+//!
+//! Scope is deliberately narrow (see docs/design/MCP_TOOL_INTEGRATION.md):
+//! this client speaks the streamable-HTTP transport and implements only the
+//! `initialize` handshake and `tools/call`. Sessions, sampling, roots, and
+//! elicitation are out of scope — MCP is a call target here, not a runtime.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use serde_json::{json, Value};
+
+const MCP_PROTOCOL_VERSION: &str = "2025-03-26";
+
+/// Outcome of a single tool call. Failures are data, not errors: the batch
+/// executor records them per-call so one bad row never poisons a batch.
+#[derive(Debug, Clone)]
+pub struct ToolCallOutcome {
+    /// Text content returned by the tool (concatenated text blocks).
+    pub content: Option<String>,
+    /// True when the *tool* reported failure (MCP `isError`).
+    pub is_error: bool,
+    /// Transport/protocol-level error, if the call never completed.
+    pub error: Option<String>,
+}
+
+impl ToolCallOutcome {
+    fn transport_error(msg: impl Into<String>) -> Self {
+        ToolCallOutcome {
+            content: None,
+            is_error: true,
+            error: Some(msg.into()),
+        }
+    }
+}
+
+/// A connected MCP-over-HTTP session. Cheap to clone; safe to share across
+/// tokio tasks (reqwest::Client is internally reference-counted).
+#[derive(Debug, Clone)]
+pub struct McpHttpClient {
+    http: reqwest::Client,
+    endpoint: String,
+    session_id: Option<String>,
+    next_id: std::sync::Arc<AtomicU64>,
+}
+
+impl McpHttpClient {
+    /// Connect to an MCP server over streamable HTTP and run the
+    /// `initialize` handshake.
+    pub async fn connect(endpoint: &str, timeout: Duration) -> Result<Self, String> {
+        let http = reqwest::Client::builder()
+            .timeout(timeout)
+            .build()
+            .map_err(|e| format!("failed to build HTTP client: {e}"))?;
+
+        let mut client = McpHttpClient {
+            http,
+            endpoint: endpoint.to_string(),
+            session_id: None,
+            next_id: std::sync::Arc::new(AtomicU64::new(1)),
+        };
+
+        let init = client
+            .post_rpc(
+                "initialize",
+                json!({
+                    "protocolVersion": MCP_PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": {"name": "polar-llama", "version": env!("CARGO_PKG_VERSION")},
+                }),
+            )
+            .await?;
+
+        if let Some(err) = init.rpc_error {
+            return Err(format!("MCP initialize failed: {err}"));
+        }
+        client.session_id = init.session_id;
+
+        // Servers expect the initialized notification before tool calls.
+        client
+            .post_notification("notifications/initialized", json!({}))
+            .await?;
+
+        Ok(client)
+    }
+
+    /// Invoke `tools/call`. Never returns Err: all failure modes are folded
+    /// into the outcome so callers can treat results as row data.
+    pub async fn call_tool(&self, name: &str, arguments: &Value) -> ToolCallOutcome {
+        let response = match self
+            .post_rpc("tools/call", json!({"name": name, "arguments": arguments}))
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => return ToolCallOutcome::transport_error(e),
+        };
+
+        if let Some(err) = response.rpc_error {
+            return ToolCallOutcome::transport_error(format!("MCP error: {err}"));
+        }
+
+        let result = match response.result {
+            Some(r) => r,
+            None => return ToolCallOutcome::transport_error("MCP response missing result"),
+        };
+
+        let is_error = result
+            .get("isError")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+
+        // Concatenate text content blocks; serialize non-text blocks as JSON
+        // so nothing the server returned is silently dropped.
+        let content = result.get("content").and_then(Value::as_array).map(|blocks| {
+            blocks
+                .iter()
+                .map(|block| match block.get("type").and_then(Value::as_str) {
+                    Some("text") => block
+                        .get("text")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string(),
+                    _ => block.to_string(),
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        });
+
+        // Some servers return structuredContent instead of/alongside content.
+        let content = match (content, result.get("structuredContent")) {
+            (Some(c), _) if !c.is_empty() => Some(c),
+            (_, Some(sc)) => Some(sc.to_string()),
+            (c, None) => c,
+        };
+
+        ToolCallOutcome {
+            content,
+            is_error,
+            error: None,
+        }
+    }
+
+    async fn post_rpc(&self, method: &str, params: Value) -> Result<RpcResponse, String> {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let body = json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params});
+        self.post_message(&body, true).await
+    }
+
+    async fn post_notification(&self, method: &str, params: Value) -> Result<(), String> {
+        let body = json!({"jsonrpc": "2.0", "method": method, "params": params});
+        self.post_message(&body, false).await.map(|_| ())
+    }
+
+    async fn post_message(&self, body: &Value, expect_response: bool) -> Result<RpcResponse, String> {
+        let mut request = self
+            .http
+            .post(&self.endpoint)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .json(body);
+
+        if let Some(sid) = &self.session_id {
+            request = request.header("Mcp-Session-Id", sid.clone());
+        }
+
+        let response = request
+            .send()
+            .await
+            .map_err(|e| format!("HTTP request failed: {e}"))?;
+
+        let session_id = response
+            .headers()
+            .get("Mcp-Session-Id")
+            .and_then(|v| v.to_str().ok())
+            .map(String::from)
+            .or_else(|| self.session_id.clone());
+
+        let status = response.status();
+        let content_type = response
+            .headers()
+            .get("Content-Type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        let text = response
+            .text()
+            .await
+            .map_err(|e| format!("failed to read HTTP response: {e}"))?;
+
+        if !status.is_success() {
+            // 202 Accepted for notifications is covered by is_success; real
+            // failures surface the body for debuggability.
+            return Err(format!("HTTP {status}: {}", truncate(&text, 500)));
+        }
+
+        if !expect_response {
+            return Ok(RpcResponse {
+                result: None,
+                rpc_error: None,
+                session_id,
+            });
+        }
+
+        let message = if content_type.starts_with("text/event-stream") {
+            parse_sse_json_rpc(&text).ok_or_else(|| "no JSON-RPC response in SSE stream".to_string())?
+        } else {
+            serde_json::from_str::<Value>(&text)
+                .map_err(|e| format!("invalid JSON-RPC response: {e}: {}", truncate(&text, 200)))?
+        };
+
+        Ok(RpcResponse {
+            rpc_error: message.get("error").map(|e| e.to_string()),
+            result: message.get("result").cloned(),
+            session_id,
+        })
+    }
+}
+
+struct RpcResponse {
+    result: Option<Value>,
+    rpc_error: Option<String>,
+    session_id: Option<String>,
+}
+
+/// Extract the last JSON-RPC response object from an SSE body. Streamable
+/// HTTP servers may emit progress notifications first; the response to our
+/// request is the event carrying an `id`.
+fn parse_sse_json_rpc(body: &str) -> Option<Value> {
+    let mut last_response: Option<Value> = None;
+    for line in body.lines() {
+        let line = line.trim_start();
+        if let Some(data) = line.strip_prefix("data:") {
+            if let Ok(value) = serde_json::from_str::<Value>(data.trim()) {
+                if value.get("id").is_some() && (value.get("result").is_some() || value.get("error").is_some()) {
+                    last_response = Some(value);
+                }
+            }
+        }
+    }
+    last_response
+}
+
+fn truncate(s: &str, max: usize) -> &str {
+    match s.char_indices().nth(max) {
+        Some((idx, _)) => &s[..idx],
+        None => s,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_sse_response() {
+        let body = "event: message\ndata: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\"}\n\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"ok\":true}}\n\n";
+        let parsed = parse_sse_json_rpc(body).unwrap();
+        assert_eq!(parsed["result"]["ok"], Value::Bool(true));
+    }
+
+    #[test]
+    fn sse_without_response_is_none() {
+        assert!(parse_sse_json_rpc("data: {\"jsonrpc\":\"2.0\",\"method\":\"x\"}\n\n").is_none());
+    }
+}

--- a/tests/test_tool_use.py
+++ b/tests/test_tool_use.py
@@ -1,0 +1,389 @@
+"""
+Tests for tool use: emission schemas, MCP introspection, and batch execution.
+
+These tests run against an in-process mock MCP server (no API keys needed),
+so they exercise the full pipeline deterministically:
+emission schema -> serialized calls -> parallel execution -> results column.
+"""
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import polars as pl
+import pytest
+
+from polar_llama import (
+    TOOL_RESULT_DTYPE,
+    execute_tool_calls,
+    mcp_tools,
+    tool_results_to_message,
+    tools_to_response_model,
+)
+from polar_llama import _json_schema_to_polars_dtype, _pydantic_to_json_schema
+
+SEARCH_FOOD_TOOL = {
+    "name": "search_food_db",
+    "description": "Search a nutrition database for a food item",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string"},
+            "database": {"type": "string", "enum": ["usda", "openfoodfacts"]},
+        },
+        "required": ["query", "database"],
+    },
+}
+
+CONVERT_UNITS_TOOL = {
+    "name": "convert_units",
+    "description": "Convert a quantity between units",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "quantity": {"type": "number"},
+            "from_unit": {"type": "string"},
+            "to_unit": {"type": "string"},
+        },
+        "required": ["quantity", "from_unit", "to_unit"],
+    },
+}
+
+
+# ============================================================================
+# Mock MCP server (streamable HTTP)
+# ============================================================================
+
+class MockMcpHandler(BaseHTTPRequestHandler):
+    """Implements initialize / tools/list / tools/call over streamable HTTP."""
+
+    calls_received = []
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length))
+        method = body.get("method")
+
+        if method == "initialize":
+            self._respond(body, {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "mock-nutrition", "version": "0.1"},
+            }, session_id="test-session-1")
+        elif method == "notifications/initialized":
+            self.send_response(202)
+            self.end_headers()
+        elif method == "tools/list":
+            self._respond(body, {"tools": [SEARCH_FOOD_TOOL, CONVERT_UNITS_TOOL]})
+        elif method == "tools/call":
+            params = body.get("params", {})
+            type(self).calls_received.append(params)
+            name = params.get("name")
+            args = params.get("arguments", {})
+            if name == "search_food_db":
+                content = json.dumps({
+                    "food": args.get("query"),
+                    "database": args.get("database"),
+                    "calories_per_100g": 155,
+                })
+                self._respond(body, {"content": [{"type": "text", "text": content}]})
+            elif name == "convert_units":
+                self._respond(body, {"content": [{"type": "text", "text": "converted"}]})
+            elif name == "always_fails":
+                self._respond(body, {
+                    "content": [{"type": "text", "text": "boom"}],
+                    "isError": True,
+                })
+            else:
+                self._respond(body, error={"code": -32602, "message": f"unknown tool {name}"})
+        else:
+            self._respond(body, error={"code": -32601, "message": "method not found"})
+
+    def _respond(self, request, result=None, error=None, session_id=None):
+        payload = {"jsonrpc": "2.0", "id": request.get("id")}
+        if error is not None:
+            payload["error"] = error
+        else:
+            payload["result"] = result
+        data = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        if session_id:
+            self.send_header("Mcp-Session-Id", session_id)
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def log_message(self, *args):
+        pass  # keep test output clean
+
+
+@pytest.fixture(scope="module")
+def mcp_server():
+    server = HTTPServer(("127.0.0.1", 0), MockMcpHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{server.server_address[1]}/mcp"
+    server.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def clear_recorded_calls():
+    MockMcpHandler.calls_received = []
+
+
+# ============================================================================
+# Phase 0: emission schema
+# ============================================================================
+
+def test_tools_to_response_model_shape():
+    model = tools_to_response_model([SEARCH_FOOD_TOOL, CONVERT_UNITS_TOOL])
+    schema = model.model_json_schema()
+
+    assert "calls" in schema["properties"]
+    tool_call_schema = schema["$defs"]["ToolCall"]
+    assert set(tool_call_schema["required"]) == {"tool_name", "arguments"}
+    assert tool_call_schema["properties"]["tool_name"]["enum"] == [
+        "search_food_db",
+        "convert_units",
+    ]
+    # Each tool's own input schema is embedded so the LLM generates against
+    # the tool's actual contract.
+    assert "search_food_db" in tool_call_schema["properties"]["arguments"]["description"]
+    assert "openfoodfacts" in tool_call_schema["properties"]["arguments"]["description"]
+
+    # Round-trips through the library's structured-output machinery.
+    instance = model(calls=[{
+        "tool_name": "search_food_db",
+        "arguments": json.dumps({"query": "eggs", "database": "usda"}),
+    }])
+    assert instance.calls[0].tool_name == "search_food_db"
+
+    with pytest.raises(Exception):
+        model(calls=[{"tool_name": "not_a_tool", "arguments": "{}"}])
+
+
+def test_tools_to_response_model_polars_dtype():
+    """The emission model must lower to a usable Polars struct dtype."""
+    model = tools_to_response_model([SEARCH_FOOD_TOOL])
+    dtype = _json_schema_to_polars_dtype(_pydantic_to_json_schema(model))
+
+    fields = {f.name: f.dtype for f in dtype.fields}
+    assert isinstance(fields["calls"], pl.List)
+    inner = fields["calls"].inner
+    inner_fields = {f.name: f.dtype for f in inner.fields}
+    assert inner_fields == {"tool_name": pl.Utf8, "arguments": pl.Utf8}
+    # Error columns from the structured-output convention are present.
+    assert "_error" in fields and "_raw" in fields
+
+
+def test_tools_normalization_accepts_multiple_forms():
+    from pydantic import BaseModel
+
+    class lookup_recipe(BaseModel):
+        """Look up a recipe by name."""
+        name: str
+
+    openai_form = {
+        "type": "function",
+        "function": {"name": "f1", "description": "d", "parameters": {"type": "object"}},
+    }
+    anthropic_form = {"name": "f2", "input_schema": {"type": "object"}}
+
+    model = tools_to_response_model([lookup_recipe, openai_form, anthropic_form])
+    specs = model.__polar_llama_tools__
+    assert [s["name"] for s in specs] == ["lookup_recipe", "f1", "f2"]
+    assert specs[0]["description"] == "Look up a recipe by name."
+    assert "name" in specs[0]["input_schema"]["properties"]
+
+
+def test_duplicate_tool_names_rejected():
+    with pytest.raises(ValueError, match="Duplicate"):
+        tools_to_response_model([SEARCH_FOOD_TOOL, SEARCH_FOOD_TOOL])
+
+
+# ============================================================================
+# Phase 0: MCP introspection
+# ============================================================================
+
+def test_mcp_tools_introspection(mcp_server):
+    tools = mcp_tools(mcp_server)
+    assert [t["name"] for t in tools] == ["search_food_db", "convert_units"]
+    assert tools[0]["input_schema"]["required"] == ["query", "database"]
+
+    # Introspected tools feed straight into the emission model.
+    model = tools_to_response_model(tools)
+    assert model.__polar_llama_tools__[0]["name"] == "search_food_db"
+
+
+def test_mcp_tools_rejects_unknown_transport():
+    with pytest.raises(ValueError, match="transport"):
+        mcp_tools("ftp://nope")
+
+
+# ============================================================================
+# Phase 1: execution — Rust MCP path
+# ============================================================================
+
+def _emitted_calls_df():
+    """A dataframe shaped like the output of the emission step."""
+    calls_dtype = pl.Struct([
+        pl.Field("calls", pl.List(pl.Struct([
+            pl.Field("tool_name", pl.Utf8),
+            pl.Field("arguments", pl.Utf8),
+        ]))),
+        pl.Field("_error", pl.Utf8),
+    ])
+    return pl.DataFrame({
+        "meal": ["two eggs and toast", "chicken bowl", "just water"],
+        "calls": pl.Series([
+            {"calls": [
+                {"tool_name": "search_food_db",
+                 "arguments": json.dumps({"query": "eggs", "database": "usda"})},
+                {"tool_name": "search_food_db",
+                 "arguments": json.dumps({"query": "toast", "database": "openfoodfacts"})},
+            ], "_error": None},
+            {"calls": [
+                {"tool_name": "search_food_db",
+                 "arguments": json.dumps({"query": "chicken bowl", "database": "usda"})},
+            ], "_error": None},
+            {"calls": [], "_error": None},
+        ], dtype=calls_dtype),
+    })
+
+
+def test_execute_tool_calls_mcp(mcp_server):
+    df = _emitted_calls_df().with_columns(
+        results=execute_tool_calls(pl.col("calls"), transport=mcp_server)
+    )
+
+    assert df["results"].dtype == TOOL_RESULT_DTYPE
+    row0 = df["results"][0].to_list()
+    assert len(row0) == 2
+    assert row0[0]["tool_name"] == "search_food_db"
+    assert row0[0]["is_error"] is False
+    assert json.loads(row0[0]["content"])["food"] == "eggs"
+    # Order within a row is preserved even though execution is parallel.
+    assert json.loads(row0[1]["content"])["food"] == "toast"
+    # Empty emission -> empty results, not null and not an error.
+    assert df["results"][2].to_list() == []
+    # All 3 calls actually reached the server.
+    assert len(MockMcpHandler.calls_received) == 3
+
+
+def test_execute_tool_calls_validates_arguments(mcp_server):
+    """Invalid arguments fail fast as data — no network call is made."""
+    df = pl.DataFrame({
+        "calls": [json.dumps([
+            {"tool_name": "search_food_db",
+             "arguments": json.dumps({"query": "eggs"})},  # missing `database`
+        ])],
+    }).with_columns(
+        results=execute_tool_calls(
+            pl.col("calls"),
+            transport=mcp_server,
+            tools=[SEARCH_FOOD_TOOL, CONVERT_UNITS_TOOL],
+        )
+    )
+
+    result = df["results"][0].to_list()[0]
+    assert result["is_error"] is True
+    assert "validation failed" in result["_error"]
+    assert len(MockMcpHandler.calls_received) == 0
+
+
+def test_execute_tool_calls_tool_error_is_data(mcp_server):
+    df = pl.DataFrame({
+        "calls": [json.dumps([{"tool_name": "always_fails", "arguments": "{}"}])],
+    }).with_columns(
+        results=execute_tool_calls(pl.col("calls"), transport=mcp_server)
+    )
+    result = df["results"][0].to_list()[0]
+    assert result["is_error"] is True
+    assert result["content"] == "boom"
+
+
+def test_execute_tool_calls_unreachable_transport_raises():
+    df = pl.DataFrame({
+        "calls": [json.dumps([{"tool_name": "x", "arguments": "{}"}])],
+    })
+    with pytest.raises(pl.exceptions.ComputeError, match="MCP"):
+        df.with_columns(
+            results=execute_tool_calls(
+                pl.col("calls"), transport="http://127.0.0.1:9/mcp", timeout_s=2
+            )
+        )
+
+
+# ============================================================================
+# Phase 1: execution — Python executor escape hatch
+# ============================================================================
+
+def test_execute_tool_calls_python_executor():
+    seen = []
+
+    def executor(tool_name, arguments):
+        seen.append((tool_name, arguments))
+        if arguments.get("query") == "explode":
+            raise RuntimeError("db unavailable")
+        return {"hits": 1, "query": arguments.get("query")}
+
+    df = _emitted_calls_df().with_columns(
+        results=execute_tool_calls(pl.col("calls"), executor=executor)
+    )
+
+    row0 = df["results"][0].to_list()
+    assert json.loads(row0[0]["content"]) == {"hits": 1, "query": "eggs"}
+    assert row0[0]["is_error"] is False
+    assert len(seen) == 3
+
+    # A raising executor becomes error data on the right call.
+    df2 = pl.DataFrame({
+        "calls": [json.dumps([
+            {"tool_name": "search_food_db", "arguments": json.dumps({"query": "explode"})},
+            {"tool_name": "search_food_db", "arguments": json.dumps({"query": "fine"})},
+        ])],
+    }).with_columns(results=execute_tool_calls(pl.col("calls"), executor=executor))
+    results = df2["results"][0].to_list()
+    assert results[0]["is_error"] is True
+    assert "db unavailable" in results[0]["_error"]
+    assert results[1]["is_error"] is False
+
+
+def test_execute_tool_calls_requires_exactly_one_target():
+    with pytest.raises(ValueError, match="exactly one"):
+        execute_tool_calls(pl.col("calls"))
+    with pytest.raises(ValueError, match="exactly one"):
+        execute_tool_calls(pl.col("calls"), transport="http://x", executor=lambda n, a: "")
+
+
+def test_null_rows_stay_null():
+    df = pl.DataFrame({"calls": pl.Series([None], dtype=pl.Utf8)}).with_columns(
+        results=execute_tool_calls(pl.col("calls"), executor=lambda n, a: "ok")
+    )
+    assert df["results"][0] is None
+
+
+# ============================================================================
+# Synthesis: results -> message
+# ============================================================================
+
+def test_tool_results_to_message():
+    results = pl.Series([[
+        {"tool_name": "search_food_db",
+         "arguments": '{"query": "eggs", "database": "usda"}',
+         "content": '{"calories_per_100g": 155}',
+         "is_error": False, "_error": None},
+        {"tool_name": "search_food_db",
+         "arguments": '{"query": "toast"}',
+         "content": None, "is_error": True,
+         "_error": "argument validation failed: 'database' is required"},
+    ]], dtype=TOOL_RESULT_DTYPE)
+
+    df = pl.DataFrame({"results": results}).with_columns(
+        message=tool_results_to_message(pl.col("results"))
+    )
+    message = json.loads(df["message"][0])
+    assert message["role"] == "user"
+    assert "search_food_db" in message["content"]
+    assert "calories_per_100g" in message["content"]
+    assert "ERROR" in message["content"]


### PR DESCRIPTION
## What

Started as a design proposal (`docs/design/MCP_TOOL_INTEGRATION.md`, first commit) evaluating whether tool use / MCP belongs in polar_llama; now also **implements the accepted recommendation** — Phases 0 and 1. The per-row agent loop (Phase 2) remains deferred behind the evidence-based criteria in the design doc.

The core idea: **don't put an agent loop inside a row — unroll it into the dataframe.** Emission is structured output, execution is a batch-parallel expression, every intermediate turn is a column.

```
row text ──► emit calls ──► execute (parallel) ──► synthesize ──► answer
 (col)         (col)             (col)                (col)
```

## Phase 0 — emission & introspection (`polar_llama/tools.py`)

- `tools_to_response_model(tools)` — builds a strict-mode-safe Pydantic emission schema: `{"calls": [{"tool_name": <enum>, "arguments": <json-string>}]}`. Each tool's own `input_schema` is embedded in the field description, so the LLM generates against the tool's real contract — it never has to "reformat per the MCP". Accepts MCP `tools/list` entries, Anthropic/OpenAI-style dicts, and Pydantic models.
- `mcp_tools(transport)` — `tools/list` introspection over streamable HTTP and stdio. MCP's role is deliberately narrow: a schema source and call target, not a runtime.
- `tool_results_to_message(expr)` — renders a results column as a message for the synthesis turn (`combine_messages` + `inference_messages`).

## Phase 1 — batch-parallel execution

- `src/mcp.rs` — minimal MCP streamable-HTTP client in Rust: `initialize` handshake, `Mcp-Session-Id` handling, SSE and JSON response parsing, `tools/call` only.
- `execute_tool_calls` expression (`src/expressions.rs`) — every call of every row fans out on the existing shared Tokio runtime behind a concurrency semaphore (same skeleton as `inference_async`). Arguments are validated against the selected tool's schema (`jsonschema` crate, already a dependency) **before** any network call. Per-call failures are data (`is_error`, `_error` — the structured-output convention), never exceptions; only an unreachable transport raises.
- `executor=` escape hatch — a Python callable for non-MCP targets (databases, internal APIs) with the same errors-as-data semantics on a thread pool.
- `.llama.execute_tool_calls()` / `.llama.tool_results_to_message()` namespace parity.

## Testing

`tests/test_tool_use.py` (14 tests, all passing) runs against an **in-process mock MCP server**, so the full Rust round-trip — handshake, parallel `tools/call` fan-out, ordering guarantees, validation short-circuit, tool-error propagation — is exercised deterministically with no API keys. The stdio transport was verified against a scratch stdio server. Existing non-API tests pass unchanged; `cargo test` passes.

Note: `tests/test_embeddings.py::test_basic_embedding` fails in environments where `OPENAI_API_KEY` is set, due to a pre-existing kwargs bug in `embedding_async` with no provider/model — untouched by and unrelated to this PR.

## Docs

- `docs/TOOL_USE.md` — full usage guide
- `docs/design/MCP_TOOL_INTEGRATION.md` — status updated to Accepted, Phases 0–1 implemented
- API reference + README sections, changelog entry, `examples/tool_use_calorie_tracker.py` (the motivating worked example)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SvjmQfcDybNpBas262Eso