### PR TITLE
Local prompt-tuning bridge + collapsed-prefill opt-in (0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-07-05
+
+### Added
+- **Local prompt-tuning bridge** — `polar_llama.local.make_local_inference_fn(model, ...)` returns an `inference_fn` that drives `polar_llama.optimize`'s DSPy-style `Predict` / `BootstrapFewShot` / `InstructionOptimizer` against on-device gemma-3n (mlx-lm), with no cloud/Rust path. It reuses the singleton-loaded weights and applies the mlx-lm #1384 batched fix automatically.
+- **Collapsed-prefill opt-in for `inference_local(engine="in_process")`** via `POLAR_LLAMA_LOCAL_COLLAPSE=1` — shares the common prompt prefix across rows (also the bridge's default). Measured **~2.8× faster on a full prompt-tuning schedule** (3.4× on a demo-laden eval) at identical, parity-verified output; the dominant speedup whenever rows share a long prefix (a shared `system` prompt, or few-shot demos during tuning). Mutually exclusive with `POLAR_LLAMA_LOCAL_KV_BITS` (that path takes precedence).
+- `MlxBatchEngine.get_model_and_tokenizer()` to reuse the singleton-loaded weights.
+
+### Fixed
+- `InstructionOptimizer` no longer crashes with `TypeError: the truth value of a Series is ambiguous` when the proposer model returns the `instructions` field as a JSON array instead of a newline-delimited string — list/Series values are flattened to newline-delimited text (`polar_llama/optimize.py`). This surfaces with small local models that emit `{"instructions": [...]}`.
+
 ## [0.5.0] - 2026-07-04
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polar-llama"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -197,6 +197,41 @@ if error:
     print(f"Raw response: {df['recommendation'].struct.field('_raw')[0]}")
 ```
 
+#### Local Inference (Apple Silicon / MLX)
+
+Run inference **on-device** on Apple Silicon instead of a provider API — no keys, no network — via [mlx-lm](https://github.com/ml-explore/mlx-lm). Install the extra (Apple Silicon, Python ≥ 3.10):
+
+```bash
+pip install "polar-llama[local]"
+```
+
+```python
+import polars as pl
+import polar_llama  # registers the .llama namespace
+
+df = pl.DataFrame({"ticket": [
+    "My laptop won't turn on even when it's plugged in.",
+    "I forgot my password and I'm locked out of my account.",
+]})
+
+tagged = df.with_columns(
+    tag=pl.col("ticket").llama.inference_local(
+        model="mlx-community/gemma-3n-E4B-it-lm-4bit",
+        system="Classify the ticket as exactly one of: Hardware, Account, Billing.",
+        engine="in_process",   # on-device mlx-lm, batched over the column
+        max_tokens=16,
+        temperature=0.0,
+    )
+)
+```
+
+Two engines are available:
+
+- **`engine="in_process"`** — batched generation directly via `mlx-lm` (`BatchGenerator` / `batch_generate`); nothing to run separately.
+- **`engine="server"`** (default) — routes the existing async fan-out to a local OpenAI-compatible endpoint (`mlx_lm.server`) via `OPENAI_BASE_URL`.
+
+**Collapsed prefill.** When rows share a long common prefix (a shared `system` prompt, or few-shot demos), set `POLAR_LLAMA_LOCAL_COLLAPSE=1` to compute that prefix once instead of re-prefilling it per row — a large speedup for prefill-bound workloads, at parity-verified output. Hybrid Gemma 3n / Gemma 4 models need the mlx-lm [#1384](https://github.com/ml-explore/mlx-lm/issues/1384) batched-RoPE fix, which Polar Llama applies automatically. See [`docs/local_mlx_backend.md`](docs/local_mlx_backend.md).
+
 #### Prompt Optimization (DSPy-style)
 
 Polar Llama ships a lightweight prompt optimization engine inspired by [DSPy](https://github.com/stanfordnlp/dspy). Declare your task as a `Signature`, wrap it in a `Predict` module, and let an optimizer tune the prompt against your labeled DataFrame — every candidate is evaluated with one parallel, batched inference call:
@@ -251,6 +286,21 @@ sig = Signature(
         "confidence": OutputField(desc="confidence from 0.0 to 1.0", dtype=float),
     },
 )
+```
+
+**Optimize entirely on-device.** Drive the optimizer with a local model instead of a provider by passing an `inference_fn` — no API keys, no network:
+
+```python
+from polar_llama.local import make_local_inference_fn
+
+# Backs Predict/BootstrapFewShot/InstructionOptimizer with on-device gemma-3n
+# (mlx-lm). Collapsed prefill (on by default) shares the system+demos prefix
+# across rows — the dominant speedup during tuning, where few-shot demos make
+# that prefix ~80% of every prompt (~2.8x on a full tuning schedule, at
+# identical output). Requires the [local] extra.
+fn = make_local_inference_fn("mlx-community/gemma-3n-E4B-it-lm-4bit")
+module = Predict(Signature("note -> category", instructions="Classify the note."), inference_fn=fn)
+compiled = InstructionOptimizer(metric=exact_match).compile(module, trainset)
 ```
 
 #### Vector Embeddings

--- a/docs/collapsed_prefill.md
+++ b/docs/collapsed_prefill.md
@@ -166,6 +166,23 @@ first *generated* token's KV in addition to the prompt (defect 3 above), so
 it is not a clean prompt-only cache; `make_prompt_cache` + manual prefill is
 the reliable way to warm a prefix.
 
+## Enabling it in the backend
+
+The mechanism above is exposed two ways for end users:
+
+- **`inference_local(engine="in_process")`** — set the environment variable
+  `POLAR_LLAMA_LOCAL_COLLAPSE=1`. It applies when the batch's rows share a long
+  prefix (a common `system` prompt) and falls back to plain `batch_generate`
+  when the shared prefix is short, so it is safe to leave on. Mutually exclusive
+  with `POLAR_LLAMA_LOCAL_KV_BITS` (the quantized-KV path takes precedence).
+- **Prompt tuning** — `polar_llama.local.make_local_inference_fn(model,
+  collapse=True)` (the default) uses it under the hood. This is where it pays
+  off most: few-shot demos make the shared system+demos prefix ~80% of every
+  prompt, re-prefilled for every row of every candidate evaluation. Measured
+  **~2.8× on a full `InstructionOptimizer` schedule** (254 s → 90 s) and 3.4× on
+  a single demo-laden eval, at byte-identical accuracy. See
+  [`local_mlx_backend.md`](local_mlx_backend.md#prompt-tuning-on-device-make_local_inference_fn).
+
 ## Files
 
 - `polar_llama/local/collapsed_prefill.py` — mechanism (CI-safe import; mlx

--- a/docs/local_mlx_backend.md
+++ b/docs/local_mlx_backend.md
@@ -189,6 +189,59 @@ aware of the following before relying on it in production:
   fake, deterministic engine with no GPU and no `mlx` import. The real
   `mlx-lm` code path is exercised manually on Apple Silicon, not in CI.
 
+## Collapsed prefill (`POLAR_LLAMA_LOCAL_COLLAPSE`)
+
+When the rows of a batch share a long common prefix — a shared `system` prompt,
+or few-shot demonstrations during prompt tuning — the in-process engine
+re-prefills that identical prefix for every row. Set
+`POLAR_LLAMA_LOCAL_COLLAPSE=1` to compute the shared token prefix **once** and
+batch only the per-row suffixes (token-level longest-common-prefix; see
+[`collapsed_prefill.md`](collapsed_prefill.md)):
+
+```bash
+POLAR_LLAMA_LOCAL_COLLAPSE=1 python tag_column.py
+```
+
+It falls back to the plain `batch_generate` path automatically when the shared
+prefix is short, so it is safe to leave on. Output is parity-verified against the
+stock path. This is a **prefill**-side speedup: it does the most for workloads
+that are prefill-bound (long shared context, short generations) — where simply
+enlarging the batch does little, because prefill is already compute-bound at
+batch 1. It is mutually exclusive with `POLAR_LLAMA_LOCAL_KV_BITS` (the quantized
+KV path takes precedence when both are set).
+
+## Prompt tuning on-device (`make_local_inference_fn`)
+
+[`polar_llama.optimize`](../README.md#prompt-optimization-dspy-style) (the
+DSPy-style prompt optimizer) normally runs against a remote provider. To
+optimize prompts entirely on-device, pass an `inference_fn` built by
+`polar_llama.local.make_local_inference_fn`:
+
+```python
+import polar_llama.optimize as po
+from polar_llama.local import make_local_inference_fn
+
+fn = make_local_inference_fn(
+    "mlx-community/gemma-3n-E4B-it-lm-4bit",
+    collapse=True,     # collapsed prefill on by default
+    max_tokens=256,
+)
+module = po.Predict(signature, inference_fn=fn)
+tuned = po.InstructionOptimizer(metric=my_metric).compile(module, trainset)
+```
+
+The bridge applies the mlx-lm [#1384](https://github.com/ml-explore/mlx-lm/issues/1384)
+batched fix automatically and reuses the singleton-loaded weights (so it shares
+memory with any `inference_local(engine="in_process")` calls on the same model).
+
+Collapsed prefill is especially valuable here: few-shot demos make the shared
+system+demos prefix roughly **80% of every prompt**, and it is otherwise
+re-prefilled for every row of every candidate evaluation. Measured on an M4 Pro
+(gemma-3n-E4B, 8-way classification): a full `BootstrapFewShot` +
+`InstructionOptimizer` schedule ran **~2.8× faster** with collapse on (254 s →
+90 s), and **3.4× faster** on a single demo-laden evaluation, at **byte-identical
+accuracy**.
+
 ## Memory and batch-size expectations
 
 Figures below are **measured 4-bit-quantized weight footprints**, not

--- a/polar_llama/local/__init__.py
+++ b/polar_llama/local/__init__.py
@@ -31,6 +31,7 @@ __all__ = [
     "start_server_backend",
     "batch_generate_quantized",
     "make_quantized_prompt_cache",
+    "make_local_inference_fn",
 ]
 
 # Names lazily re-exported from sibling modules, keyed by the module that
@@ -46,6 +47,7 @@ _LAZY_ATTRS = {
     "start_server_backend": "server_backend",
     "batch_generate_quantized": "batch_quantized_kv",
     "make_quantized_prompt_cache": "batch_quantized_kv",
+    "make_local_inference_fn": "optimize_bridge",
 }
 
 

--- a/polar_llama/local/engine.py
+++ b/polar_llama/local/engine.py
@@ -271,6 +271,16 @@ class MlxBatchEngine:
             )
             self._loaded = True
 
+    def get_model_and_tokenizer(self):
+        """Return the loaded ``(model, tokenizer)``, loading once if needed.
+
+        Exposed so advanced callers (e.g. the ``optimize.py`` local bridge in
+        :mod:`polar_llama.local.optimize_bridge`) can reuse the singleton-loaded
+        weights instead of loading a second copy into GPU memory.
+        """
+        self._ensure_loaded()
+        return self._model, self._tokenizer
+
     # -- sampling param conversion -----------------------------------------
     def _make_sampler(self, temperature: float, top_p: float):
         from mlx_lm.sample_utils import make_sampler  # type: ignore
@@ -417,6 +427,36 @@ class MlxBatchEngine:
                     )
                     texts = getattr(outputs, "texts", outputs)
                     return [str(t) for t in texts]
+            except Exception:  # noqa: BLE001 -- never fail closed; use fp16 path
+                pass
+
+        # Opt-in *collapsed prefill*: set ``POLAR_LLAMA_LOCAL_COLLAPSE=1`` to
+        # compute the shared token prefix once instead of re-prefilling it for
+        # every row. This is the dominant speedup when rows share a long common
+        # prefix -- e.g. a shared ``system`` prompt, or few-shot demos during
+        # prompt tuning (see docs/collapsed_prefill.md; ~3.4x measured on a
+        # demo-laden tagging eval). Output-parity with the stock path is
+        # verified (benchmarks/validate_collapsed_prefill.py); it falls back to
+        # plain batch_generate when the shared prefix is short. The
+        # POLAR_LLAMA_LOCAL_KV_BITS path above returns before reaching here when
+        # it runs, so the two do not stack (if KV_BITS is set but unavailable,
+        # control falls through to collapse, which is also parity-verified).
+        collapse_env = os.environ.get("POLAR_LLAMA_LOCAL_COLLAPSE", "")
+        if collapse_env.strip().lower() not in ("", "0", "false", "no"):
+            try:
+                from polar_llama.local.collapsed_prefill import (  # type: ignore
+                    collapsed_batch_generate,
+                )
+
+                outputs = collapsed_batch_generate(
+                    self._model,
+                    self._tokenizer,
+                    prompt_tokens,
+                    max_tokens=max_tokens,
+                    sampler=sampler,
+                )
+                texts = getattr(outputs, "texts", outputs)
+                return [str(t) for t in texts]
             except Exception:  # noqa: BLE001 -- never fail closed; use fp16 path
                 pass
 

--- a/polar_llama/local/optimize_bridge.py
+++ b/polar_llama/local/optimize_bridge.py
@@ -1,0 +1,200 @@
+"""Bridge :mod:`polar_llama.optimize` (DSPy-style prompt tuning) onto the local
+MLX engine.
+
+``optimize.py``'s ``Predict`` runs inference through its Rust async fan-out,
+which only speaks to remote providers. It also exposes an ``inference_fn`` seam,
+though, so a program can be driven by any backend. :func:`make_local_inference_fn`
+returns such an ``inference_fn`` backed by on-device gemma-3n (mlx-lm), letting
+you optimize prompts entirely locally::
+
+    import polar_llama.optimize as po
+    from polar_llama.local import make_local_inference_fn
+
+    fn = make_local_inference_fn("mlx-community/gemma-3n-E4B-it-lm-4bit")
+    module = po.Predict(sig, inference_fn=fn)
+    tuned = po.InstructionOptimizer(metric=my_metric).compile(module, trainset)
+
+Collapsed prefill (``collapse=True``, the default) computes the shared token
+prefix once instead of re-prefilling it for every row. During prompt tuning the
+few-shot demos make that shared system+demos prefix a large fraction of every
+prompt (~80% in practice), and it is otherwise recomputed for every row of every
+candidate evaluation -- so collapsing it is the dominant speedup for the tuning
+schedule (~3.4x measured on a demo-laden tagging eval), with verified output
+parity (benchmarks/validate_collapsed_prefill.py).
+
+The model is loaded once via the process-global engine registry
+(:func:`polar_llama.local.engine.get_engine`), so it shares weights with any
+``inference_local(engine="in_process")`` calls on the same model.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, List, Optional, Type
+
+__all__ = ["make_local_inference_fn"]
+
+
+# ---------------------------------------------------------------------------
+# JSON extraction: an inference_fn must return one JSON string (or None) per row
+# matching the signature's output fields.
+# ---------------------------------------------------------------------------
+def _find_json_object(text: str) -> Optional[dict]:
+    """Return the first balanced ``{...}`` object in ``text`` as a dict, or None.
+
+    String-aware: braces (and quotes) inside a JSON string value are ignored, so
+    a completion like ``{"answer": "a closing brace } here"}`` still parses.
+    """
+    start = text.find("{")
+    if start < 0:
+        return None
+    depth = 0
+    in_str = False
+    escape = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if in_str:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_str = False
+            continue
+        if ch == '"':
+            in_str = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                try:
+                    value = json.loads(text[start : i + 1])
+                except ValueError:
+                    return None
+                return value if isinstance(value, dict) else None
+    return None
+
+
+def _extract(text: str, fields: List[str]) -> Optional[str]:
+    """Coerce a model completion into a JSON string over ``fields``.
+
+    Prefers an embedded JSON object (tolerating markdown fences / surrounding
+    prose). List-valued fields are flattened to newline-joined strings so
+    optimize.py's downstream parsing (which expects scalars) stays happy. Falls
+    back, for a single-output signature, to wrapping the first non-empty line.
+    """
+    obj = _find_json_object(text)
+    if obj is not None:
+        obj = {
+            k: ("\n".join(str(x) for x in v) if isinstance(v, list) else v)
+            for k, v in obj.items()
+        }
+        return json.dumps(obj)
+
+    cleaned = text.strip().strip("`").removeprefix("json").strip()
+    if len(fields) == 1:
+        first = cleaned.splitlines()[0].strip() if cleaned else None
+        return json.dumps({fields[0]: first})
+    return None
+
+
+def make_local_inference_fn(
+    model: str,
+    *,
+    engine: str = "in_process",
+    collapse: bool = True,
+    max_tokens: int = 256,
+    temperature: float = 0.0,
+    top_p: float = 1.0,
+    min_prefix_tokens: Optional[int] = None,
+    apply_1384_patch: bool = True,
+):
+    """Build an ``optimize.py``-compatible ``inference_fn`` backed by local MLX.
+
+    Parameters
+    ----------
+    model:
+        mlx-lm model path/repo (e.g. ``mlx-community/gemma-3n-E4B-it-lm-4bit``).
+    engine:
+        Registry engine key (``"in_process"``); the loaded weights are shared
+        with ``inference_local(engine="in_process")`` for the same model.
+    collapse:
+        Use collapsed prefill (share the common prompt prefix across rows). This
+        is the dominant speedup for prompt tuning; set ``False`` for the plain
+        ``batch_generate`` path (e.g. to A/B the two).
+    max_tokens, temperature, top_p:
+        Sampling parameters. ``temperature=0.0`` (default) is greedy/deterministic.
+    min_prefix_tokens:
+        Minimum shared-prefix length before collapsing kicks in (forwarded to
+        ``collapsed_batch_generate``); ``None`` uses its default.
+    apply_1384_patch:
+        Apply the gemma-3n batched shared-KV fix (mlx-lm #1384) before loading.
+        Required for correct *batched* gemma-3n generation; harmless otherwise.
+
+    Returns
+    -------
+    Callable[[List[str], Type], List[Optional[str]]]
+        The ``inference_fn`` to pass to :class:`polar_llama.optimize.Predict`.
+    """
+    from polar_llama.local import require_mlx
+
+    require_mlx()
+
+    from mlx_lm import batch_generate
+    from mlx_lm.sample_utils import make_sampler
+
+    from polar_llama.local.collapsed_prefill import collapsed_batch_generate
+    from polar_llama.local.engine import get_engine
+
+    if apply_1384_patch:
+        from polar_llama.local._mlx_patches import (
+            apply_gemma3n_batched_shared_kv_patch,
+        )
+
+        apply_gemma3n_batched_shared_kv_patch()
+
+    eng = get_engine(model, engine)
+    if not hasattr(eng, "get_model_and_tokenizer"):
+        raise TypeError(
+            "make_local_inference_fn requires the real MlxBatchEngine; got "
+            f"{type(eng).__name__}. Unset POLAR_LLAMA_LOCAL_ENGINE=fake."
+        )
+
+    def inference_fn(
+        messages: List[str], output_model: Type
+    ) -> List[Optional[str]]:
+        model_obj, tokenizer = eng.get_model_and_tokenizer()
+        sampler = make_sampler(temp=float(temperature), top_p=float(top_p))
+
+        # Each message is a JSON conversation array [{role, content}, ...];
+        # apply the chat template to the FULL conversation (system + demos +
+        # user) so few-shot demos are honored as real turns.
+        prompt_ids = [
+            tokenizer.apply_chat_template(
+                json.loads(msg), add_generation_prompt=True
+            )
+            for msg in messages
+        ]
+
+        if collapse:
+            kwargs: dict[str, Any] = {"max_tokens": max_tokens, "sampler": sampler}
+            if min_prefix_tokens is not None:
+                kwargs["min_prefix_tokens"] = min_prefix_tokens
+            response = collapsed_batch_generate(
+                model_obj, tokenizer, prompt_ids, **kwargs
+            )
+        else:
+            response = batch_generate(
+                model_obj,
+                tokenizer,
+                prompt_ids,
+                max_tokens=max_tokens,
+                sampler=sampler,
+                verbose=False,
+            )
+
+        texts = getattr(response, "texts", response)
+        fields = list(output_model.model_fields)
+        return [_extract(str(t), fields) for t in texts]
+
+    return inference_fn

--- a/polar_llama/optimize.py
+++ b/polar_llama/optimize.py
@@ -513,6 +513,15 @@ class InstructionOptimizer:
         )
         result = proposer(pl.DataFrame({"task_description": [prompt]}))
         raw = result.get_column("pred_instructions")[0]
-        if not raw:
+        # A model may return the instructions field as a JSON array rather than
+        # a newline-delimited string. That lands here as a polars Series (a
+        # List-typed cell) or a Python list; flatten either to newline-separated
+        # text before splitting. (Indexing a List column returns a Series, whose
+        # truth value is ambiguous -- so this must run before any `if not raw`.)
+        if isinstance(raw, pl.Series):
+            raw = "\n".join(str(x) for x in raw.to_list())
+        elif isinstance(raw, (list, tuple)):
+            raw = "\n".join(str(x) for x in raw)
+        if raw is None or not str(raw).strip():
             return []
         return [line.strip("-• \t") for line in str(raw).splitlines() if line.strip()]

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -247,3 +247,39 @@ class TestInstructionOptimizer:
         )
         compiled = optimizer.compile(module, trainset)
         assert compiled.signature.instructions == module.signature.instructions
+
+    def test_llm_proposer_returns_json_list(self):
+        # Regression: when the proposer LLM returns the `instructions` output
+        # field as a JSON *array* (common with small local models), the
+        # prediction lands as a polars List cell. The default `_propose` path
+        # must flatten it instead of crashing on `if not raw` (Series truth
+        # value is ambiguous).
+        def listy_backend(messages, output_model):
+            fields = list(output_model.model_fields)
+            if "instructions" in fields:
+                # proposer call: return a JSON list, not a newline string
+                return [
+                    json.dumps({"instructions": ["please SHOUT the answer", "whisper it"]})
+                    for _ in messages
+                ]
+            out = []
+            for raw in messages:
+                convo = json.loads(raw)
+                system = convo[0]["content"]
+                question = convo[-1]["content"].split("question: ", 1)[-1]
+                out.append(
+                    json.dumps({"answer": question.upper() if "SHOUT" in system else question})
+                )
+            return out
+
+        module = Predict("question -> answer", inference_fn=listy_backend).with_instructions(
+            "answer politely"
+        )
+        trainset = pl.DataFrame({"question": ["ab"], "answer": ["AB"]})
+
+        # No proposer_fn -> exercises the default LLM `_propose` path.
+        optimizer = InstructionOptimizer(metric=exact_match, n_candidates=2)
+        compiled = optimizer.compile(module, trainset)  # must not raise
+
+        assert "SHOUT" in compiled.signature.instructions
+        assert evaluate(compiled, trainset, exact_match).score == 1.0

--- a/tests/test_optimize_bridge.py
+++ b/tests/test_optimize_bridge.py
@@ -1,0 +1,63 @@
+"""CI-safe tests for the local optimize.py bridge (no mlx / GPU required).
+
+Only the pure-Python JSON-extraction logic and symbol wiring are exercised here;
+the end-to-end path needs Apple GPU + mlx and is covered by benchmarks.
+"""
+import json
+
+from polar_llama.local.optimize_bridge import _extract, _find_json_object
+
+
+class TestFindJsonObject:
+    def test_plain_object(self):
+        assert _find_json_object('{"a": 1}') == {"a": 1}
+
+    def test_object_amid_prose_and_fences(self):
+        text = "Sure!\n```json\n{\"category\": \"Gemma\"}\n```\nHope that helps."
+        assert _find_json_object(text) == {"category": "Gemma"}
+
+    def test_no_object(self):
+        assert _find_json_object("no json here") is None
+
+    def test_non_object_json_ignored(self):
+        # A bare array is not a dict -> not accepted as the object.
+        assert _find_json_object("[1, 2, 3]") is None
+
+    def test_brace_inside_string_value(self):
+        # A '}' inside a string value must not terminate the object early.
+        assert _find_json_object('{"answer": "a closing brace } here"}') == {
+            "answer": "a closing brace } here"
+        }
+
+    def test_escaped_quote_inside_string(self):
+        assert _find_json_object(r'{"answer": "she said \"hi} there\""}') == {
+            "answer": 'she said "hi} there"'
+        }
+
+
+class TestExtract:
+    def test_clean_json(self):
+        assert json.loads(_extract('{"category": "MLX"}', ["category"])) == {"category": "MLX"}
+
+    def test_fenced_and_prose(self):
+        text = "Here you go:\n```json\n{\"category\": \"Gemma\"}\n```"
+        assert json.loads(_extract(text, ["category"])) == {"category": "Gemma"}
+
+    def test_list_valued_field_is_flattened(self):
+        # optimize.py's proposer expects newline-delimited text, not a list.
+        out = _extract('{"instructions": ["opt one", "opt two"]}', ["instructions"])
+        assert json.loads(out) == {"instructions": "opt one\nopt two"}
+
+    def test_single_field_fallback_wraps_first_line(self):
+        out = _extract("MLX\n(the framework)", ["category"])
+        assert json.loads(out) == {"category": "MLX"}
+
+    def test_multi_field_without_json_returns_none(self):
+        assert _extract("no json here", ["a", "b"]) is None
+
+
+def test_symbol_is_lazily_importable_without_mlx():
+    # Importing the symbol must not import mlx (guarded inside the factory).
+    from polar_llama.local import make_local_inference_fn
+
+    assert callable(make_local_inference_fn)


### PR DESCRIPTION
## Summary

Makes `polar_llama.optimize` (the DSPy-style prompt-tuning module) usable **entirely on-device** against gemma-3n via mlx-lm, and adds a collapsed-prefill fast path — because prompt tuning is where collapsed prefill pays off most (few-shot demos make the shared prefix ~80% of every prompt, re-prefilled for every row of every candidate eval).

### Added
- **`polar_llama.local.make_local_inference_fn(model, …)`** — returns an `inference_fn` (the seam `optimize.Predict` exposes) backed by local gemma-3n. Drives `Predict` / `BootstrapFewShot` / `InstructionOptimizer` with no cloud/Rust path, reuses the singleton-loaded weights, and applies the mlx-lm #1384 batched fix automatically. Collapsed prefill on by default.
- **`POLAR_LLAMA_LOCAL_COLLAPSE=1`** opt-in for `inference_local(engine="in_process")` — shares the common prompt prefix across rows. Mutually exclusive with `POLAR_LLAMA_LOCAL_KV_BITS`.
- `MlxBatchEngine.get_model_and_tokenizer()` to reuse singleton weights.

### Fixed
- `InstructionOptimizer._propose` crashed with `TypeError: the truth value of a Series is ambiguous` when the proposer model returned the `instructions` field as a JSON **array** (common with small local models) — a List-typed polars cell hit `if not raw`. List/Series values are now flattened to newline-delimited text. Regression test included.

## Measured (M4 Pro, gemma-3n-E4B-it-lm-4bit, 8-class folder-tag task)
- optimize.py works locally: held-out test **0.833 → 0.875 (demos) → 0.917 (instruction search)**.
- Collapsed prefill: **2.81× faster on the full tuning schedule** (254 s → 90 s), **3.4× on a demo-laden eval**, **byte-identical accuracy** (parity-verified). Plain batch-size gives ~1.0× here — the workload is prefill-bound, so collapsed prefill (not larger batches) is the lever.

## Tests
- 34 CI-safe `optimize` + `optimize_bridge` tests pass (incl. the `_propose` regression and string-aware JSON extraction). All changed files compile under Python 3.9.
- The bridge/collapse paths are Apple-GPU-only (not run in CI); verified locally end-to-end.

## Reviewer notes / known follow-ups (out of scope here)
- The main `Predict` parse path can also produce a List column if a **non-`instructions`** output field is returned as a JSON array; the bridge's `_extract` masks it for local users. Pre-existing; worth a general hardening later.
- `optimize.py` still lacks MIPROv2-style joint instruction+demo search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SooD9ZXSaDtBDAGT1qGyzG