### PR TITLE
fix(local): in_process gemma3n crash + unmask stats ZeroDivisionError (#70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `inference_local(engine="in_process")` on Gemma 3n no longer crashes end-to-end (#70). The mlx-lm #1384 batched shared-KV fix was only applied on the prompt-tuning bridge/benchmark paths, never on the `inference_local` load path, so `MlxBatchEngine` loaded gemma-3n unpatched and batched generation raised `ValueError: too many values to unpack (expected 2)`. Both this patch and a new guard are now applied automatically at model load (`polar_llama/local/engine.py::_apply_mlx_patches`).
+- Unmasked the real in-process error: `mlx_lm.generate.BatchGenerator.stats` divided `prompt_tokens / prompt_time` with `prompt_time == 0` in its teardown, raising `ZeroDivisionError` *during* exception handling and replacing the underlying error. A new guarded, idempotent patch (`apply_batchgen_stats_zerodiv_patch`) wraps the context manager so a body exception is never masked and a zero-time exit yields `tps = 0.0`.
+
 ## [0.5.1] - 2026-07-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,9 +770,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1995,7 +1995,7 @@ dependencies = [
 
 [[package]]
 name = "polar-llama"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/polar_llama/local/_mlx_patches.py
+++ b/polar_llama/local/_mlx_patches.py
@@ -1,6 +1,6 @@
-"""Runtime workarounds for upstream mlx-lm bugs.
+"""Runtime workarounds for upstream mlx-lm bugs (see issue #70).
 
-Currently contains a single patch:
+Contains two independent, guarded, idempotent patches:
 
 ``apply_gemma3n_batched_shared_kv_patch``
     Works around https://github.com/ml-explore/mlx-lm/issues/1384 (present in
@@ -41,6 +41,22 @@ Currently contains a single patch:
             apply_gemma3n_batched_shared_kv_patch,
         )
         apply_gemma3n_batched_shared_kv_patch()
+
+    ``apply_batchgen_stats_zerodiv_patch``
+        Works around an unguarded division in ``mlx_lm.generate``'s
+        ``BatchGenerator.stats`` context manager (mlx-lm <= 0.31.3): its
+        ``finally`` computes ``stats.prompt_tps = prompt_tokens / prompt_time``
+        with no zero guard. When ``prompt_time == 0`` this raises
+        ``ZeroDivisionError`` from inside the ``finally`` -- during exception
+        teardown it *replaces* the real error the caller raised (masking), and
+        on a clean zero-work exit it crashes outright. The patch wraps the
+        original context manager: it never masks the body's exception, and on a
+        clean exit it converts a zero-time ``ZeroDivisionError`` into
+        ``tps = 0.0``. In that zero corner case upstream's post-division
+        accumulation (generation_tokens/time and peak_memory) is skipped; this
+        is acceptable (no work was done). The patch is a no-op if mlx-lm is
+        absent or once upstream guards the division. Like the gemma3n patch it
+        is applied explicitly, at model load, not on import.
 """
 
 from __future__ import annotations
@@ -49,6 +65,7 @@ import inspect
 from typing import Any, Optional
 
 _PATCH_FLAG = "_polar_llama_1384_patched"
+_STATS_PATCH_FLAG = "_polar_llama_stats_zerodiv_patched"
 
 
 def apply_gemma3n_batched_shared_kv_patch() -> bool:
@@ -265,4 +282,76 @@ def apply_gemma3n_batched_shared_kv_patch() -> bool:
     gemma3n.Gemma3nDecoderLayer.__call__ = decoder_layer_call
     gemma3n.LanguageModel.__call__ = language_model_call
     setattr(gemma3n, _PATCH_FLAG, True)
+    return True
+
+
+def apply_batchgen_stats_zerodiv_patch() -> bool:
+    """Guard ``mlx_lm.generate.BatchGenerator.stats`` against divide-by-zero.
+
+    The upstream context manager computes ``prompt_tps = prompt_tokens /
+    prompt_time`` in a ``finally`` with no zero guard (mlx-lm <= 0.31.3). This
+    wraps it so that (a) an exception raised in the ``with`` body is never
+    masked by a teardown ``ZeroDivisionError``, and (b) a clean zero-time exit
+    yields ``tps = 0.0`` instead of crashing.
+
+    Returns:
+        ``True`` if the guard is active (just applied or applied earlier),
+        ``False`` if not needed (mlx-lm absent, API changed, or upstream
+        already guards the division).
+    """
+    import importlib
+    from contextlib import contextmanager
+
+    try:
+        gen_mod = importlib.import_module("mlx_lm.generate")
+    except ImportError:
+        return False  # mlx-lm absent (or sys.modules sentinel): no-op
+
+    # Idempotent: never wrap twice.
+    if getattr(gen_mod, _STATS_PATCH_FLAG, False):
+        return True
+
+    BatchGenerator = getattr(gen_mod, "BatchGenerator", None)
+    if BatchGenerator is None:
+        return False
+
+    orig_stats = BatchGenerator.stats
+    try:
+        src = inspect.getsource(orig_stats)
+    except (OSError, TypeError):
+        return False
+    # No-op once upstream guards the division.
+    if "stats.prompt_tokens / stats.prompt_time" not in src:
+        return False
+
+    @contextmanager
+    def stats(self, stats=None):
+        cm = orig_stats(self, stats)
+        st = cm.__enter__()
+        try:
+            yield st
+        except BaseException as exc:
+            # Teardown must never mask the body's real error.
+            try:
+                cm.__exit__(type(exc), exc, exc.__traceback__)
+            except ZeroDivisionError:
+                pass
+            raise
+        else:
+            try:
+                cm.__exit__(None, None, None)
+            except ZeroDivisionError:
+                # Clean zero-work exit: upstream aborted at the prompt_tps
+                # division, so recompute both tps defensively as 0.0.
+                st.prompt_tps = (
+                    st.prompt_tokens / st.prompt_time if st.prompt_time else 0.0
+                )
+                st.generation_tps = (
+                    st.generation_tokens / st.generation_time
+                    if st.generation_time
+                    else 0.0
+                )
+
+    BatchGenerator.stats = stats
+    setattr(gen_mod, _STATS_PATCH_FLAG, True)
     return True

--- a/polar_llama/local/engine.py
+++ b/polar_llama/local/engine.py
@@ -33,7 +33,6 @@ import threading
 from typing import (
     Callable,
     Dict,
-    Iterable,
     Iterator,
     List,
     Optional,
@@ -211,6 +210,29 @@ def _require_mlx() -> None:
         ) from exc
 
 
+def _apply_mlx_patches() -> None:
+    """Apply all upstream mlx-lm workarounds (issue #70) before generation.
+
+    Both patches are individually guarded, idempotent no-ops when not
+    applicable, so this is called unconditionally on the real mlx load path.
+    Best-effort: a patch is a hardening measure, never load-critical, so an
+    unexpected failure here must not prevent the model from loading.
+    """
+    from polar_llama.local._mlx_patches import (
+        apply_batchgen_stats_zerodiv_patch,
+        apply_gemma3n_batched_shared_kv_patch,
+    )
+
+    for patch in (
+        apply_gemma3n_batched_shared_kv_patch,  # mlx-lm #1384 (unpack crash / garbage)
+        apply_batchgen_stats_zerodiv_patch,  # BatchGenerator.stats masking / zerodiv
+    ):
+        try:
+            patch()
+        except Exception:  # noqa: BLE001 -- hardening must never break load
+            pass
+
+
 # ---------------------------------------------------------------------------
 # MlxBatchEngine -- the real Apple-silicon path (BLOCKED-ON-GPU / import-guarded)
 # ---------------------------------------------------------------------------
@@ -237,6 +259,9 @@ class MlxBatchEngine:
     to restore the Metal wired-memory limit -- is opt-in via
     ``POLAR_LLAMA_LOCAL_STREAMING=1`` and its per-``insert`` kwargs remain
     unverified against 0.31.3.
+
+    Upstream mlx-lm workarounds (issue #70) are applied once, in
+    ``_ensure_loaded``, before ``load()`` runs -- see :func:`_apply_mlx_patches`.
     """
 
     def __init__(
@@ -262,6 +287,10 @@ class MlxBatchEngine:
             if self._loaded:
                 return
             _require_mlx()
+            # Apply upstream mlx-lm workarounds (issue #70) before load so the
+            # gemma3n model class is patched before any weights are built and
+            # the BatchGenerator.stats guard is live before generation.
+            _apply_mlx_patches()
             from mlx_lm import load  # type: ignore
 
             self._model, self._tokenizer = load(

--- a/tests/test_local_patches.py
+++ b/tests/test_local_patches.py
@@ -1,0 +1,210 @@
+"""CI-safe regression tests for issue #70 mlx-lm workarounds.
+
+No mlx imports: the patch functions are guarded no-ops without mlx, and the
+engine wiring is exercised with fake mlx_lm modules injected via sys.modules.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from contextlib import contextmanager
+
+import polars as pl
+import pytest
+
+import polar_llama.local._mlx_patches as patches
+import polar_llama.local.engine as engine_mod
+from polar_llama.local.engine import (
+    FakeEngine,
+    MlxBatchEngine,
+    clear_registry,
+    register_engine,
+)
+from polar_llama.local.expr import inference_local
+
+pytestmark = pytest.mark.local
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Isolate the process-global registry between tests."""
+    clear_registry()
+    yield
+    clear_registry()
+
+
+# ---------------------------------------------------------------------------
+# 1. Both patches run, in order, BEFORE load; and load-once holds.
+# ---------------------------------------------------------------------------
+def test_ensure_loaded_applies_both_patches_before_load(monkeypatch):
+    calls = []
+    monkeypatch.setattr(engine_mod, "_require_mlx", lambda: calls.append("require"))
+    monkeypatch.setattr(
+        patches,
+        "apply_gemma3n_batched_shared_kv_patch",
+        lambda: (calls.append("gemma3n"), True)[1],
+    )
+    monkeypatch.setattr(
+        patches,
+        "apply_batchgen_stats_zerodiv_patch",
+        lambda: (calls.append("stats"), True)[1],
+    )
+
+    fake_mlx = types.ModuleType("mlx_lm")
+
+    def load(model, tokenizer_config=None, model_config=None):
+        calls.append("load")
+        return ("MODEL", "TOK")
+
+    fake_mlx.load = load
+    monkeypatch.setitem(sys.modules, "mlx_lm", fake_mlx)
+
+    eng = MlxBatchEngine("dummy")
+    assert eng.get_model_and_tokenizer() == ("MODEL", "TOK")
+    assert calls == ["require", "gemma3n", "stats", "load"]
+
+    # load-once: no further patch/load calls on second access.
+    eng.get_model_and_tokenizer()
+    assert calls == ["require", "gemma3n", "stats", "load"]
+
+
+# ---------------------------------------------------------------------------
+# 1b. The helper itself never raises even if a patch blows up.
+# ---------------------------------------------------------------------------
+def test_apply_mlx_patches_swallows_patch_errors(monkeypatch):
+    def boom():
+        raise RuntimeError("patch exploded")
+
+    monkeypatch.setattr(patches, "apply_gemma3n_batched_shared_kv_patch", boom)
+    monkeypatch.setattr(patches, "apply_batchgen_stats_zerodiv_patch", boom)
+    engine_mod._apply_mlx_patches()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# 2. FakeEngine end-to-end never touches the patch functions.
+# ---------------------------------------------------------------------------
+def test_fake_engine_path_never_touches_patches(monkeypatch):
+    monkeypatch.setattr(
+        patches,
+        "apply_gemma3n_batched_shared_kv_patch",
+        lambda: pytest.fail("patch called on FakeEngine path"),
+    )
+    monkeypatch.setattr(
+        patches,
+        "apply_batchgen_stats_zerodiv_patch",
+        lambda: pytest.fail("patch called on FakeEngine path"),
+    )
+    register_engine("dummy-70", FakeEngine("dummy-70"), engine="in_process")
+    df = pl.DataFrame({"prompt": ["a", "b"]})
+    out = df.with_columns(
+        answer=inference_local(pl.col("prompt"), model="dummy-70", engine="in_process")
+    )
+    assert out["answer"].to_list() == ["echo:a", "echo:b"]
+
+
+# ---------------------------------------------------------------------------
+# 3. The stats guard: unmasks, guards clean-zero exit, is idempotent.
+# ---------------------------------------------------------------------------
+def _install_fake_generate(monkeypatch, prompt_time):
+    """Inject a fake mlx_lm.generate whose stats() replicates the unguarded
+    upstream 0.31.3 finally block (source-sniffable via inspect.getsource)."""
+
+    class BatchStats:
+        def __init__(self):
+            self.prompt_tokens = 0
+            self.prompt_time = 0.0
+            self.prompt_tps = 0.0
+            self.generation_tokens = 0
+            self.generation_time = 0.0
+            self.generation_tps = 0.0
+
+    class BatchGenerator:
+        _pt = prompt_time
+
+        @contextmanager
+        def stats(self, stats=None):
+            stats = stats or BatchStats()
+            try:
+                yield stats
+            finally:
+                stats.prompt_tokens += 5
+                stats.prompt_time += self._pt
+                stats.prompt_tps = stats.prompt_tokens / stats.prompt_time
+                stats.generation_tokens += 3
+                stats.generation_time += 1.0
+                stats.generation_tps = stats.generation_tokens / stats.generation_time
+
+    mod = types.ModuleType("mlx_lm.generate")
+    mod.BatchStats = BatchStats
+    mod.BatchGenerator = BatchGenerator
+    pkg = types.ModuleType("mlx_lm")
+    monkeypatch.setitem(sys.modules, "mlx_lm", pkg)
+    monkeypatch.setitem(sys.modules, "mlx_lm.generate", mod)
+    return mod
+
+
+def test_stats_zerodiv_patch_unmasks_and_guards(monkeypatch):
+    mod = _install_fake_generate(monkeypatch, prompt_time=0.0)
+    assert patches.apply_batchgen_stats_zerodiv_patch() is True
+
+    gen = mod.BatchGenerator()
+
+    # Unmasking: the body's error propagates, not ZeroDivisionError.
+    with pytest.raises(ValueError, match="real error"):
+        with gen.stats():
+            raise ValueError("real error")
+
+    # Clean zero-work exit: no crash, tps guarded to 0.0.
+    with gen.stats() as st:
+        pass
+    assert st.prompt_tps == 0.0
+    assert st.generation_tps == 0.0
+
+    # Idempotent: identity unchanged, still True.
+    first = mod.BatchGenerator.stats
+    assert patches.apply_batchgen_stats_zerodiv_patch() is True
+    assert mod.BatchGenerator.stats is first
+
+
+def test_stats_zerodiv_patch_normal_path_unchanged(monkeypatch):
+    mod = _install_fake_generate(monkeypatch, prompt_time=2.0)
+    assert patches.apply_batchgen_stats_zerodiv_patch() is True
+    gen = mod.BatchGenerator()
+    with gen.stats() as st:
+        pass
+    assert st.prompt_tps == 2.5  # 5 / 2.0, unchanged behavior
+    assert st.generation_tps == 3.0  # 3 / 1.0
+    assert st.generation_tokens == 3  # post-division accumulation ran
+
+
+# ---------------------------------------------------------------------------
+# 4. No-op paths: mlx absent, and upstream-already-guarded.
+# ---------------------------------------------------------------------------
+def test_stats_zerodiv_patch_noop_when_module_absent(monkeypatch):
+    monkeypatch.setitem(sys.modules, "mlx_lm.generate", None)  # forces ImportError
+    assert patches.apply_batchgen_stats_zerodiv_patch() is False
+
+
+def test_stats_zerodiv_patch_noop_when_already_guarded(monkeypatch):
+    class BatchGenerator:
+        @contextmanager
+        def stats(self, stats=None):
+            # Guarded division: the divisor is bound to a local before use, so
+            # the unguarded upstream substring never appears in this source,
+            # and the source-sniff gates the patch off.
+            try:
+                yield stats
+            finally:
+                pt = stats.prompt_time if stats is not None else 0.0
+                if pt:
+                    stats.prompt_tps = stats.prompt_tokens / pt
+
+    mod = types.ModuleType("mlx_lm.generate")
+    mod.BatchGenerator = BatchGenerator
+    monkeypatch.setitem(sys.modules, "mlx_lm", types.ModuleType("mlx_lm"))
+    monkeypatch.setitem(sys.modules, "mlx_lm.generate", mod)
+
+    before = BatchGenerator.stats
+    assert patches.apply_batchgen_stats_zerodiv_patch() is False
+    assert BatchGenerator.stats is before  # untouched


### PR DESCRIPTION
Fixes #70.

## Two stacked bugs

`pl.col(...).llama.inference_local(engine="in_process")` failed end-to-end on Apple Silicon with one bug masking the other.

### Primary — `too many values to unpack (expected 2)`
The mlx-lm **#1384** batched shared-KV fix (`apply_gemma3n_batched_shared_kv_patch`, in `_mlx_patches.py`) was only applied on the prompt-tuning bridge (`optimize_bridge.py`) and the benchmarks — **never** on the real `inference_local` load path. `MlxBatchEngine._ensure_loaded()` called `mlx_lm.load()` directly, so gemma-3n loaded **unpatched** and batched generation hit `keys, values = cache.state` where the batched cache's `state` is a 4-tuple → `ValueError`. (The issue's repro comment assumed `import polar_llama` applies the patch; per the module docstring it does not, and neither did the engine.)

### Masking — `ZeroDivisionError: division by zero`
`mlx_lm.generate.BatchGenerator.stats` computes `prompt_tps = prompt_tokens / prompt_time` with `prompt_time == 0` in its teardown. That ran via `gen.throw()` **while the primary error was propagating**, replacing it — so every caller only saw "division by zero".

## Fix
New `_apply_mlx_patches()` in `engine.py`, called from `_ensure_loaded()` **before** `mlx_lm.load()`:
- applies the gemma3n #1384 patch (so the model class is patched before weights build), and
- applies a **new** `apply_batchgen_stats_zerodiv_patch` that wraps the `stats` context manager: it **never masks** an exception raised in the `with` body, and converts a clean zero-time exit to `tps = 0.0`.

Both patches are **guarded** (no-op if mlx-lm is absent or already fixed — the stats guard source-sniffs for the unguarded division) and **idempotent** (module flags). Patch application is **best-effort/non-fatal** and never touches `FakeEngine`.

## Tests
`tests/test_local_patches.py` — 7 CI-safe tests, **no mlx required** (marked `local`, not `local_gpu`):
- `_ensure_loaded` applies **both** patches, in order, **before** `load()` (the core regression for the primary bug), and load-once holds;
- the FakeEngine path never touches the patch functions;
- the stats guard unmasks a body exception, guards zero-time to `0.0`, and is idempotent;
- no-op paths (mlx absent / already-guarded upstream).

**Verification:** `uv run pytest tests/test_local_patches.py -m "not local_gpu"` → 7 passed. Full CI-safe suite (`-m "not local_gpu"`) → no new failures; the only failing tests (`test_local_ci_smoke.py`, which assert mlx is *absent*) fail identically on the base commit because this dev box has mlx installed, and pass in CI where it isn't.

> Note: I could not exercise real gemma-3n GPU generation here (no model weights on this box), so the runtime path is covered by code-level reproduction of both failure modes plus the load-path wiring test rather than a live E4B decode. Worth a confirming run on your machine with the actual `mlx-community/gemma-3n-E4B-it-lm-4bit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnthn-ai/codesmith/polar_llama/pr/72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786494438&installation_id=141504833&pr_number=72&repository=pnthn-ai%2Fpolar_llama&return_to=https%3A%2F%2Fgithub.com%2Fpnthn-ai%2Fpolar_llama%2Fpull%2F72&signature=8f12c4078f35d761969d3705928f0a0f05e49e279102c7b49323518c7652ec0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->