### PR TITLE
feat: streaming inference via inference_stream() (#74) + release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-13
+
+### Added
+- **Streaming inference** (`inference_stream()`, issue #74): stream completions token-by-token with an `on_token(row_index, delta)` callback, returning a DataFrame-only `Struct{text: Utf8, finished: Boolean}` column (`STREAM_RESPONSE_DTYPE`) so the DataFrame stays rectangular even when a stream is cut off. `finished=False` covers every non-terminal outcome: a mid-stream provider `error` event, a transport drop, EOF without a completion marker, an `on_token` callback that raises, or Ctrl-C — all of these are reported as a `RuntimeWarning` with partial text returned rather than an exception propagating out of the expression. Native SSE parsing for OpenAI, Groq (OpenAI-compatible), and Anthropic; Gemini and Bedrock stream via a buffered fallback (one full-text delta then completion). `response_model`/`response_format` are rejected immediately with a clear `ValueError` — streaming is text-only.
+- `GROQ_BASE_URL` environment variable override for the Groq endpoint, matching the existing `OPENAI_BASE_URL` / `ANTHROPIC_BASE_URL` pattern (also needed so streaming's mock-server tests can point Groq at a local server).
+- `reqwest`'s `stream` feature, enabling chunked body streaming (`bytes_stream()`) for the new SSE drivers.
+
 ## [0.5.3] - 2026-07-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "polar-llama"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2917,6 +2917,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -2937,12 +2938,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -3816,6 +3819,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polar-llama"
-version = "0.5.3"
+version = "0.6.0"
 edition = "2021"
 
 [lib]
@@ -17,7 +17,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # rustls with the OS certificate store, so TLS verification stays on even
 # behind corporate proxies with custom CAs
-reqwest = { version = "0.12", features = ["json", "rustls-tls-native-roots"], default-features = false }
+reqwest = { version = "0.12", features = ["json", "stream", "rustls-tls-native-roots"], default-features = false }
 polars = { version = "0.53", default-features = false, features = ["dtype-struct"] }
 polars-arrow = { version = "0.53", default-features = false }
 polars-core = { version = "0.53", default-features = false }

--- a/README.md
+++ b/README.md
@@ -197,6 +197,35 @@ if error:
     print(f"Raw response: {df['recommendation'].struct.field('_raw')[0]}")
 ```
 
+#### Streaming Responses
+
+`inference_stream()` streams completions token-by-token via an `on_token(row_index, delta)` callback, while still returning a plain DataFrame column — there's no separate iterator to manage. Each row's result is a `Struct{text: Utf8, finished: Boolean}`: `finished=True` means the stream completed normally; `finished=False` covers any interruption (a provider error mid-stream, a dropped connection, Ctrl-C, or an `on_token` callback that raises) and comes with a `RuntimeWarning` plus whatever partial text had arrived — the DataFrame itself is never left in a broken state.
+
+```python
+import polars as pl
+from polar_llama import inference_stream, Provider
+
+df = pl.DataFrame({
+    'prompt': ["Tell me a short joke", "Say hello in French"]
+})
+
+df = df.with_columns(
+    response=inference_stream(
+        pl.col('prompt'),
+        provider=Provider.OPENAI,
+        model='gpt-4o-mini',
+        on_token=lambda i, d: print(d, end=""),
+    )
+)
+
+print(df.select(
+    pl.col('response').struct.field('text'),
+    pl.col('response').struct.field('finished'),
+))
+```
+
+Streaming is text-only: pass `response_model` and you'll get a clear `ValueError` telling you to use `inference_async()` for structured output instead. OpenAI, Groq, and Anthropic stream natively over SSE; Gemini and Bedrock fall back to a single "full response, then done" delta so every provider works with the same API.
+
 #### Local Inference (Apple Silicon / MLX)
 
 Run inference **on-device** on Apple Silicon instead of a provider API — no keys, no network — via [mlx-lm](https://github.com/ml-explore/mlx-lm). Install the extra (Apple Silicon, Python ≥ 3.10):
@@ -580,4 +609,4 @@ Polar Llama is released under the MIT license. For more details, see the LICENSE
 - [x] **Multiple Provider Support**: Support for different LLM providers (OpenAI, Anthropic, Gemini, Groq, AWS Bedrock).
 - [x] **Structured Data Outputs**: Add support for structured data outputs using Pydantic models with type validation and Polars Struct returns.
 - [x] **Tool Use / MCP**: Batch-parallel tool-call emission and execution with MCP support (see [docs/TOOL_USE.md](docs/TOOL_USE.md)).
-- [ ] **Streaming Responses**: Support for streaming responses from LLM providers.
+- [x] **Streaming Responses**: Support for streaming responses from LLM providers (`inference_stream()`, see above).

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -11,6 +11,7 @@ Complete reference documentation for all Polar Llama expressions and functions.
   - [inference](#inference)
   - [inference_async](#inference_async)
   - [inference_messages](#inference_messages)
+  - [inference_stream](#inference_stream)
   - [string_to_message](#string_to_message)
   - [combine_messages](#combine_messages)
   - [tag_taxonomy](#tag_taxonomy)
@@ -412,6 +413,69 @@ df = df.with_columns(
 - Maintains conversation context across multiple turns
 - Each row can have a different conversation history
 - Messages must be valid JSON
+
+---
+
+### inference_stream
+
+Stream completions token-by-token, with the final per-row result still returned as a plain DataFrame column (no separate iterator). This is a text-only API: `response_model` / `response_format` are rejected immediately.
+
+**Signature:**
+```python
+STREAM_RESPONSE_DTYPE = pl.Struct({"text": pl.Utf8, "finished": pl.Boolean})
+
+def inference_stream(
+    expr: IntoExpr,
+    *,
+    provider: Optional[Union[str, Provider]] = None,
+    model: Optional[str] = None,
+    on_token: Optional[Callable[[int, str], None]] = None,
+    messages: bool = False,
+    response_model: Optional[Type[BaseModel]] = None,
+    response_format: Optional[Type[BaseModel]] = None,
+) -> pl.Expr
+```
+
+**Parameters:**
+- `expr` (IntoExpr): The text expression to use for inference (or JSON message arrays, with `messages=True`)
+- `provider` (str | Provider, optional): The LLM provider to use. Defaults to `Provider.OPENAI`. Gemini and Bedrock have no native SSE transport wired up and stream via a buffered fallback (one full-text delta, then completion)
+- `model` (str, optional): The specific model name
+- `on_token` (callable, optional): `on_token(row_index, delta)`, invoked for every text delta as it arrives. `row_index` is the index within the batch this call executes — equal to the column index under the default `collect()` engine, but may restart from 0 per batch under the streaming/new-streaming engine
+- `messages` (bool, optional): When `True`, each row is a JSON-encoded message array instead of a bare user message string
+- `response_model` / `response_format`: Not supported — passing either raises `ValueError` immediately
+
+**Returns:**
+- `pl.Expr`: Expression of dtype `STREAM_RESPONSE_DTYPE` (`Struct{text: Utf8, finished: Boolean}`). A null input row produces a null struct row.
+
+**`finished` semantics:**
+- `finished=True`: the stream reached a clean terminator (`[DONE]` for OpenAI/Groq, `message_stop` for Anthropic, or the buffered-fallback path)
+- `finished=False`: the stream was cut off — a mid-stream provider `error` event, a transport drop, EOF without a terminator, an `on_token` callback that raised, or Ctrl-C. `text` holds whatever partial content had arrived (possibly `""`)
+
+**Cancellation:** if `on_token` raises, or the user presses Ctrl-C (only detected on the main Python thread), in-flight streams for the batch are aborted and the call returns normally with a `RuntimeWarning` — unfinished rows come back with their partial text and `finished=False`. No exception (including `KeyboardInterrupt`) ever propagates out of the expression; the DataFrame's height and schema are always intact.
+
+**Example:**
+```python
+import polars as pl
+from polar_llama import inference_stream, Provider
+
+df = pl.DataFrame({
+    'prompt': ["Tell me a short joke", "Say hello in French"]
+})
+
+df = df.with_columns(
+    response=inference_stream(
+        pl.col('prompt'),
+        provider=Provider.OPENAI,
+        model='gpt-4o-mini',
+        on_token=lambda i, d: print(d, end=""),
+    )
+)
+
+print(df.select(
+    pl.col('response').struct.field('text'),
+    pl.col('response').struct.field('finished'),
+))
+```
 
 ---
 

--- a/polar_llama/__init__.py
+++ b/polar_llama/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Union, Type, Dict, Any, List
+from typing import TYPE_CHECKING, Callable, Optional, Union, Type, Dict, Any, List
 import json
 
 import polars as pl
@@ -42,6 +42,19 @@ except ImportError:
 
             def __str__(self):
                 return self.value
+
+
+# Import the streaming pyfunction directly from the extension module. Unlike
+# the other expressions, `inference_stream` cannot go through
+# `register_plugin` (kwargs cross that boundary via serde, which cannot carry
+# a Python callable), so it calls this pyfunction from a `map_batches` UDF.
+try:
+    from .polar_llama import _stream_inference_batch
+except ImportError:
+    try:
+        from polar_llama.polar_llama import _stream_inference_batch
+    except ImportError:
+        _stream_inference_batch = None
 
 
 # Import and initialize the expressions helper to ensure expressions are registered
@@ -778,6 +791,139 @@ def inference_messages(
     return result_expr
 
 
+# ============================================================================
+# Streaming Inference
+# ============================================================================
+
+#: DataFrame-only streaming output dtype: a single self-describing struct
+#: column so the DataFrame stays rectangular even after cancellation.
+#: `finished=True` means a terminator was seen ("[DONE]" / `message_stop`, or
+#: the buffered-fallback path used by providers with no native SSE support).
+#: `finished=False` means the stream was cut off (callback raised, Ctrl-C, a
+#: mid-stream provider `error` event, a transport drop, or EOF without a
+#: terminator) -- `text` holds whatever partial content arrived, possibly "".
+STREAM_RESPONSE_DTYPE = pl.Struct({"text": pl.Utf8, "finished": pl.Boolean})
+
+
+def inference_stream(
+    expr: IntoExpr,
+    *,
+    provider: Optional[Union[str, Provider]] = None,
+    model: Optional[str] = None,
+    on_token: Optional[Callable[[int, str], None]] = None,
+    messages: bool = False,
+    response_model: Optional[Type["BaseModel"]] = None,
+    response_format: Optional[Type["BaseModel"]] = None,
+) -> pl.Expr:
+    """
+    Stream completions token-by-token for the given text expressions.
+
+    Unlike ``inference_async``, this is a text-only, DataFrame-oriented
+    streaming API: there is no Python iterator. Instead, each row's stream is
+    driven to completion (or cancellation) internally, with an optional
+    ``on_token`` callback invoked for every delta as it arrives, and the final
+    per-row result returned as a ``Struct{text: Utf8, finished: Boolean}``
+    (``STREAM_RESPONSE_DTYPE``) column -- so the DataFrame stays rectangular
+    and consistent even when a row's stream is cut off.
+
+    Parameters
+    ----------
+    expr : polars.Expr
+        The text expression to use for inference (or JSON message arrays,
+        with ``messages=True``).
+    provider : str or Provider, optional
+        The provider to use (OpenAI, Anthropic, Gemini, Groq, Bedrock).
+        Gemini and Bedrock do not have a native streaming transport wired up
+        here; they fall back to one full-text delta followed by completion.
+    model : str, optional
+        The model name to use.
+    on_token : callable, optional
+        ``on_token(row_index, delta)``, called for every text delta as it
+        arrives. ``row_index`` is the index *within the batch this pyfunction
+        call executes*, which equals the column index under the default
+        ``collect()`` engine, but may restart from 0 per batch under the
+        streaming/new-streaming engine. If the callback raises, that row's
+        stream is cancelled (see Cancellation below); no exception ever
+        propagates out of the expression.
+    messages : bool, optional
+        When True, each row is a JSON-encoded message array (as produced by
+        ``string_to_message`` / ``combine_messages``) instead of a bare user
+        message string.
+    response_model, response_format : optional
+        Not supported by streaming. Passing either raises ``ValueError``
+        immediately -- use ``inference_async`` for structured output.
+
+    Returns
+    -------
+    polars.Expr
+        Expression of dtype ``STREAM_RESPONSE_DTYPE``
+        (``Struct{text: Utf8, finished: Boolean}``). A null input row produces
+        a null struct row.
+
+    Cancellation
+    ------------
+    If the ``on_token`` callback raises, or the user presses Ctrl-C (only
+    detected on the main Python thread), in-flight streams are aborted and the
+    call returns normally with a ``RuntimeWarning``: unfinished rows come back
+    with whatever partial text had arrived and ``finished=False``. The
+    DataFrame's height and schema are always intact -- streaming never raises
+    the callback's exception or a ``KeyboardInterrupt`` out of the expression.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from polar_llama import inference_stream
+    >>>
+    >>> df = pl.DataFrame({"prompt": ["Tell me a joke", "Say hi"]})
+    >>> result = df.with_columns(
+    ...     response=inference_stream(
+    ...         pl.col("prompt"),
+    ...         on_token=lambda i, d: print(d, end=""),
+    ...     )
+    ... )
+    >>> result.select(
+    ...     pl.col("response").struct.field("text"),
+    ...     pl.col("response").struct.field("finished"),
+    ... )
+    """
+    if response_model is not None or response_format is not None:
+        raise ValueError(
+            "inference_stream is text-only: response_model is not supported; "
+            "use inference_async for structured output"
+        )
+
+    if _stream_inference_batch is None:
+        raise ImportError(
+            "_stream_inference_batch could not be imported from the polar_llama "
+            "native extension; inference_stream is unavailable. Did the build "
+            "succeed?"
+        )
+
+    expr = parse_into_expr(expr)
+
+    if provider is not None and not isinstance(provider, str):
+        provider_str = (
+            provider.as_str() if hasattr(provider, "as_str") else str(provider)
+        )
+    else:
+        provider_str = provider
+
+    def _udf(s: pl.Series) -> pl.Series:
+        texts, finished = _stream_inference_batch(
+            s.to_list(), provider_str, model, on_token, messages
+        )
+        return pl.Series(
+            s.name,
+            [
+                None if t is None else {"text": t, "finished": f}
+                for t, f in zip(texts, finished)
+            ],
+            dtype=STREAM_RESPONSE_DTYPE,
+        )
+
+    return expr.map_batches(_udf, return_dtype=STREAM_RESPONSE_DTYPE)
+
+
 def string_to_message(expr: IntoExpr, *, message_type: str) -> pl.Expr:
     """
     Convert a string to a message with the specified type.
@@ -1377,6 +1523,26 @@ class LlamaNamespace:
             response_model=response_model or response_format,
             cache=cache,
             system_prompt=system_prompt,
+        )
+
+    def inference_stream(
+        self,
+        *,
+        provider: Optional[Union[str, Provider]] = None,
+        model: Optional[str] = None,
+        on_token: Optional[Callable[[int, str], None]] = None,
+        messages: bool = False,
+    ) -> pl.Expr:
+        """
+        Stream completions token-by-token for the expression.
+        See ``polar_llama.inference_stream``.
+        """
+        return inference_stream(
+            self._expr,
+            provider=provider,
+            model=model,
+            on_token=on_token,
+            messages=messages,
         )
 
     def inference_local(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod model_client;
 pub mod ann;
 pub mod cost;
 pub mod mcp;
+mod stream_pyfn;
 
 #[cfg(target_os = "linux")]
 use jemallocator::Jemalloc;
@@ -71,6 +72,10 @@ fn polar_llama(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // Add the register_expressions function to the module
     m.add_function(wrap_pyfunction!(register_expressions, m)?)?;
+
+    // Streaming inference entry point (bypasses the polars_expr/serde kwargs
+    // boundary so it can receive a Python callback directly).
+    m.add_function(wrap_pyfunction!(stream_pyfn::_stream_inference_batch, m)?)?;
 
     Ok(())
 }

--- a/src/model_client/anthropic.rs
+++ b/src/model_client/anthropic.rs
@@ -1,8 +1,10 @@
 use serde_json::{json, Value};
 use async_trait::async_trait;
 use super::{ModelClient, ModelClientError, Message, Provider};
+use super::streaming::{self, SseFrame, StreamEvent};
 use serde::{Deserialize, Serialize};
 use reqwest::Client;
+use tokio::sync::mpsc::Sender;
 
 /// Default Anthropic model
 pub const DEFAULT_ANTHROPIC_MODEL: &str = "claude-opus-4-8";
@@ -210,8 +212,56 @@ impl ModelClient for AnthropicClient {
         let body = self.format_request_body(messages, schema, model_name);
 
         let mut request = self.apply_auth(client.post(self.api_endpoint()), &api_key);
+        request = self.apply_cache_beta_headers(request, messages);
 
-        // Prompt-caching beta header(s); extended (1h) TTL needs the extra beta.
+        let response = request.json(&body).send().await?;
+        let status = response.status();
+        let text = response.text().await?;
+        if status.is_success() {
+            self.parse_response(&text)
+        } else {
+            Err(ModelClientError::Http(status.as_u16(), text))
+        }
+    }
+
+    async fn send_request_streaming(
+        &self,
+        client: &Client,
+        messages: &[Message],
+        row: usize,
+        tx: &Sender<(usize, StreamEvent)>,
+    ) -> Result<(), ModelClientError> {
+        let api_key = self.get_api_key();
+        let mut body = self.format_request_body(messages, None, None);
+        body["stream"] = json!(true);
+
+        let mut request = self.apply_auth(client.post(self.api_endpoint()), &api_key);
+        request = self.apply_cache_beta_headers(request, messages);
+
+        let response = request.json(&body).send().await?;
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(ModelClientError::Http(status.as_u16(), text));
+        }
+
+        streaming::drive_sse_stream(response, row, tx, |frame: &SseFrame| {
+            streaming::anthropic_frame_to_event(frame)
+        })
+        .await;
+        Ok(())
+    }
+}
+
+impl AnthropicClient {
+    /// Attach the prompt-caching beta header(s) when any message carries a
+    /// `cache_control` marker; extended (1h) TTL needs the extra beta flag.
+    /// Shared by the structured and streaming request paths.
+    fn apply_cache_beta_headers(
+        &self,
+        request: reqwest::RequestBuilder,
+        messages: &[Message],
+    ) -> reqwest::RequestBuilder {
         if messages.iter().any(|msg| msg.cache_control.is_some()) {
             let needs_extended_ttl = messages.iter().any(|msg| {
                 msg.cache_control.as_ref().and_then(|cc| cc.ttl.as_deref()) == Some("1h")
@@ -221,16 +271,9 @@ impl ModelClient for AnthropicClient {
             } else {
                 "prompt-caching-2024-07-31"
             };
-            request = request.header("anthropic-beta", beta);
-        }
-
-        let response = request.json(&body).send().await?;
-        let status = response.status();
-        let text = response.text().await?;
-        if status.is_success() {
-            self.parse_response(&text)
+            request.header("anthropic-beta", beta)
         } else {
-            Err(ModelClientError::Http(status.as_u16(), text))
+            request
         }
     }
 }

--- a/src/model_client/groq.rs
+++ b/src/model_client/groq.rs
@@ -1,7 +1,10 @@
 use serde_json::{json, Value};
 use async_trait::async_trait;
 use super::{ModelClient, ModelClientError, Message, Provider};
+use super::streaming::{self, StreamEvent};
 use serde::Deserialize;
+use reqwest::Client;
+use tokio::sync::mpsc::Sender;
 
 /// Default Groq model (llama3-70b-8192 was decommissioned by Groq)
 pub const DEFAULT_GROQ_MODEL: &str = "llama-3.3-70b-versatile";
@@ -54,7 +57,9 @@ impl ModelClient for GroqClient {
     }
 
     fn api_endpoint(&self) -> String {
-        "https://api.groq.com/openai/v1/chat/completions".to_string()
+        let base = std::env::var("GROQ_BASE_URL")
+            .unwrap_or_else(|_| "https://api.groq.com".to_string());
+        format!("{}/openai/v1/chat/completions", base.trim_end_matches('/'))
     }
 
     fn model_name(&self) -> &str {
@@ -112,5 +117,16 @@ impl ModelClient for GroqClient {
             .next()
             .and_then(|choice| choice.message.content)
             .ok_or_else(|| ModelClientError::ParseError("No response content".to_string()))
+    }
+
+    async fn send_request_streaming(
+        &self,
+        client: &Client,
+        messages: &[Message],
+        row: usize,
+        tx: &Sender<(usize, StreamEvent)>,
+    ) -> Result<(), ModelClientError> {
+        // Groq is OpenAI-SSE-compatible.
+        streaming::run_openai_sse(self, client, messages, row, tx).await
     }
 }

--- a/src/model_client/mod.rs
+++ b/src/model_client/mod.rs
@@ -3,6 +3,9 @@ pub mod anthropic;
 pub mod gemini;
 pub mod groq;
 pub mod bedrock;
+pub mod streaming;
+
+pub use streaming::{StreamEvent, stream_batch};
 
 use reqwest::Client;
 use std::error::Error;
@@ -236,6 +239,23 @@ pub trait ModelClient {
             Provider::Groq => std::env::var("GROQ_API_KEY").unwrap_or_default(),
             Provider::Bedrock => String::new(), // Bedrock uses AWS credentials
         }
+    }
+
+    /// Streaming send: emits `StreamEvent`s for this row over `tx` as they
+    /// arrive. Default implementation is a buffered fallback so providers
+    /// without a native SSE override (Gemini, Bedrock) still work: it awaits
+    /// the full response and emits a single `Delta` followed by `Done`.
+    async fn send_request_streaming(
+        &self,
+        client: &Client,
+        messages: &[Message],
+        row: usize,
+        tx: &tokio::sync::mpsc::Sender<(usize, streaming::StreamEvent)>,
+    ) -> Result<(), ModelClientError> {
+        let text = self.send_request(client, messages).await?;
+        let _ = tx.send((row, streaming::StreamEvent::Delta(text))).await;
+        let _ = tx.send((row, streaming::StreamEvent::Done)).await;
+        Ok(())
     }
 }
 

--- a/src/model_client/openai.rs
+++ b/src/model_client/openai.rs
@@ -1,8 +1,10 @@
 use serde_json::{json, Value};
 use async_trait::async_trait;
 use super::{ModelClient, ModelClientError, Message, Provider, EmbeddingClient};
+use super::streaming::{self, StreamEvent};
 use serde::{Deserialize, Serialize};
 use reqwest::Client;
+use tokio::sync::mpsc::Sender;
 
 /// Default OpenAI chat model
 pub const DEFAULT_OPENAI_MODEL: &str = "gpt-4o-mini";
@@ -119,6 +121,16 @@ impl ModelClient for OpenAIClient {
             .next()
             .and_then(|choice| choice.message.content)
             .ok_or_else(|| ModelClientError::ParseError("No response content".to_string()))
+    }
+
+    async fn send_request_streaming(
+        &self,
+        client: &Client,
+        messages: &[Message],
+        row: usize,
+        tx: &Sender<(usize, StreamEvent)>,
+    ) -> Result<(), ModelClientError> {
+        streaming::run_openai_sse(self, client, messages, row, tx).await
     }
 }
 

--- a/src/model_client/streaming.rs
+++ b/src/model_client/streaming.rs
@@ -1,0 +1,547 @@
+//! Server-Sent Events (SSE) streaming support shared across providers.
+//!
+//! This module implements an incremental SSE parser, provider-specific frame
+//! decoders (OpenAI-compatible wire format and Anthropic's), and the batch
+//! fan-out driver that turns a set of message arrays into a stream of
+//! `(row, StreamEvent)` pairs delivered over a bounded mpsc channel.
+
+use super::{Message, ModelClient, ModelClientError, Provider};
+use futures::StreamExt;
+use reqwest::Client;
+use std::sync::LazyLock;
+use std::time::Duration;
+use tokio::sync::mpsc::Sender;
+
+/// A single decoded streaming event for one row.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StreamEvent {
+    /// A text delta (partial token(s)) to append to the row's accumulated text.
+    Delta(String),
+    /// The stream reached a clean terminator ("[DONE]" / `message_stop`).
+    Done,
+    /// The stream failed or was cut off; `finished` stays false for this row.
+    Error(String),
+}
+
+/// One complete SSE frame: an optional `event:` field name and the
+/// concatenated `data:` payload (multi-line `data:` fields are joined with
+/// `\n`, matching the SSE spec).
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SseFrame {
+    pub event: Option<String>,
+    pub data: String,
+}
+
+/// Incremental SSE parser: buffers partial lines across network chunks and
+/// yields complete (blank-line terminated) frames.
+pub struct SseParser {
+    buf: String,
+}
+
+impl Default for SseParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SseParser {
+    pub fn new() -> Self {
+        Self { buf: String::new() }
+    }
+
+    /// Feed raw bytes (possibly a partial line, possibly several frames);
+    /// returns every complete frame contained in the accumulated buffer.
+    /// Handles LF and CRLF line endings, multi-line `data:` fields, `event:`
+    /// fields, and `:`-prefixed comment lines (ignored).
+    pub fn feed(&mut self, chunk: &[u8]) -> Vec<SseFrame> {
+        // Lossy is fine here: SSE payloads are expected to be valid UTF-8;
+        // any stray invalid bytes degrade gracefully instead of panicking.
+        self.buf.push_str(&String::from_utf8_lossy(chunk));
+        // Normalize CRLF to LF so frame-boundary detection only has to look
+        // for a single pattern ("\n\n"). Re-running this over the whole
+        // (small, since we drain consumed frames below) buffer on every feed
+        // is simpler and safer than trying to track a split "\r" across
+        // chunk boundaries.
+        if self.buf.contains('\r') {
+            self.buf = self.buf.replace("\r\n", "\n");
+        }
+
+        let mut frames = Vec::new();
+        // A frame ends at a blank line ("\n\n"). Process as many complete
+        // frames as are currently buffered.
+        while let Some(pos) = self.buf.find("\n\n") {
+            let raw_frame = self.buf[..pos].to_string();
+            self.buf.drain(..pos + 2);
+            if let Some(frame) = parse_frame(&raw_frame) {
+                frames.push(frame);
+            }
+        }
+
+        frames
+    }
+}
+
+/// Parse one raw frame (lines joined by `\n` or `\r\n`, no trailing blank
+/// line) into an `SseFrame`. Lines starting with `:` are comments and
+/// skipped. Unknown fields are ignored per the SSE spec.
+fn parse_frame(raw: &str) -> Option<SseFrame> {
+    let mut event: Option<String> = None;
+    let mut data_lines: Vec<&str> = Vec::new();
+
+    for line in raw.split('\n') {
+        let line = line.strip_suffix('\r').unwrap_or(line);
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix(':') {
+            let _ = rest; // comment line, ignored
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("event:") {
+            event = Some(rest.trim_start().to_string());
+        } else if let Some(rest) = line.strip_prefix("data:") {
+            data_lines.push(rest.strip_prefix(' ').unwrap_or(rest));
+        }
+        // Other fields (id:, retry:) are ignored; we don't need them.
+    }
+
+    if event.is_none() && data_lines.is_empty() {
+        return None;
+    }
+
+    Some(SseFrame {
+        event,
+        data: data_lines.join("\n"),
+    })
+}
+
+/// OpenAI-wire-format frame -> event. Shared by OpenAI and Groq (Groq is
+/// OpenAI-SSE-compatible).
+///
+/// - `data: [DONE]` -> `Done`
+/// - JSON with a top-level `error` object -> `Error`
+/// - `choices[0].delta.content` present and non-empty -> `Delta`
+/// - otherwise (e.g. a role-only delta, or an empty content chunk) -> `None`
+///   (skip; not every frame carries text)
+pub fn openai_frame_to_event(frame: &SseFrame) -> Option<StreamEvent> {
+    let data = frame.data.trim();
+    if data.is_empty() {
+        return None;
+    }
+    if data == "[DONE]" {
+        return Some(StreamEvent::Done);
+    }
+
+    let value: serde_json::Value = match serde_json::from_str(data) {
+        Ok(v) => v,
+        Err(_) => return None,
+    };
+
+    if let Some(error) = value.get("error") {
+        let message = error
+            .get("message")
+            .and_then(|m| m.as_str())
+            .unwrap_or("unknown error")
+            .to_string();
+        return Some(StreamEvent::Error(message));
+    }
+
+    let content = value
+        .get("choices")
+        .and_then(|c| c.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|choice| choice.get("delta"))
+        .and_then(|delta| delta.get("content"))
+        .and_then(|c| c.as_str());
+
+    match content {
+        Some(text) if !text.is_empty() => Some(StreamEvent::Delta(text.to_string())),
+        _ => None,
+    }
+}
+
+/// Anthropic frame -> event, keyed on the `event:` field (falling back to
+/// `data.type` if `event:` is absent, which some proxies/mocks omit).
+///
+/// - `content_block_delta` with `delta.type == "text_delta"` -> `Delta(delta.text)`
+/// - `message_stop` -> `Done`
+/// - `error` -> `Error(error.message)`
+/// - `ping` / `message_start` / `message_delta` / `content_block_start` /
+///   `content_block_stop` -> `None` (ignored)
+pub fn anthropic_frame_to_event(frame: &SseFrame) -> Option<StreamEvent> {
+    let data = frame.data.trim();
+    if data.is_empty() {
+        return None;
+    }
+    let value: serde_json::Value = serde_json::from_str(data).ok()?;
+    let event_type = frame
+        .event
+        .clone()
+        .or_else(|| value.get("type").and_then(|t| t.as_str()).map(String::from))?;
+
+    match event_type.as_str() {
+        "content_block_delta" => {
+            let delta = value.get("delta")?;
+            if delta.get("type").and_then(|t| t.as_str()) == Some("text_delta") {
+                let text = delta.get("text").and_then(|t| t.as_str()).unwrap_or("");
+                if text.is_empty() {
+                    None
+                } else {
+                    Some(StreamEvent::Delta(text.to_string()))
+                }
+            } else {
+                None
+            }
+        }
+        "message_stop" => Some(StreamEvent::Done),
+        "error" => {
+            let message = value
+                .get("error")
+                .and_then(|e| e.get("message"))
+                .and_then(|m| m.as_str())
+                .unwrap_or("unknown error")
+                .to_string();
+            Some(StreamEvent::Error(message))
+        }
+        "ping" | "message_start" | "message_delta" | "content_block_start"
+        | "content_block_stop" => None,
+        _ => None,
+    }
+}
+
+/// Streaming-dedicated HTTP client: same builder as the default shared
+/// client, but WITHOUT a total request timeout (reqwest's `.timeout()` covers
+/// the whole body read, which would kill any stream longer than the limit).
+/// `connect_timeout` bounds the initial connection; `read_timeout` bounds the
+/// gap *between* body chunks, so a server that returns 200 headers and then
+/// goes silent forever fails with a timeout instead of hanging the whole
+/// `collect()` (which the pump could otherwise only escape via Ctrl-C). A
+/// legitimately slow-but-progressing stream keeps resetting the per-read
+/// clock, so a generous 120s window never truncates real output.
+static STREAM_HTTP_CLIENT: LazyLock<Client> = LazyLock::new(|| {
+    Client::builder()
+        .connect_timeout(Duration::from_secs(30))
+        .read_timeout(Duration::from_secs(120))
+        .build()
+        .unwrap_or_else(|_| Client::new())
+});
+
+/// Access the shared streaming HTTP client (no total timeout).
+pub fn stream_http_client() -> &'static Client {
+    &STREAM_HTTP_CLIENT
+}
+
+/// Shared driver for any OpenAI-SSE-compatible provider (OpenAI, Groq): sends
+/// a streaming chat completion request and forwards decoded events to `tx`.
+///
+/// Frame emission stops after `Done`/`Error`. EOF without a terminator frame
+/// is reported as an `Error`. A transport error while reading the body is
+/// also reported as an `Error`. `tx.send` failures (receiver dropped, e.g.
+/// after abort) are ignored -- the pump may have already stopped listening.
+pub async fn run_openai_sse<T: ModelClient + Sync + ?Sized>(
+    model_client: &T,
+    http: &Client,
+    messages: &[Message],
+    row: usize,
+    tx: &Sender<(usize, StreamEvent)>,
+) -> Result<(), ModelClientError> {
+    let mut body = model_client.format_request_body(messages, None, None);
+    body["stream"] = serde_json::json!(true);
+
+    let api_key = model_client.get_api_key();
+    let request = model_client.apply_auth(http.post(model_client.api_endpoint()), &api_key);
+
+    let response = request.json(&body).send().await?;
+    let status = response.status();
+    if !status.is_success() {
+        let text = response.text().await.unwrap_or_default();
+        return Err(ModelClientError::Http(status.as_u16(), text));
+    }
+
+    drive_sse_stream(response, row, tx, openai_frame_to_event).await;
+    Ok(())
+}
+
+/// Shared byte-stream -> frame -> event pump used by both provider drivers.
+/// Stops forwarding events once `Done`/`Error` has been seen (but keeps
+/// draining nothing further -- the function simply returns), and synthesizes
+/// an `Error` if the stream ends (EOF or transport error) without ever
+/// emitting a terminator.
+pub(crate) async fn drive_sse_stream<F>(
+    response: reqwest::Response,
+    row: usize,
+    tx: &Sender<(usize, StreamEvent)>,
+    frame_to_event: F,
+) where
+    F: Fn(&SseFrame) -> Option<StreamEvent>,
+{
+    let mut parser = SseParser::new();
+    let mut byte_stream = response.bytes_stream();
+    let mut terminated = false;
+
+    while let Some(item) = byte_stream.next().await {
+        match item {
+            Ok(bytes) => {
+                for frame in parser.feed(&bytes) {
+                    if let Some(event) = frame_to_event(&frame) {
+                        let is_terminal = matches!(event, StreamEvent::Done | StreamEvent::Error(_));
+                        let _ = tx.send((row, event)).await;
+                        if is_terminal {
+                            terminated = true;
+                            break;
+                        }
+                    }
+                }
+                if terminated {
+                    break;
+                }
+            }
+            Err(e) => {
+                let _ = tx.send((row, StreamEvent::Error(e.to_string()))).await;
+                terminated = true;
+                break;
+            }
+        }
+    }
+
+    if !terminated {
+        let _ = tx
+            .send((
+                row,
+                StreamEvent::Error("stream ended without completion marker".to_string()),
+            ))
+            .await;
+    }
+}
+
+/// Batch fan-out mirroring `run_batch`: each row drives
+/// `send_request_streaming` concurrently, bounded by `max_concurrency`. A
+/// row-level `Err` becomes an `Error` event for that row. All `tx` clones
+/// drop once every row's future completes, closing the channel -- this is
+/// the pump's termination signal.
+pub async fn stream_batch(
+    provider: Provider,
+    model: String,
+    message_arrays: Vec<(usize, Vec<Message>)>,
+    tx: Sender<(usize, StreamEvent)>,
+) {
+    let client = super::create_client(provider, &model);
+    let http = stream_http_client().clone();
+
+    let futures_iter = message_arrays.into_iter().map(|(row, messages)| {
+        let client = &client;
+        let http = &http;
+        let tx = tx.clone();
+        async move {
+            if let Err(e) = client.send_request_streaming(http, &messages, row, &tx).await {
+                let _ = tx.send((row, StreamEvent::Error(e.to_string()))).await;
+            }
+        }
+    });
+
+    futures::stream::iter(futures_iter)
+        .buffered(super::max_concurrency())
+        .collect::<Vec<()>>()
+        .await;
+    // `tx` (the original passed-in sender) and every per-row clone above are
+    // dropped here, closing the channel so the pump's `recv()` returns `None`.
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ------------------------------------------------------------------
+    // R1: SSE parser reassembles frames split across `feed()` calls.
+    // ------------------------------------------------------------------
+    #[test]
+    fn sse_parser_reassembles_split_frames() {
+        let mut parser = SseParser::new();
+        let full = b"event: content_block_delta\ndata: {\"a\":1}\n\n";
+
+        let mut frames = Vec::new();
+        for byte in full {
+            frames.extend(parser.feed(&[*byte]));
+        }
+
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].event.as_deref(), Some("content_block_delta"));
+        assert_eq!(frames[0].data, "{\"a\":1}");
+
+        // Chunk boundary mid `data:` line.
+        let mut parser2 = SseParser::new();
+        let mut frames2 = parser2.feed(b"data: {\"choi");
+        assert!(frames2.is_empty());
+        frames2.extend(parser2.feed(b"ces\":[]}\n\n"));
+        assert_eq!(frames2.len(), 1);
+        assert_eq!(frames2[0].data, "{\"choices\":[]}");
+    }
+
+    // ------------------------------------------------------------------
+    // R2: CRLF line endings, multi-line data, and comment lines.
+    // ------------------------------------------------------------------
+    #[test]
+    fn sse_parser_crlf_and_multiline_data_and_comments() {
+        let mut parser = SseParser::new();
+        let raw = b": this is a comment\r\nevent: message_stop\r\ndata: line1\r\ndata: line2\r\n\r\n";
+        let frames = parser.feed(raw);
+
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].event.as_deref(), Some("message_stop"));
+        assert_eq!(frames[0].data, "line1\nline2");
+
+        // A pure comment-only frame yields no SseFrame at all (no event, no data).
+        let mut parser2 = SseParser::new();
+        let frames2 = parser2.feed(b": keep-alive\n\n");
+        assert!(frames2.is_empty());
+    }
+
+    // ------------------------------------------------------------------
+    // R3: OpenAI frame decoding: delta, [DONE], error, empty/absent delta.
+    // ------------------------------------------------------------------
+    #[test]
+    fn openai_frame_to_event_delta_done_error() {
+        let delta_frame = SseFrame {
+            event: None,
+            data: r#"{"choices":[{"delta":{"content":"Hello"}}]}"#.to_string(),
+        };
+        assert_eq!(
+            openai_frame_to_event(&delta_frame),
+            Some(StreamEvent::Delta("Hello".to_string()))
+        );
+
+        let done_frame = SseFrame {
+            event: None,
+            data: "[DONE]".to_string(),
+        };
+        assert_eq!(openai_frame_to_event(&done_frame), Some(StreamEvent::Done));
+
+        let error_frame = SseFrame {
+            event: None,
+            data: r#"{"error":{"message":"rate limited"}}"#.to_string(),
+        };
+        assert_eq!(
+            openai_frame_to_event(&error_frame),
+            Some(StreamEvent::Error("rate limited".to_string()))
+        );
+
+        // Empty content -> skip.
+        let empty_frame = SseFrame {
+            event: None,
+            data: r#"{"choices":[{"delta":{"content":""}}]}"#.to_string(),
+        };
+        assert_eq!(openai_frame_to_event(&empty_frame), None);
+
+        // Absent delta content (e.g. role-only first chunk) -> skip.
+        let role_only_frame = SseFrame {
+            event: None,
+            data: r#"{"choices":[{"delta":{"role":"assistant"}}]}"#.to_string(),
+        };
+        assert_eq!(openai_frame_to_event(&role_only_frame), None);
+    }
+
+    // ------------------------------------------------------------------
+    // R4: Anthropic frame decoding: text_delta, message_stop, error, ignored types.
+    // ------------------------------------------------------------------
+    #[test]
+    fn anthropic_frame_to_event_all_types() {
+        let text_delta_frame = SseFrame {
+            event: Some("content_block_delta".to_string()),
+            data: r#"{"type":"content_block_delta","delta":{"type":"text_delta","text":"Hi"}}"#
+                .to_string(),
+        };
+        assert_eq!(
+            anthropic_frame_to_event(&text_delta_frame),
+            Some(StreamEvent::Delta("Hi".to_string()))
+        );
+
+        let stop_frame = SseFrame {
+            event: Some("message_stop".to_string()),
+            data: r#"{"type":"message_stop"}"#.to_string(),
+        };
+        assert_eq!(anthropic_frame_to_event(&stop_frame), Some(StreamEvent::Done));
+
+        let error_frame = SseFrame {
+            event: Some("error".to_string()),
+            data: r#"{"type":"error","error":{"message":"overloaded"}}"#.to_string(),
+        };
+        assert_eq!(
+            anthropic_frame_to_event(&error_frame),
+            Some(StreamEvent::Error("overloaded".to_string()))
+        );
+
+        for ignored in ["ping", "message_start", "message_delta", "content_block_start", "content_block_stop"] {
+            let frame = SseFrame {
+                event: Some(ignored.to_string()),
+                data: format!(r#"{{"type":"{ignored}"}}"#),
+            };
+            assert_eq!(anthropic_frame_to_event(&frame), None, "expected {ignored} to be ignored");
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // R5: default streaming fallback (trait default method) emits exactly
+    // [Delta("hello"), Done] for a dummy ModelClient with zero network.
+    // ------------------------------------------------------------------
+    struct DummyClient;
+
+    #[async_trait::async_trait]
+    impl ModelClient for DummyClient {
+        fn provider(&self) -> Provider {
+            Provider::Gemini
+        }
+        fn api_endpoint(&self) -> String {
+            "http://unused.invalid".to_string()
+        }
+        fn model_name(&self) -> &str {
+            "dummy-model"
+        }
+        fn format_messages(&self, _messages: &[Message]) -> serde_json::Value {
+            serde_json::json!([])
+        }
+        fn parse_response(&self, _response_text: &str) -> Result<String, ModelClientError> {
+            Ok(String::new())
+        }
+        async fn send_request(
+            &self,
+            _client: &Client,
+            _messages: &[Message],
+        ) -> Result<String, ModelClientError> {
+            Ok("hello".to_string())
+        }
+    }
+
+    #[test]
+    fn default_streaming_fallback_emits_delta_then_done() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let (tx, mut rx) = tokio::sync::mpsc::channel::<(usize, StreamEvent)>(8);
+            let client = DummyClient;
+            let http = Client::new();
+            let messages = vec![Message {
+                role: "user".to_string(),
+                content: "hi".to_string(),
+                cache_control: None,
+            }];
+
+            client
+                .send_request_streaming(&http, &messages, 0, &tx)
+                .await
+                .unwrap();
+            drop(tx);
+
+            let mut events = Vec::new();
+            while let Some(evt) = rx.recv().await {
+                events.push(evt);
+            }
+
+            assert_eq!(
+                events,
+                vec![
+                    (0, StreamEvent::Delta("hello".to_string())),
+                    (0, StreamEvent::Done),
+                ]
+            );
+        });
+    }
+}

--- a/src/stream_pyfn.rs
+++ b/src/stream_pyfn.rs
@@ -1,0 +1,220 @@
+//! The Python-facing entry point for `inference_stream`: a `#[pyfunction]`
+//! (not a `polars_expr` plugin) because it needs to receive a real Python
+//! callable (`on_token`) as a `PyObject` -- kwargs routed through the
+//! `polars_expr` plugin boundary are serde-deserialized and cannot carry a
+//! Python callback.
+//!
+//! See `src/model_client/streaming.rs` for the SSE parsing / provider fan-out
+//! machinery this drives.
+
+use crate::model_client::{self, streaming, Message, Provider, StreamEvent};
+use crate::utils::RT;
+use pyo3::exceptions::PyRuntimeWarning;
+use pyo3::prelude::*;
+use std::str::FromStr;
+use tokio::task::JoinHandle;
+
+fn get_default_model(provider: Provider) -> &'static str {
+    match provider {
+        Provider::OpenAI => model_client::openai::DEFAULT_OPENAI_MODEL,
+        Provider::Anthropic => model_client::anthropic::DEFAULT_ANTHROPIC_MODEL,
+        Provider::Gemini => model_client::gemini::DEFAULT_GEMINI_MODEL,
+        Provider::Groq => model_client::groq::DEFAULT_GROQ_MODEL,
+        Provider::Bedrock => model_client::bedrock::DEFAULT_BEDROCK_MODEL,
+    }
+}
+
+/// Per-row output: parallel `(text, finished)` vectors, one entry per input
+/// row (`None` for a null input row in both).
+type StreamBatchResult = (Vec<Option<String>>, Vec<Option<bool>>);
+
+/// Resolve the provider/model pair exactly like
+/// `expressions::resolve_provider_and_model`, but from raw `Option<&str>`
+/// arguments instead of a deserialized kwargs struct (this entry point takes
+/// its arguments directly as pyfunction parameters, not via the plugin/serde
+/// boundary).
+fn resolve_provider_and_model(provider: Option<&str>, model: Option<&str>) -> (Provider, String) {
+    let provider = provider
+        .and_then(|s| Provider::from_str(s).ok())
+        .unwrap_or(Provider::OpenAI);
+    let model = model
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| get_default_model(provider).to_string());
+    (provider, model)
+}
+
+/// Batch entry point for `inference_stream`. Returns `(text, finished)`
+/// vectors, one entry per input row (`None`/`None` for a null input row).
+///
+/// See `polar_llama/__init__.py::inference_stream` for the Python-facing
+/// wrapper and `docs/design` / the module docstring there for the full
+/// streaming contract (struct dtype, cancellation semantics, etc).
+#[pyfunction]
+#[pyo3(signature = (inputs, provider=None, model=None, callback=None, messages=false))]
+pub fn _stream_inference_batch(
+    py: Python<'_>,
+    inputs: Vec<Option<String>>,
+    provider: Option<&str>,
+    model: Option<&str>,
+    callback: Option<Py<PyAny>>,
+    messages: bool,
+) -> PyResult<StreamBatchResult> {
+    let (provider, model) = resolve_provider_and_model(provider, model);
+    let n_rows = inputs.len();
+
+    // Build (orig_idx, Vec<Message>) pairs for non-null rows. `messages=true`
+    // rows are JSON message arrays parsed via parse_message_json; a parse
+    // failure yields an immediately-resolved row (empty text, unfinished)
+    // rather than failing the whole batch.
+    let mut active: Vec<(usize, Vec<Message>)> = Vec::new();
+    // Rows resolved before any network call happens at all (null input, or a
+    // messages-parse failure): (orig_idx, text, finished).
+    let mut precomputed: Vec<(usize, String, bool)> = Vec::new();
+    let mut parse_notice: Option<String> = None;
+
+    for (idx, opt_value) in inputs.into_iter().enumerate() {
+        match opt_value {
+            None => {
+                // Null input row -> null struct row; tracked implicitly by
+                // being absent from both `active` and `precomputed` and
+                // defaulting to None at scatter time.
+            }
+            Some(value) => {
+                if messages {
+                    match crate::utils::parse_message_json(&value) {
+                        Ok(msgs) => active.push((idx, msgs)),
+                        Err(e) => {
+                            precomputed.push((idx, String::new(), false));
+                            parse_notice.get_or_insert_with(|| {
+                                format!("row {idx}: failed to parse message JSON: {e}")
+                            });
+                        }
+                    }
+                } else {
+                    active.push((
+                        idx,
+                        vec![Message {
+                            role: "user".to_string(),
+                            content: value,
+                            cache_control: None,
+                        }],
+                    ));
+                }
+            }
+        }
+    }
+
+    // Map original row index -> position in the active-rows accumulator
+    // arrays, since a stream event's `row` field is the original index.
+    let n_active = active.len();
+    let mut orig_idx_of: Vec<usize> = Vec::with_capacity(n_active);
+    for (orig_idx, _) in &active {
+        orig_idx_of.push(*orig_idx);
+    }
+    let mut pos_of_orig: std::collections::HashMap<usize, usize> =
+        std::collections::HashMap::with_capacity(n_active);
+    for (pos, orig_idx) in orig_idx_of.iter().enumerate() {
+        pos_of_orig.insert(*orig_idx, pos);
+    }
+
+    let mut acc: Vec<String> = vec![String::new(); n_active];
+    let mut finished: Vec<bool> = vec![false; n_active];
+    let mut notice: Option<String> = parse_notice;
+
+    if n_active > 0 {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<(usize, StreamEvent)>(256);
+        let handle: JoinHandle<()> = RT.spawn(streaming::stream_batch(provider, model, active, tx));
+
+        // Pump loop on the calling (Python/Polars) thread. This is the only
+        // blocking point, and it runs ONLY inside `py.detach` (the current,
+        // non-deprecated name for what used to be `allow_threads`): a
+        // Python-side stall can therefore never wedge a tokio worker that is
+        // blocked on sending into the bounded channel while this thread holds
+        // the GIL, because the GIL is not held during the wait. The callback
+        // below runs only after the GIL is reacquired, i.e. only on this
+        // (the calling) thread, never from a tokio worker.
+        loop {
+            // Wake at least every 100ms even when no event arrives, so a
+            // pending signal (Ctrl-C) is serviced promptly during a silent
+            // post-connect stall -- not only when the next delta happens to
+            // land. `blocking_recv()` alone would park indefinitely with the
+            // GIL released, leaving check_signals() unreachable until traffic
+            // resumed. RT.block_on runs on this (the calling) thread, which is
+            // never a tokio worker, so it cannot deadlock the runtime.
+            let recv = py.detach(|| {
+                RT.block_on(async {
+                    tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv()).await
+                })
+            });
+
+            // Service Ctrl-C on every wake, whether or not an event arrived.
+            if let Err(_sig) = py.check_signals() {
+                // Ctrl-C (or another pending signal-raised exception). Per the
+                // owner ruling this becomes a partial-with-notice result, not
+                // a raised exception: consume it, don't propagate it.
+                notice = Some("interrupted by user (KeyboardInterrupt)".to_string());
+                handle.abort();
+                break;
+            }
+
+            let (row, evt) = match recv {
+                Err(_elapsed) => continue, // 100ms tick, no event: re-check signals
+                Ok(None) => break,         // channel closed = batch done
+                Ok(Some(item)) => item,
+            };
+            let Some(&pos) = pos_of_orig.get(&row) else {
+                // Defensive: an event for a row we didn't schedule. Should be
+                // unreachable, but never let it panic the pump.
+                continue;
+            };
+
+            match evt {
+                StreamEvent::Delta(delta) => {
+                    acc[pos].push_str(&delta);
+                    if let Some(cb) = &callback {
+                        if let Err(e) = cb.call1(py, (row, delta.as_str())) {
+                            notice = Some(format!("on_token callback raised: {e}"));
+                            handle.abort();
+                            break;
+                        }
+                    }
+                }
+                StreamEvent::Done => finished[pos] = true,
+                StreamEvent::Error(msg) => {
+                    // finished stays false for this row.
+                    notice.get_or_insert_with(|| format!("row {row} stream error: {msg}"));
+                }
+            }
+        }
+        drop(rx); // after abort: any sender still alive fails silently (`let _ = send`)
+    }
+
+    if let Some(notice_msg) = notice {
+        let message = format!(
+            "inference_stream: {notice_msg}; unfinished rows returned with finished=false"
+        );
+        // CString::new can fail only on embedded NUL bytes; message is our
+        // own formatted text so this is not expected, but degrade instead of
+        // panicking if it ever happens.
+        if let Ok(c_message) = std::ffi::CString::new(message) {
+            let category = py.get_type::<PyRuntimeWarning>();
+            let _ = PyErr::warn(py, category.as_any(), &c_message, 1);
+        }
+    }
+
+    // Scatter results back to original indices; null inputs and rows never
+    // scheduled (shouldn't happen beyond null/parse-failure) -> (None, None).
+    let mut out_text: Vec<Option<String>> = vec![None; n_rows];
+    let mut out_finished: Vec<Option<bool>> = vec![None; n_rows];
+
+    for (pos, orig_idx) in orig_idx_of.into_iter().enumerate() {
+        out_text[orig_idx] = Some(std::mem::take(&mut acc[pos]));
+        out_finished[orig_idx] = Some(finished[pos]);
+    }
+    for (orig_idx, text, is_finished) in precomputed {
+        out_text[orig_idx] = Some(text);
+        out_finished[orig_idx] = Some(is_finished);
+    }
+
+    Ok((out_text, out_finished))
+}

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""
+Test suite for `inference_stream` (issue #74).
+
+The bulk of these tests run against a local stdlib mock SSE server (no
+network, no API keys, no mlx) so they run in CI. A couple of gated real-API
+smoke tests at the bottom are skipped unless the relevant API key is set,
+mirroring the pattern in tests/test_embeddings.py.
+"""
+
+import json
+import os
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import polars as pl
+import pytest
+
+from polar_llama import STREAM_RESPONSE_DTYPE, inference_stream
+
+
+# ============================================================================
+# Mock SSE server
+# ============================================================================
+
+
+def _sleep(seconds: float):
+    """A script entry that makes the mock server pause before continuing."""
+    return ("__sleep__", seconds)
+
+
+def openai_delta(text: str) -> bytes:
+    return (
+        "data: " + json.dumps({"choices": [{"delta": {"content": text}}]}) + "\n\n"
+    ).encode()
+
+
+def openai_done() -> bytes:
+    return b"data: [DONE]\n\n"
+
+
+def openai_error(message: str) -> bytes:
+    return ("data: " + json.dumps({"error": {"message": message}}) + "\n\n").encode()
+
+
+def anthropic_delta(text: str) -> bytes:
+    payload = {
+        "type": "content_block_delta",
+        "delta": {"type": "text_delta", "text": text},
+    }
+    return f"event: content_block_delta\ndata: {json.dumps(payload)}\n\n".encode()
+
+
+def anthropic_stop() -> bytes:
+    return b'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+
+
+def anthropic_error(message: str) -> bytes:
+    payload = {"type": "error", "error": {"message": message}}
+    return f"event: error\ndata: {json.dumps(payload)}\n\n".encode()
+
+
+class _SSEHandler(BaseHTTPRequestHandler):
+    """Streams a scripted sequence of raw SSE bytes, chosen by the content of
+    the request's last message. Deliberately left on HTTP/1.0 (the
+    BaseHTTPRequestHandler default): with no Content-Length header, the
+    client reads the body until the connection closes -- which is exactly the
+    "EOF without a terminator frame" case some tests need, and requires no
+    chunked-encoding bookkeeping for the rest.
+    """
+
+    def log_message(self, format, *args):  # noqa: A002 - silence request logging
+        pass
+
+    def _script_key(self, payload: dict):
+        messages = payload.get("messages") or []
+        if messages:
+            return messages[-1].get("content")
+        return None
+
+    def do_POST(self):  # noqa: N802 - http.server naming convention
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        body = self.rfile.read(length) if length else b""
+        try:
+            payload = json.loads(body) if body else {}
+        except json.JSONDecodeError:
+            payload = {}
+
+        key = self._script_key(payload)
+        script = self.server.scripts.get(
+            key, self.server.scripts.get("__default__", [])
+        )
+
+        try:
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.end_headers()
+            for item in script:
+                if isinstance(item, tuple) and item and item[0] == "__sleep__":
+                    time.sleep(item[1])
+                    continue
+                self.wfile.write(item)
+                self.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            # Client aborted the stream (e.g. cancellation test) -- expected.
+            return
+
+
+@pytest.fixture
+def sse_server():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _SSEHandler)
+    server.daemon_threads = True
+    server.scripts = {}
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base_url = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        yield server, base_url
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+@pytest.fixture(autouse=True)
+def _dummy_keys(monkeypatch):
+    # Every provider path reads its key via std env lookup; the mock server
+    # doesn't check auth, but set dummy values so nothing falls through to a
+    # real, unset-key code path.
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+
+
+# ============================================================================
+# P1: multi-chunk assembly (OpenAI)
+# ============================================================================
+
+
+def test_multi_chunk_assembly_openai(sse_server, monkeypatch):
+    server, base_url = sse_server
+    server.scripts["Hello"] = [
+        openai_delta("Hello"),
+        openai_delta(" world"),
+        openai_delta("!"),
+        openai_done(),
+    ]
+    monkeypatch.setenv("OPENAI_BASE_URL", base_url)
+
+    df = pl.DataFrame({"prompt": ["Hello"]})
+    result = df.with_columns(
+        response=inference_stream(pl.col("prompt"), provider="openai")
+    )
+
+    assert result["response"].dtype == STREAM_RESPONSE_DTYPE
+    row = result["response"][0]
+    assert row == {"text": "Hello world!", "finished": True}
+
+
+# ============================================================================
+# P2: Anthropic message_stop terminator
+# ============================================================================
+
+
+def test_anthropic_stream_message_stop(sse_server, monkeypatch):
+    server, base_url = sse_server
+    server.scripts["Hi there"] = [
+        anthropic_delta("Hi "),
+        anthropic_delta("there!"),
+        anthropic_stop(),
+    ]
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", base_url)
+
+    df = pl.DataFrame({"prompt": ["Hi there"]})
+    result = df.with_columns(
+        response=inference_stream(pl.col("prompt"), provider="anthropic")
+    )
+
+    row = result["response"][0]
+    assert row == {"text": "Hi there!", "finished": True}
+
+
+# ============================================================================
+# P3: Groq reuses the OpenAI SSE decoder via GROQ_BASE_URL
+# ============================================================================
+
+
+def test_groq_reuses_openai_sse(sse_server, monkeypatch):
+    server, base_url = sse_server
+    server.scripts["yo"] = [
+        openai_delta("yo"),
+        openai_delta("!"),
+        openai_done(),
+    ]
+    monkeypatch.setenv("GROQ_BASE_URL", base_url)
+
+    df = pl.DataFrame({"prompt": ["yo"]})
+    result = df.with_columns(
+        response=inference_stream(pl.col("prompt"), provider="groq")
+    )
+
+    row = result["response"][0]
+    assert row == {"text": "yo!", "finished": True}
+
+
+# ============================================================================
+# P4: mid-stream provider error event
+# ============================================================================
+
+
+def test_mid_stream_error_event(sse_server, monkeypatch):
+    server, base_url = sse_server
+    server.scripts["oops"] = [
+        openai_delta("partial"),
+        openai_error("rate limited"),
+    ]
+    monkeypatch.setenv("OPENAI_BASE_URL", base_url)
+
+    df = pl.DataFrame({"prompt": ["oops"]})
+    with pytest.warns(RuntimeWarning):
+        result = df.with_columns(
+            response=inference_stream(pl.col("prompt"), provider="openai")
+        )
+
+    row = result["response"][0]
+    assert row["text"] == "partial"
+    assert row["finished"] is False
+
+
+# ============================================================================
+# P5: EOF without a completion marker
+# ============================================================================
+
+
+def test_eof_without_done(sse_server, monkeypatch):
+    server, base_url = sse_server
+    server.scripts["cutoff"] = [openai_delta("partial")]
+    monkeypatch.setenv("OPENAI_BASE_URL", base_url)
+
+    df = pl.DataFrame({"prompt": ["cutoff"]})
+    with pytest.warns(RuntimeWarning):
+        result = df.with_columns(
+            response=inference_stream(pl.col("prompt"), provider="openai")
+        )
+
+    row = result["response"][0]
+    assert row["text"] == "partial"
+    assert row["finished"] is False
+
+
+# ============================================================================
+# P6: on_token callback ordering per row
+# ============================================================================
+
+
+def test_on_token_callback_order(sse_server, monkeypatch):
+    server, base_url = sse_server
+    server.scripts["abc"] = [
+        openai_delta("a"),
+        openai_delta("b"),
+        openai_delta("c"),
+        openai_done(),
+    ]
+    monkeypatch.setenv("OPENAI_BASE_URL", base_url)
+
+    seen = []
+
+    def on_token(row_index, delta):
+        seen.append((row_index, delta))
+
+    df = pl.DataFrame({"prompt": ["abc"]})
+    result = df.with_columns(
+        response=inference_stream(
+            pl.col("prompt"), provider="openai", on_token=on_token
+        )
+    )
+
+    row_deltas = [d for (r, d) in seen if r == 0]
+    assert row_deltas == ["a", "b", "c"]
+    assert "".join(row_deltas) == result["response"][0]["text"]
+
+
+# ============================================================================
+# P7: callback raise cancels the batch, keeps partials, finished=False
+# ============================================================================
+
+
+def test_callback_raise_cancels_keeps_partial(sse_server, monkeypatch):
+    server, base_url = sse_server
+    server.scripts["fast"] = [
+        openai_delta("A1"),
+        openai_delta("A2"),
+        openai_delta("A3"),
+        openai_done(),
+    ]
+    server.scripts["slow"] = [
+        _sleep(0.4),
+        openai_delta("late"),
+        openai_done(),
+    ]
+    monkeypatch.setenv("OPENAI_BASE_URL", base_url)
+
+    calls = []
+
+    def on_token(row_index, delta):
+        calls.append((row_index, delta))
+        if len(calls) == 2:
+            raise RuntimeError("boom from callback")
+
+    df = pl.DataFrame({"prompt": ["fast", "slow"]})
+    with pytest.warns(RuntimeWarning):
+        result = df.with_columns(
+            response=inference_stream(
+                pl.col("prompt"), provider="openai", on_token=on_token
+            )
+        )
+
+    # DataFrame stays rectangular and intact.
+    assert result.height == 2
+    assert result["response"].dtype == STREAM_RESPONSE_DTYPE
+
+    fast_row = result.filter(pl.col("prompt") == "fast")["response"][0]
+    slow_row = result.filter(pl.col("prompt") == "slow")["response"][0]
+
+    # Exactly the two deltas processed before the raise made it into the
+    # accumulated text; the stream was cancelled before completion.
+    assert fast_row["text"] == "A1A2"
+    assert fast_row["finished"] is False
+
+    # The "slow" row was still sleeping server-side when the batch was
+    # aborted, so it never got any content.
+    assert slow_row["text"] == ""
+    assert slow_row["finished"] is False
+
+
+# ============================================================================
+# P8: null input rows pass through as null struct rows
+# ============================================================================
+
+
+def test_null_rows_pass_through(sse_server, monkeypatch):
+    server, base_url = sse_server
+    server.scripts["present"] = [openai_delta("ok"), openai_done()]
+    monkeypatch.setenv("OPENAI_BASE_URL", base_url)
+
+    df = pl.DataFrame({"prompt": ["present", None]})
+    result = df.with_columns(
+        response=inference_stream(pl.col("prompt"), provider="openai")
+    )
+
+    assert result["response"][0] == {"text": "ok", "finished": True}
+    assert result["response"][1] is None
+
+
+# ============================================================================
+# P9: response_model / response_format rejected
+# ============================================================================
+
+
+def test_response_model_rejected():
+    df = pl.DataFrame({"prompt": ["hi"]})
+    with pytest.raises(ValueError):
+        df.with_columns(
+            response=inference_stream(
+                pl.col("prompt"), provider="openai", response_model=object
+            )
+        )
+    with pytest.raises(ValueError):
+        df.with_columns(
+            response=inference_stream(
+                pl.col("prompt"), provider="openai", response_format=object
+            )
+        )
+
+
+# ============================================================================
+# P10: multi-row alignment
+# ============================================================================
+
+
+def test_multi_row_alignment(sse_server, monkeypatch):
+    server, base_url = sse_server
+    server.scripts["row-zero"] = [openai_delta("zero"), openai_done()]
+    server.scripts["row-one"] = [openai_delta("one"), openai_done()]
+    server.scripts["row-two"] = [openai_delta("two"), openai_done()]
+    monkeypatch.setenv("OPENAI_BASE_URL", base_url)
+
+    df = pl.DataFrame({"prompt": ["row-zero", "row-one", "row-two"]})
+    result = df.with_columns(
+        response=inference_stream(pl.col("prompt"), provider="openai")
+    )
+
+    texts = [row["text"] for row in result["response"]]
+    assert texts == ["zero", "one", "two"]
+    assert all(row["finished"] for row in result["response"])
+
+
+# ============================================================================
+# P11: messages=True mode
+# ============================================================================
+
+
+def test_messages_mode(sse_server, monkeypatch):
+    server, base_url = sse_server
+    server.scripts["msgtest"] = [openai_delta("reply"), openai_done()]
+    monkeypatch.setenv("OPENAI_BASE_URL", base_url)
+
+    message_json = json.dumps([{"role": "user", "content": "msgtest"}])
+    df = pl.DataFrame({"messages": [message_json]})
+    result = df.with_columns(
+        response=inference_stream(pl.col("messages"), provider="openai", messages=True)
+    )
+
+    row = result["response"][0]
+    assert row == {"text": "reply", "finished": True}
+
+
+# ============================================================================
+# Gated real-API smoke tests (skipped in CI without the relevant key)
+# ============================================================================
+
+
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
+)
+def test_streaming_real_openai():
+    df = pl.DataFrame({"prompt": ["Say the word 'hello'.", "Count to three."]})
+    seen = []
+    result = df.with_columns(
+        response=inference_stream(
+            pl.col("prompt"),
+            provider="openai",
+            on_token=lambda i, d: seen.append((i, d)),
+        )
+    )
+    assert result.height == 2
+    for row in result["response"]:
+        assert row["finished"] is True
+        assert row["text"]
+    assert len(seen) >= 1
+
+
+@pytest.mark.skipif(
+    not os.environ.get("ANTHROPIC_API_KEY"), reason="ANTHROPIC_API_KEY not set"
+)
+def test_streaming_real_anthropic():
+    df = pl.DataFrame({"prompt": ["Say the word 'hello'.", "Count to three."]})
+    seen = []
+    result = df.with_columns(
+        response=inference_stream(
+            pl.col("prompt"),
+            provider="anthropic",
+            on_token=lambda i, d: seen.append((i, d)),
+        )
+    )
+    assert result.height == 2
+    for row in result["response"]:
+        assert row["finished"] is True
+        assert row["text"]
+    assert len(seen) >= 1


### PR DESCRIPTION
Closes #74. Ships as **0.6.0** (version bump + CHANGELOG included).

## What
`inference_stream()` — a **Polars expression** that streams completions token-by-token via an `on_token(row_index, delta)` callback, returning a DataFrame-only `Struct{text: Utf8, finished: Boolean}` column so the frame stays rectangular.

Per owner rulings:
- **DataFrame-shaped only** — no standalone iterator API.
- **Cancellation = partial with notice** — `finished=false` covers every non-terminal outcome (mid-stream provider error, transport drop, EOF without terminator, callback raising, Ctrl-C). These surface as a `RuntimeWarning` with partial text preserved, never an exception out of the expression.
- **0.6.0**.

## How
- **Rust**: SSE line parser; `send_request_streaming` trait method with a **buffered default fallback** (Gemini/Bedrock emit one delta → `finished=true`); native SSE for OpenAI, Groq (OpenAI-compatible), Anthropic; a `_stream_inference_batch` `#[pyfunction]` that fans out on the global runtime, drains a bounded mpsc channel, and calls back under the GIL (`py.detach` while awaiting). Pump wakes every 100ms so **Ctrl-C is serviced during a silent stall**, and the streaming client has a **120s per-read idle timeout** so a silent server can't hang `collect()`. `response_model` rejected (text-only). Adds `GROQ_BASE_URL`.

## Tests & proof
- `tests/test_streaming.py` — mock-SSE-server unit tests (multi-chunk assembly, `[DONE]`/`message_stop`, mid-stream error, cancellation → partial + `finished=false`), no key / no mlx; plus gated real-API tests. **11 passed, 2 skipped.**
- **Verified live** across **OpenAI** (gpt-4o-mini), **Anthropic** (claude-haiku-4-5), **Groq** (llama-4-scout): incremental streaming with **byte-exact** delta reassembly, correct `finished` flags, and cancellation preserving partial text (`finished=false`) with a consistent schema and fast abort (~1s).
- `cargo clippy --all-features` clean under `-Dwarnings`.

## Adversarial review
Opus review: APPROVE. The one contract-relevant risk it flagged (Ctrl-C unresponsive during a silent post-connect stall) is **fixed in this branch** via the periodic signal check + idle read timeout above.

Deferred to sub-issues: Gemini/Bedrock native SSE, MLX in-process streaming, streaming structured outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnthn-ai/codesmith/polar_llama/pr/88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786590066&installation_id=141504833&pr_number=88&repository=pnthn-ai%2Fpolar_llama&return_to=https%3A%2F%2Fgithub.com%2Fpnthn-ai%2Fpolar_llama%2Fpull%2F88&signature=48fe2d7ef92a8c1782467ebb7856468d91d783f3bdb1673242b05285d8edb91f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->