### PR TITLE
Release 0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3] - 2026-07-13
+
+### Fixed
+- `tag_taxonomy()` no longer fails on OpenAI (and other strict-schema providers) with `invalid_request_error: 'required' ... Extra required key 'thinking'` (#51). Two stacked OpenAI-strict-mode schema violations are fixed: (1) the per-field `thinking` reasoning is now `List[{value, reasoning}]` instead of a `Dict[str, str]` dynamic-key map (which strict mode rejects for lacking `properties`/`required`); (2) `_pydantic_to_json_schema` now strips sibling keywords from `$ref` nodes (pydantic emits taxonomy fields as `{"$ref": ..., "description": ...}`, which strict mode rejects with "$ref cannot have keywords"). Verified end-to-end with live OpenAI (`gpt-4o-mini`), Anthropic (`claude-haiku-4-5`), and Groq (`llama-4-scout`) calls. `_validate_strict_mode_schema` now also warns when a user-supplied response model uses a `Dict`-typed field.
+
 ## [0.5.2] - 2026-07-12
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,7 +1995,7 @@ dependencies = [
 
 [[package]]
 name = "polar-llama"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polar-llama"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
Release **0.5.3** — bug-fix release.

Version bump (`Cargo.toml`/`Cargo.lock` 0.5.2 → 0.5.3) + CHANGELOG.

### Fixed (already merged: #86)
- `tag_taxonomy()` now works on OpenAI and other strict-schema providers (#51). Fixes two stacked OpenAI-strict-mode schema violations: `thinking` is now `List[{value, reasoning}]` (was a `Dict[str,str]` dynamic map), and `$ref` sibling keywords are stripped from the generated schema.

**Verified live** with real API calls: OpenAI `gpt-4o-mini`, Anthropic `claude-haiku-4-5`, Groq `llama-4-scout` — all tag successfully with no schema error.

Merging + tagging `v0.5.3` triggers the trusted-publishing `release` job → PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnthn-ai/codesmith/polar_llama/pr/87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786582381&installation_id=141504833&pr_number=87&repository=pnthn-ai%2Fpolar_llama&return_to=https%3A%2F%2Fgithub.com%2Fpnthn-ai%2Fpolar_llama%2Fpull%2F87&signature=6e0d2bd205f943e6e29e3bb66e8971d5c187bc13283a9b25f24a977a4b16b0aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->