### PR TITLE
Release 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-07-12
+
 ### Fixed
 - `inference_local(engine="in_process")` on Gemma 3n no longer crashes end-to-end (#70). The mlx-lm #1384 batched shared-KV fix was only applied on the prompt-tuning bridge/benchmark paths, never on the `inference_local` load path, so `MlxBatchEngine` loaded gemma-3n unpatched and batched generation raised `ValueError: too many values to unpack (expected 2)`. Both this patch and a new guard are now applied automatically at model load (`polar_llama/local/engine.py::_apply_mlx_patches`).
 - Unmasked the real in-process error: `mlx_lm.generate.BatchGenerator.stats` divided `prompt_tokens / prompt_time` with `prompt_time == 0` in its teardown, raising `ZeroDivisionError` *during* exception handling and replacing the underlying error. A new guarded, idempotent patch (`apply_batchgen_stats_zerodiv_patch`) wraps the context manager so a body exception is never masked and a zero-time exit yields `tps = 0.0`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,7 +1995,7 @@ dependencies = [
 
 [[package]]
 name = "polar-llama"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polar-llama"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
Release **0.5.2** — bug-fix release.

Version bump (`Cargo.toml` / `Cargo.lock` 0.5.1 → 0.5.2) + CHANGELOG promotion of the `[Unreleased]` entries under `[0.5.2]`.

### Fixed (already merged: #72)
- `inference_local(engine="in_process")` on Gemma 3n no longer crashes end-to-end (#70) — the mlx-lm #1384 batched shared-KV patch is now applied on the `in_process` load path, plus a new guard for the masking `BatchGenerator.stats` `ZeroDivisionError`.

Merging this and tagging `v0.5.2` triggers the trusted-publishing `release` job → PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnthn-ai/codesmith/polar_llama/pr/73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786498798&installation_id=141504833&pr_number=73&repository=pnthn-ai%2Fpolar_llama&return_to=https%3A%2F%2Fgithub.com%2Fpnthn-ai%2Fpolar_llama%2Fpull%2F73&signature=7b6d8c63eaaeb62a6be91cc2e4155597d6cf6d4a1b3fac810a2f0a4bb77d97d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->