### PR TITLE
feat: content-hash dedup & response caching (#77) + release 0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-07-14
+
+### Added
+- **In-run duplicate collapsing and a persistent, cross-job response cache** (`inference_async(..., dedupe=True)` / `response_cache=...`, and `inference_messages`, issue #77): `dedupe=True` sends each unique row in a batch to the backend once and fans the result back out to every row that shared it, at zero extra I/O. `response_cache="path"` (or a `ResponseCache(path, ttl=..., on_mismatch=...)`) adds a persistent store on top -- reusing `polar_llama/checkpoint.py`'s Parquet-part store, atomic writes, and fingerprint-based invalidation verbatim -- so identical requests from a *different* run or process reuse a prior result. `response_cache=` implies `dedupe=True` automatically. Only successful results are ever persisted; a failed row always recomputes. Pass `dedupe_stats=DedupeStats()` to get `rows_total`/`rows_null`/`cache_hits`/`rows_collapsed`/`calls_made`/`hit_rate` back after a collect. `ResponseCache(...).prune()`/`.clear()` compact/invalidate the store manually. Both kwargs default to off/`None` -- byte-identical to the pre-#77 code path. See `docs/design/RESPONSE_CACHE.md`.
+- Extracted the hit/pending/fan-out grouping bookkeeping shared by checkpointing and dedupe into `polar_llama.keys.plan_collapse`/`fan_out`; `checkpoint.checkpointed_expr` now calls these instead of duplicating the logic (verified behavior-identical -- `tests/test_checkpointing.py` passes unmodified against the refactor).
+
+### Notes
+- Not currently supported together (raise `ValueError`): `response_cache=` + `checkpoint=` (two persistent stores for one expression); `response_cache=` + `usage=True` (the usage envelope's failed-row shape isn't recognized by the store's ok/fail classification -- same reason as `checkpoint=` + `usage=True`). `dedupe=True` alongside `checkpoint=` is allowed and silently subsumed (checkpoint already collapses duplicates per batch). `dedupe=True` + `usage=True` (no store) is allowed; duplicate rows carry the same `usage` struct as the row actually computed, so `SUM(cost_usd)` over-counts by the collapse factor -- `dedupe_stats.calls_made` is the true-spend signal.
+
 ## [0.6.2] - 2026-07-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "polar-llama"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polar-llama"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -266,6 +266,33 @@ totals = out.select(
 
 `cost_usd` is computed from a packaged, overridable price table (`polar_llama/pricing.py`); pass `price_table=` (a dict or path) or call `register_model_price(...)` to add/override models. Unknown models yield `cost_usd = null` with a one-time warning. Usage is captured for OpenAI, Groq, Anthropic, Gemini, and Bedrock; the MLX local engine reports tokens + latency with `cost_usd = 0.0`. `usage=False` (the default) is unchanged.
 
+#### Duplicate Collapsing & a Persistent Response Cache
+
+Two related, separately-gated features. `dedupe=True` collapses exact-duplicate rows **within one run** — each unique input is sent once and the result is fanned back out to every row that asked for it, zero extra I/O:
+
+```python
+out = df.with_columns(answer=inference_async(pl.col("prompt"), model="gpt-4o-mini", dedupe=True))
+```
+
+`response_cache="path"` adds a persistent, **cross-job** store (implies `dedupe=True` automatically): identical requests from a different run, even a different process, reuse a prior result instead of re-calling the backend.
+
+```python
+from polar_llama import ResponseCache, DedupeStats
+
+stats = DedupeStats()
+out = df.with_columns(
+    answer=inference_async(
+        pl.col("prompt"),
+        model="gpt-4o-mini",
+        response_cache=ResponseCache("responses.cache", ttl="24h"),
+        dedupe_stats=stats,
+    )
+)
+print(stats.hit_rate, stats.rows_collapsed, stats.calls_made)
+```
+
+Only successful results are ever persisted — a failed row always recomputes on the next run. `ttl=` expires entries lazily on read; call `ResponseCache(...).prune()` to compact the store and reclaim expired entries, or `.clear()` to invalidate everything. Not currently supported together with `checkpoint=` or `usage=True` (raises `ValueError` — see `docs/design/RESPONSE_CACHE.md` for the full interop rules and why).
+
 #### Local Inference (Apple Silicon / MLX)
 
 Run inference **on-device** on Apple Silicon instead of a provider API — no keys, no network — via [mlx-lm](https://github.com/ml-explore/mlx-lm). Install the extra (Apple Silicon, Python ≥ 3.10):

--- a/docs/design/CHECKPOINTING.md
+++ b/docs/design/CHECKPOINTING.md
@@ -88,3 +88,13 @@ bare `None`. A successful *plain-text* row is the model's raw output and is
 - **Invalidate on prompt/model/param change**: the key embeds the fingerprint.
 - **Works with structured outputs and tool-use**: the struct-decode path is
   unchanged; stored raw strings round-trip identically.
+
+## Related: duplicate collapsing / response cache (issue #77)
+
+`dedupe=True` and `response_cache=...` (`polar_llama/dedup.py`) reuse this
+module's hit/pending/fan-out bookkeeping (extracted to
+`polar_llama.keys.plan_collapse`/`fan_out`, which `checkpoint.checkpointed_expr`
+now calls too) and `CheckpointStore` itself (via the `ResponseCacheStore`
+subclass) for a persistent, cross-job response cache. See
+`docs/design/RESPONSE_CACHE.md` for the full design and the interop rules
+between `checkpoint=`, `usage=`, `dedupe=`, and `response_cache=`.

--- a/docs/design/RESPONSE_CACHE.md
+++ b/docs/design/RESPONSE_CACHE.md
@@ -1,0 +1,179 @@
+# Duplicate collapsing and a persistent response cache (issue #77)
+
+`inference_async(..., dedupe=True)` / `inference_messages(..., dedupe=True)`
+collapse exact-duplicate rows within one run before sending them to the
+backend. `response_cache=...` adds a persistent, cross-job store on top,
+reusing `polar_llama/checkpoint.py`'s Parquet-part store verbatim.
+
+The feature is **DataFrame-shaped**, exactly like checkpointing (#75): the
+API stays a lazy Polars expression, composes in `with_columns`/`LazyFrame`
+pipelines, and works under both the default and streaming collect engines.
+
+## Naming: four different "caches"
+
+This library now has four kwargs that are all, loosely, "a cache". They are
+deliberately kept separate rather than overloaded onto one `cache=` kwarg:
+
+| Kwarg              | What it caches                                                          |
+| ------------------ | ------------------------------------------------------------------------ |
+| `cache=`            | Provider prompt-prefix caching (transport-level; changes how a request is *sent*, never what is asked for). |
+| `checkpoint=`       | Resume the *same* job after a crash.                                     |
+| `dedupe=`           | Collapse exact-duplicate rows *within one run*, zero I/O.                |
+| `response_cache=`   | Reuse results *across* runs/processes for identical requests.            |
+
+`response_cache=` **implies** `dedupe=True` silently: computing content keys
+to consult the store already does all the grouping work, so serving a cache
+without also collapsing in-batch duplicates would be pure waste.
+
+## Mechanism
+
+Both features share one Python module, `polar_llama/dedup.py`, and one
+`map_batches` UDF wrapper, `deduped_expr` (mirrors
+`checkpoint.checkpointed_expr`'s shape exactly). Per batch the UDF:
+
+1. Computes a per-row content key (`polar_llama.keys.content_key`) — the
+   exact same primitive checkpointing uses, extracted grouping logic
+   included (see below).
+2. If a `ResponseCacheStore` is attached, loads its index (TTL-filtered).
+3. Splits rows into hits (served from the store) and pending, deduplicating
+   pending rows by key so identical inputs are only requested once per
+   batch — even with no store at all, this is `dedupe=True`'s entire
+   contract.
+4. Runs the caller-supplied `run_pending` callback **once**, over every
+   unique pending input in the batch (no chunking — see "Why no
+   `flush_every`" below).
+5. Fans each result back out to every row that shared its key, in original
+   order.
+6. If a store is attached, persists only the `ok=True` results.
+
+### Shared collapse bookkeeping: `polar_llama/keys.py`
+
+The hit/pending/fan-out bookkeeping used to live inline in
+`checkpoint.checkpointed_expr`'s `_udf`. It has been extracted to
+`polar_llama.keys.plan_collapse` / `polar_llama.keys.fan_out` (pure, no I/O)
+so `dedup.py` can reuse it byte-for-byte, and `checkpoint.py` has been
+refactored to call the same helpers instead of duplicating the logic.
+`tests/test_checkpointing.py` passes unmodified against the refactor — this
+was verified as a behavior-preservation gate before anything else was built.
+
+### Why no `flush_every` chunking
+
+Checkpointing chunks pending rows and flushes to disk after each chunk so a
+crash loses at most `flush_every` rows' worth of duplicate spend — there is
+a durability contract for a long-running, resumable job. Dedupe has no such
+contract: a "batch" here is transient (one `map_batches` invocation), not a
+resumable job, and the Rust inference plugin already parallelizes internally
+across the rows it's given. So `deduped_expr` sends every unique pending row
+to `run_pending` in one call — simpler and at least as fast.
+
+### Why only `ok=True` is ever persisted
+
+A transient failure (rate limit, timeout, provider outage) must never be
+replayed cross-job as if it were a real answer. `deduped_expr` always passes
+`serve_failed=False` to `plan_collapse` (dedupe/response_cache never treats
+a stored failure as "done") and only appends `ok=True` rows to the store —
+a failed row simply recomputes on the next run, exactly like an uncached
+call would.
+
+## The persistent store: `ResponseCacheStore`
+
+A thin subclass of `polar_llama.checkpoint.CheckpointStore` living in
+`dedup.py`. It reuses the parent's on-disk layout (append-only Parquet
+parts, atomic `os.replace` writes, fingerprint filtering, latest-`ts`-wins
+read-side dedup) verbatim, and adds:
+
+- **TTL-on-read filtering** (`load_index(ttl_seconds=...)`): an entry older
+  than `now - ttl_seconds` is treated as absent (pending, not a hit).
+  Enforced lazily on every read — an expired entry sits inert on disk until
+  reclaimed.
+- **`prune(now=None)`**: compaction. Reads every part, drops expired and
+  superseded entries (keeping the latest `ts` per key across **all**
+  fingerprints sharing the directory, so other jobs'/configs' entries
+  survive), rewrites the survivors as one new part, deletes the old parts.
+  Never required for correctness — pure housekeeping.
+- **`clear()`**: deletes every part file (full invalidation). `_meta.json`
+  is left as-is.
+
+`ResponseCache.clear()` / `.prune()` are the user-facing entry points; they
+construct a `ResponseCacheStore` with `fingerprint=None` (an administrative
+handle not tied to any one run's config) and delegate.
+
+**Fingerprint**: identical to checkpointing's
+`polar_llama.keys.config_fingerprint` — the same `_request_fingerprint`
+helper in `polar_llama/__init__.py` (extracted from what used to be
+duplicated inline in `inference_async`/`inference_messages`) computes it for
+both the checkpoint path and the dedupe/response_cache path. Since content
+keys embed the fingerprint, a shared cache directory can safely hold entries
+from many different configs (model, schema, endpoint, ...) simultaneously —
+their key spaces are disjoint, exactly the property checkpointing already
+relies on.
+
+## Stats: `DedupeStats`
+
+Aggregates (`rows_total`, `rows_null`, `cache_hits`, `rows_collapsed`,
+`calls_made`) don't fit a pure-expression return value, so they're surfaced
+via a caller-passed mutable accumulator:
+
+```python
+stats = DedupeStats()
+out = df.with_columns(r=inference_async(pl.col("p"), dedupe=True, dedupe_stats=stats))
+print(stats.hit_rate, stats.rows_collapsed, stats.calls_made)
+```
+
+The UDF `+=`s into it (lock-guarded, so it's safe across concurrently
+collecting LazyFrames) once per batch at collect time. Rejected
+alternatives: a module-level "last run" global (races between concurrent
+runs); returning a tuple from the expression (breaks the pure-expression
+contract); log-only (not programmatic — though a `logging.debug` summary
+line is still emitted per batch for free observability).
+
+`DedupeStats` is deliberately **not** folded into `CacheMetrics`
+(`polar_llama/types.py`) — that type is token/provider-shaped (prompt
+caching); `DedupeStats` is call/row-shaped. Kept separate, documented in
+both docstrings.
+
+## Interop rules
+
+1. **`response_cache=` + `checkpoint=`** → raises `ValueError`. Two
+   persistent stores for one expression; point `checkpoint=` at same-job
+   resume, `response_cache=` at cross-job reuse. Composing them (a layered
+   cache → checkpoint → compute lookup) is deferred, not needed for v1.
+2. **`dedupe=True` + `checkpoint=`** → allowed, silently subsumed (no
+   warning). The checkpoint UDF already collapses duplicates per batch on
+   its own.
+3. **`response_cache=` + `usage=True`** → raises `ValueError`. Same
+   envelope problem as `checkpoint=` + `usage=True` (see
+   `docs/design/CHECKPOINTING.md`): `usage=True` wraps every row in
+   `{"response": ..., "usage": {...}}`, and the store's `ok`/`fail`
+   classification (`checkpoint._is_error_row`) only recognizes a top-level
+   `{"_error": ...}` shape — under the envelope a failed row would be
+   misclassified as `ok=True` and cached. A served row's cached `usage`
+   would also misreport spend (stale tokens/latency from whenever it was
+   first computed).
+4. **`dedupe=True` + `usage=True`** (no store) → allowed. Fanned-back
+   duplicate rows carry the **same** `usage` struct as the row that was
+   actually computed — the raw envelope string is exactly what fans out, so
+   this falls out naturally and truthfully reflects "what the model
+   returned for this content". **Documented consequence:**
+   `SUM(cost_usd)` over-counts actual spend by the collapse factor;
+   `dedupe_stats.calls_made` is the true-spend signal, or
+   `df.unique(subset=[...])` before summing. (Zeroing duplicate usage was
+   rejected: it requires rewriting envelopes post-hoc, makes per-row usage
+   lie about what the response cost to produce, and breaks row-identity
+   with an uncached run.)
+5. **`dedupe=`/`response_cache=` + provider `cache=`** → compose freely.
+   Provider prompt caching is transport-level and already excluded from
+   `config_fingerprint` (`polar_llama/keys.py`). Fewer unique calls simply
+   means fewer opportunities for the provider's own cache to hit.
+6. **`inference_stream`** → out of scope; no `dedupe=`/`response_cache=`
+   kwargs.
+
+## Testing
+
+`tests/test_dedupe_cache.py` mirrors `tests/test_checkpointing.py`'s
+layering: unit tests against `deduped_expr` with a counting stub (no
+network), an end-to-end test against a local mock OpenAI-compatible HTTP
+server, and a gated real-API proof skipped unless `OPENAI_API_KEY` is set.
+`tests/test_checkpointing.py` was run unmodified against the `keys.py`
+extraction/`checkpoint.py` refactor as a behavior-preservation gate — all
+pre-existing tests pass with zero edits.

--- a/polar_llama/__init__.py
+++ b/polar_llama/__init__.py
@@ -1,7 +1,17 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Optional, Union, Type, Dict, Any, List
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Optional,
+    Tuple,
+    Union,
+    Type,
+    Dict,
+    Any,
+    List,
+)
 import json
 
 import polars as pl
@@ -13,6 +23,13 @@ from polar_llama.keys import (
     config_fingerprint,
     canonicalize_messages_input,
     endpoint_fingerprint_input,
+)
+from polar_llama.dedup import (
+    DedupeStats,
+    ResponseCache,
+    ResponseCacheStore,
+    _parse_ttl,
+    deduped_expr,
 )
 from polar_llama import pricing
 from polar_llama.pricing import register_model_price, set_price_table
@@ -614,6 +631,43 @@ def _make_run_pending(
     return run_pending
 
 
+def _request_fingerprint(
+    symbol: str, kwargs: Dict[str, Any], system_prompt: Optional[str] = None
+) -> Tuple[str, Dict[str, Any]]:
+    """Compute the request-shaping fingerprint + a debuggable inputs dict.
+
+    Shared by the checkpoint path (issue #75) and the dedupe/response_cache
+    path (issue #77) so "the same request" means exactly the same thing to
+    both -- extracted from what used to be duplicated inline in
+    `inference_async` and `inference_messages` (`config_fingerprint` +
+    `endpoint_fingerprint_input`, `polar_llama/keys.py`). The returned
+    `fingerprint_inputs` dict is purely for `_meta.json` debuggability (not
+    used for invalidation -- `fingerprint` alone is authoritative), so
+    unifying its shape across both call sites changes no observable
+    behavior.
+    """
+    endpoint = endpoint_fingerprint_input(kwargs["provider"])
+    fingerprint = config_fingerprint(
+        symbol=symbol,
+        provider=kwargs["provider"],
+        model=kwargs["model"],
+        response_schema=kwargs["response_schema"],
+        response_model_name=kwargs["response_model_name"],
+        system_prompt=system_prompt,
+        extra={"endpoint": endpoint},
+    )
+    fingerprint_inputs = {
+        "symbol": symbol,
+        "provider": kwargs["provider"],
+        "model": kwargs["model"],
+        "response_model_name": kwargs["response_model_name"],
+        "has_response_schema": kwargs["response_schema"] is not None,
+        "has_system_prompt": system_prompt is not None,
+        "endpoint": endpoint,
+    }
+    return fingerprint, fingerprint_inputs
+
+
 def inference_async(
     expr: IntoExpr,
     *,
@@ -626,6 +680,9 @@ def inference_async(
     checkpoint: Optional[Union[str, Path, Checkpoint]] = None,
     usage: bool = False,
     price_table: Optional[Union[Dict[str, Any], str, Path]] = None,
+    dedupe: bool = False,
+    response_cache: Optional[Union[str, Path, ResponseCache]] = None,
+    dedupe_stats: Optional[DedupeStats] = None,
 ) -> pl.Expr:
     """
     Asynchronously infer completions for the given text expressions using an LLM.
@@ -736,6 +793,63 @@ def inference_async(
         ``polar_llama/data/prices.json``: ``{"<provider>": {"<model>":
         {"input_per_1m": ..., "output_per_1m": ..., "cached_input_per_1m":
         ...}}}``.
+    dedupe : bool, optional
+        Enable in-run duplicate collapsing (issue #77): identical rows
+        *within one batch* are sent to the backend once, and the single
+        result is fanned back out to every row that asked for it. Zero
+        extra I/O -- pure in-memory content-hash grouping. Default: False
+        (byte-identical to the pre-#77 code path -- every row is sent as
+        its own request, even exact duplicates). Ignored (silently
+        subsumed, no warning) when ``checkpoint=`` is also set -- the
+        checkpoint UDF already collapses duplicates per batch.
+    response_cache : str, Path, or ResponseCache, optional
+        Enable a persistent, cross-job response cache (issue #77): a
+        str/Path is shorthand for ``ResponseCache(path)``; pass a
+        ``ResponseCache`` for ``ttl``/``on_mismatch`` control. Identical
+        requests -- across different runs, even different processes --
+        reuse a prior result instead of re-calling the backend. Implies
+        ``dedupe=True`` for free (computing content keys to consult the
+        store already does the grouping). Only successful results are ever
+        persisted; a failed row always recomputes on the next run. Not
+        currently supported together with ``checkpoint=`` or ``usage=True``
+        (raises ``ValueError`` -- see below). Default: None (disabled).
+
+        See also ``polar_llama.ResponseCache.clear()`` /
+        ``.prune()`` for manual invalidation/compaction.
+
+        Disambiguation -- four different things are all called "cache" in
+        this library:
+
+        =================  ================================================
+        Kwarg              What it caches
+        =================  ================================================
+        ``cache=``         Provider prompt-prefix caching (transport-level;
+                            changes how a request is *sent*, not what is
+                            asked for).
+        ``checkpoint=``     Resume the *same* job after a crash.
+        ``dedupe=``         Collapse exact-duplicate rows *within one run*.
+        ``response_cache=`` Reuse results *across* runs/processes for
+                            identical requests.
+        =================  ================================================
+
+        These compose freely except where noted above: ``dedupe=``/
+        ``response_cache=`` alongside provider ``cache=`` simply means
+        fewer unique calls reach the provider, so fewer opportunities for
+        its own prompt-cache to hit.
+    dedupe_stats : DedupeStats, optional
+        Mutable accumulator populated (in place, at collect time) with
+        ``rows_total``, ``rows_null``, ``cache_hits``, ``rows_collapsed``,
+        and ``calls_made`` when ``dedupe=True`` or ``response_cache=...``
+        is set. See ``polar_llama.DedupeStats``. Ignored (never populated)
+        when neither is set.
+
+        Example::
+
+            >>> stats = DedupeStats()
+            >>> out = df.with_columns(
+            ...     r=inference_async(pl.col("p"), dedupe=True, dedupe_stats=stats)
+            ... )
+            >>> stats.hit_rate, stats.rows_collapsed, stats.calls_made  # doctest: +SKIP
 
     Returns
     -------
@@ -751,6 +865,27 @@ def inference_async(
             "with checkpoint=... (the checkpoint store's failed-row detection "
             "does not look inside the usage envelope -- see the `usage` "
             "parameter docstring). Use one or the other for now."
+        )
+
+    if response_cache is not None and checkpoint is not None:
+        raise ValueError(
+            "inference_async: response_cache=... cannot be combined with "
+            "checkpoint=... -- two persistent stores for one expression. "
+            "Point checkpoint= at a directory for same-job resume, "
+            "response_cache= at a directory for cross-job reuse; the "
+            "checkpoint path already collapses in-batch duplicates on its "
+            "own, so composing the two is not needed."
+        )
+
+    if response_cache is not None and usage:
+        raise ValueError(
+            "inference_async: response_cache=... is not currently supported "
+            "together with usage=True (the same envelope problem as "
+            "checkpoint=... + usage=True -- see the `usage` parameter "
+            "docstring: a failed row's error is nested one level deeper "
+            "under the usage envelope, so it would be misclassified as ok "
+            "and cached; a served row's cached usage would also misreport "
+            "spend). Use one or the other for now."
         )
 
     # Convert Provider to string to make it picklable. All keys are always
@@ -797,31 +932,43 @@ def inference_async(
     if checkpoint is not None:
         if not isinstance(checkpoint, Checkpoint):
             checkpoint = Checkpoint(checkpoint)
-        endpoint = endpoint_fingerprint_input(kwargs["provider"])
-        fingerprint = config_fingerprint(
-            symbol="inference_async",
-            provider=kwargs["provider"],
-            model=kwargs["model"],
-            response_schema=kwargs["response_schema"],
-            response_model_name=kwargs["response_model_name"],
-            system_prompt=system_prompt,
-            extra={"endpoint": endpoint},
+        fingerprint, fingerprint_inputs = _request_fingerprint(
+            "inference_async", kwargs, system_prompt
         )
-        fingerprint_inputs = {
-            "symbol": "inference_async",
-            "provider": kwargs["provider"],
-            "model": kwargs["model"],
-            "response_model_name": kwargs["response_model_name"],
-            "has_response_schema": kwargs["response_schema"] is not None,
-            "has_system_prompt": system_prompt is not None,
-            "endpoint": endpoint,
-        }
         result_expr = checkpointed_expr(
             expr,
             run_pending=_make_run_pending("inference_async", kwargs),
             fingerprint=fingerprint,
             checkpoint=checkpoint,
             fingerprint_inputs=fingerprint_inputs,
+            has_schema=kwargs["response_schema"] is not None,
+        )
+    elif dedupe or response_cache is not None:
+        fingerprint, fingerprint_inputs = _request_fingerprint(
+            "inference_async", kwargs, system_prompt
+        )
+        store = None
+        ttl_seconds = None
+        if response_cache is not None:
+            rc = (
+                response_cache
+                if isinstance(response_cache, ResponseCache)
+                else ResponseCache(response_cache)
+            )
+            store = ResponseCacheStore(
+                rc.path,
+                fingerprint,
+                rc.on_mismatch,
+                fingerprint_inputs=fingerprint_inputs,
+            )
+            ttl_seconds = _parse_ttl(rc.ttl)
+        result_expr = deduped_expr(
+            expr,
+            run_pending=_make_run_pending("inference_async", kwargs),
+            fingerprint=fingerprint,
+            store=store,
+            ttl_seconds=ttl_seconds,
+            stats=dedupe_stats,
             has_schema=kwargs["response_schema"] is not None,
         )
     else:
@@ -955,6 +1102,9 @@ def inference_messages(
     checkpoint: Optional[Union[str, Path, Checkpoint]] = None,
     usage: bool = False,
     price_table: Optional[Union[Dict[str, Any], str, Path]] = None,
+    dedupe: bool = False,
+    response_cache: Optional[Union[str, Path, ResponseCache]] = None,
+    dedupe_stats: Optional[DedupeStats] = None,
 ) -> pl.Expr:
     """
     Process message arrays (conversations) for inference using LLMs.
@@ -1011,6 +1161,20 @@ def inference_messages(
     price_table : dict, str, or Path, optional
         Per-call cost-resolution override (``usage=True`` only). See
         ``inference_async``.
+    dedupe : bool, optional
+        Enable in-run duplicate collapsing (issue #77). See
+        ``inference_async`` for the full description; behaves identically
+        here, including sharing content keys across the two accepted input
+        shapes (JSON-string vs. ``List(Struct{role, content})``) exactly
+        like ``checkpoint=`` does. Default: False.
+    response_cache : str, Path, or ResponseCache, optional
+        Enable a persistent, cross-job response cache (issue #77). See
+        ``inference_async`` for the full description; behaves identically
+        here. Not currently supported together with ``checkpoint=`` or
+        ``usage=True`` (raises ``ValueError``). Default: None.
+    dedupe_stats : DedupeStats, optional
+        Mutable accumulator for ``dedupe=``/``response_cache=`` aggregates.
+        See ``inference_async``.
 
     Returns
     -------
@@ -1026,6 +1190,21 @@ def inference_messages(
             "together with checkpoint=... (see the `usage` parameter "
             "docstring on inference_async for why). Use one or the other "
             "for now."
+        )
+
+    if response_cache is not None and checkpoint is not None:
+        raise ValueError(
+            "inference_messages: response_cache=... cannot be combined with "
+            "checkpoint=... (see the `response_cache` parameter docstring "
+            "on inference_async for why). Use one or the other for now."
+        )
+
+    if response_cache is not None and usage:
+        raise ValueError(
+            "inference_messages: response_cache=... is not currently "
+            "supported together with usage=True (see the `response_cache` "
+            "parameter docstring on inference_async for why). Use one or "
+            "the other for now."
         )
 
     # Both JSON-string input and List(Struct{role, content}) input are handled
@@ -1073,23 +1252,9 @@ def inference_messages(
     if checkpoint is not None:
         if not isinstance(checkpoint, Checkpoint):
             checkpoint = Checkpoint(checkpoint)
-        endpoint = endpoint_fingerprint_input(kwargs["provider"])
-        fingerprint = config_fingerprint(
-            symbol="inference_messages",
-            provider=kwargs["provider"],
-            model=kwargs["model"],
-            response_schema=kwargs["response_schema"],
-            response_model_name=kwargs["response_model_name"],
-            extra={"endpoint": endpoint},
+        fingerprint, fingerprint_inputs = _request_fingerprint(
+            "inference_messages", kwargs
         )
-        fingerprint_inputs = {
-            "symbol": "inference_messages",
-            "provider": kwargs["provider"],
-            "model": kwargs["model"],
-            "response_model_name": kwargs["response_model_name"],
-            "has_response_schema": kwargs["response_schema"] is not None,
-            "endpoint": endpoint,
-        }
         result_expr = checkpointed_expr(
             expr,
             run_pending=_make_run_pending("inference_messages", kwargs),
@@ -1097,6 +1262,35 @@ def inference_messages(
             checkpoint=checkpoint,
             canonicalize=canonicalize_messages_input,
             fingerprint_inputs=fingerprint_inputs,
+            has_schema=kwargs["response_schema"] is not None,
+        )
+    elif dedupe or response_cache is not None:
+        fingerprint, fingerprint_inputs = _request_fingerprint(
+            "inference_messages", kwargs
+        )
+        store = None
+        ttl_seconds = None
+        if response_cache is not None:
+            rc = (
+                response_cache
+                if isinstance(response_cache, ResponseCache)
+                else ResponseCache(response_cache)
+            )
+            store = ResponseCacheStore(
+                rc.path,
+                fingerprint,
+                rc.on_mismatch,
+                fingerprint_inputs=fingerprint_inputs,
+            )
+            ttl_seconds = _parse_ttl(rc.ttl)
+        result_expr = deduped_expr(
+            expr,
+            run_pending=_make_run_pending("inference_messages", kwargs),
+            fingerprint=fingerprint,
+            canonicalize=canonicalize_messages_input,
+            store=store,
+            ttl_seconds=ttl_seconds,
+            stats=dedupe_stats,
             has_schema=kwargs["response_schema"] is not None,
         )
     else:
@@ -1840,6 +2034,9 @@ class LlamaNamespace:
         checkpoint: Optional[Union[str, Path, Checkpoint]] = None,
         usage: bool = False,
         price_table: Optional[Union[Dict[str, Any], str, Path]] = None,
+        dedupe: bool = False,
+        response_cache: Optional[Union[str, Path, ResponseCache]] = None,
+        dedupe_stats: Optional[DedupeStats] = None,
     ) -> pl.Expr:
         """
         Asynchronously infer completions for the expression using an LLM.
@@ -1867,6 +2064,15 @@ class LlamaNamespace:
             ``inference_async`` for details).
         price_table : dict, str, or Path, optional
             Per-call cost-resolution override (``usage=True`` only).
+        dedupe : bool, optional
+            Enable in-run duplicate collapsing (see the functional
+            ``inference_async`` for details).
+        response_cache : str, Path, or ResponseCache, optional
+            Enable a persistent, cross-job response cache (see the
+            functional ``inference_async`` for details).
+        dedupe_stats : DedupeStats, optional
+            Mutable accumulator for ``dedupe=``/``response_cache=``
+            aggregates.
 
         Returns
         -------
@@ -1883,6 +2089,9 @@ class LlamaNamespace:
             checkpoint=checkpoint,
             usage=usage,
             price_table=price_table,
+            dedupe=dedupe,
+            response_cache=response_cache,
+            dedupe_stats=dedupe_stats,
         )
 
     def inference_stream(

--- a/polar_llama/checkpoint.py
+++ b/polar_llama/checkpoint.py
@@ -80,7 +80,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import polars as pl
 
-from polar_llama.keys import content_key
+from polar_llama.keys import CollapsePlan, fan_out, plan_collapse
 
 _META_FILENAME = "_meta.json"
 _FORMAT_VERSION = 1
@@ -219,7 +219,7 @@ class CheckpointStore:
     def __init__(
         self,
         path: Union[str, Path],
-        fingerprint: str,
+        fingerprint: Optional[str],
         on_mismatch: str = "restart",
         fingerprint_inputs: Optional[Dict[str, Any]] = None,
     ) -> None:
@@ -234,6 +234,14 @@ class CheckpointStore:
         return self.path / _META_FILENAME
 
     def _reconcile_meta(self, fingerprint_inputs: Optional[Dict[str, Any]]) -> None:
+        if self.fingerprint is None:
+            # Administrative access (issue #77's `ResponseCache.clear()` /
+            # `.prune()`, via `ResponseCacheStore`) that isn't tied to any
+            # one run's fingerprint -- never touch `_meta.json`. Every real
+            # caller (checkpoint or dedupe/response_cache) always passes a
+            # real fingerprint string, so this branch is unreachable from
+            # any existing code path.
+            return
         if self.meta_path.exists():
             try:
                 meta = json.loads(self.meta_path.read_text())
@@ -272,12 +280,25 @@ class CheckpointStore:
     def _part_paths(self) -> List[Path]:
         return sorted(self.path.glob("part-*.parquet"))
 
-    def load_index(self) -> Dict[str, Tuple[bool, str]]:
+    def load_index(
+        self, ttl_seconds: Optional[float] = None
+    ) -> Dict[str, Tuple[bool, str]]:
         """Load the store into `key -> (ok, result_raw)`, deduped.
 
         Among entries sharing a key, the latest `ts` wins; exact ties prefer
         `ok=True` (a fresh success over a stale failure written at the same
         instant).
+
+        Parameters
+        ----------
+        ttl_seconds
+            Optional TTL, in seconds, applied on read: entries older than
+            `now - ttl_seconds` are treated as if absent (pending, not a
+            hit). `None` (the default -- what `checkpoint.py` always uses)
+            disables TTL filtering entirely, matching pre-#77 behavior.
+            Added for issue #77's `ResponseCacheStore`, which enforces TTL
+            lazily on every read rather than deleting expired entries
+            eagerly (`prune()` does that on demand).
         """
         parts = self._part_paths()
         if not parts:
@@ -303,6 +324,12 @@ class CheckpointStore:
         df = df.filter(pl.col("fingerprint") == self.fingerprint)
         if df.height == 0:
             return {}
+
+        if ttl_seconds is not None:
+            cutoff = _now_utc() - datetime.timedelta(seconds=ttl_seconds)
+            df = df.filter(pl.col("ts") >= cutoff)
+            if df.height == 0:
+                return {}
 
         # Sort ascending by (key, ts, ok); `False < True` means an ok=True
         # row sorts *after* an ok=False row at the same timestamp, so taking
@@ -408,45 +435,26 @@ def checkpointed_expr(
 
         dtype = s.dtype
         raw_inputs: List[Any] = s.to_list()
-        n = len(raw_inputs)
 
-        keys: List[Optional[str]] = [None] * n
-        for i, v in enumerate(raw_inputs):
-            if v is None:
-                continue
-            hash_source = canonicalize(v) if canonicalize is not None else v
-            keys[i] = content_key(hash_source, fingerprint)
-
-        results: List[Optional[str]] = [None] * n
-        # Ordered de-dup of pending rows by key: identical inputs (including
-        # duplicates already inside this one batch) are only ever sent to
-        # `run_pending` once; every row sharing that key gets the same
-        # result fanned back out below.
-        unique_pending_keys: List[str] = []
-        unique_pending_inputs: List[Any] = []
-        seen_pending: Dict[str, int] = {}
-        key_to_positions: Dict[str, List[int]] = {}
-
-        for i, key in enumerate(keys):
-            if key is None:
-                continue  # null row: passes through as null, never stored
-            hit = index.get(key)
-            if hit is not None:
-                ok, stored_raw = hit
-                if ok or not checkpoint.retry_failed:
-                    results[i] = stored_raw
-                    continue
-            key_to_positions.setdefault(key, []).append(i)
-            if key not in seen_pending:
-                seen_pending[key] = len(unique_pending_keys)
-                unique_pending_keys.append(key)
-                unique_pending_inputs.append(raw_inputs[i])
+        # Grouping/hit-vs-pending bookkeeping is shared with issue #77's
+        # dedupe/response-cache path -- see `polar_llama.keys.plan_collapse`.
+        # `serve_failed=not checkpoint.retry_failed` reproduces the exact
+        # hit rule this loop used to implement inline: an `ok=True` stored
+        # entry is always a hit; an `ok=False` entry is a hit only when
+        # `retry_failed=False` (otherwise it's pending -- retried).
+        plan: CollapsePlan = plan_collapse(
+            raw_inputs,
+            fingerprint,
+            canonicalize=canonicalize,
+            index=index,
+            serve_failed=not checkpoint.retry_failed,
+        )
 
         flush_every = checkpoint.flush_every
-        n_unique = len(unique_pending_keys)
+        n_unique = len(plan.unique_pending_keys)
         for start in range(0, n_unique, flush_every):
-            chunk_keys = unique_pending_keys[start : start + flush_every]
-            chunk_inputs = unique_pending_inputs[start : start + flush_every]
+            chunk_keys = plan.unique_pending_keys[start : start + flush_every]
+            chunk_inputs = plan.unique_pending_inputs[start : start + flush_every]
 
             chunk_series = pl.Series(chunk_inputs, dtype=dtype)
             chunk_result_series = run_pending(chunk_series)
@@ -458,13 +466,13 @@ def checkpointed_expr(
                 is_err, err_type = _is_error_row(raw, has_schema)
                 oks.append(not is_err)
                 errors.append(err_type)
-                for pos in key_to_positions[key]:
-                    results[pos] = raw
+
+            fan_out(plan, chunk_keys, chunk_raws)
 
             # Flush *this chunk* before moving to the next one: a crash
             # loses at most the in-flight chunk's worth of duplicate spend.
             store.append(chunk_keys, chunk_raws, oks, errors)
 
-        return pl.Series(s.name, results, dtype=pl.Utf8)
+        return pl.Series(s.name, plan.results, dtype=pl.Utf8)
 
     return expr.map_batches(_udf, return_dtype=pl.Utf8)

--- a/polar_llama/dedup.py
+++ b/polar_llama/dedup.py
@@ -1,0 +1,480 @@
+"""In-run duplicate collapsing and a persistent cross-job response cache
+(issue #77).
+
+Two related but distinct features, both built on the content-hash primitives
+in `polar_llama/keys.py`:
+
+- **In-run dedupe** (`dedupe=True`, no store): identical rows *within one
+  batch* are sent to the backend once and the single result is fanned back
+  out to every row that asked for it. Zero I/O beyond the inference calls
+  themselves.
+- **Persistent response cache** (`response_cache=...`): a directory-backed
+  store -- a thin, feature-flavored subclass of
+  `polar_llama.checkpoint.CheckpointStore` -- that lets identical requests
+  from *different* runs (even different processes) reuse a prior result.
+  Implies in-run dedupe for free, since computing content keys to consult
+  the store already does all the grouping work.
+
+Both are implemented as a single `map_batches` UDF wrapper (`deduped_expr`,
+mirroring `checkpoint.checkpointed_expr`'s shape exactly): the public API
+stays a lazy `pl.Expr`, so it composes in `with_columns` / `LazyFrame`
+pipelines and works under both the default and streaming collect engines.
+
+Key differences from checkpointing (deliberate, not oversights):
+
+- No chunked `flush_every` loop -- there is no crash-durability contract for
+  dedupe (a "batch" here is transient, not a resumable job), and the Rust
+  inference plugin already parallelizes internally, so one call over all
+  pending rows is both simpler and at least as fast.
+- Only `ok=True` results are ever persisted to a response cache. A
+  transient failure must never be replayed cross-job as if it were a real
+  answer -- it simply recomputes on the next run, exactly like an
+  uncached call would.
+- `ResponseCacheStore` reuses `CheckpointStore`'s on-disk layout, atomic
+  writes, and read-side dedup verbatim; it only adds TTL-on-read filtering
+  and manual invalidation (`prune()`, `clear()`).
+
+See `docs/design/RESPONSE_CACHE.md` for the full design write-up and the
+interop rules with `checkpoint=`, `usage=`, and provider `cache=`.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import os
+import threading
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import polars as pl
+
+from polar_llama.checkpoint import CheckpointStore, _is_error_row, _now_utc
+from polar_llama.keys import CollapsePlan, fan_out, plan_collapse
+
+logger = logging.getLogger(__name__)
+
+
+# ============================================================================
+# TTL parsing
+# ============================================================================
+
+_TTL_UNIT_SECONDS = {"s": 1.0, "m": 60.0, "h": 3600.0, "d": 86400.0}
+
+
+def _parse_ttl(
+    ttl: Optional[Union[str, int, float, datetime.timedelta]],
+) -> Optional[float]:
+    """Normalize a `ResponseCache.ttl` value to seconds (or `None` = never expires).
+
+    Accepts a `datetime.timedelta`, a plain number of seconds (`int`/`float`),
+    or a string of the form `"<number><unit>"` where unit is one of
+    `s`/`m`/`h`/`d` (e.g. `"30m"`, `"24h"`, `"7d"`).
+
+    Examples
+    --------
+    >>> _parse_ttl(None) is None
+    True
+    >>> _parse_ttl(90)
+    90.0
+    >>> _parse_ttl(datetime.timedelta(minutes=1.5))
+    90.0
+    >>> _parse_ttl("30m")
+    1800.0
+    >>> _parse_ttl("24h")
+    86400.0
+    >>> _parse_ttl("7d")
+    604800.0
+    """
+    if ttl is None:
+        return None
+    if isinstance(ttl, datetime.timedelta):
+        return ttl.total_seconds()
+    if isinstance(ttl, bool):  # bool is an int subclass -- reject explicitly
+        raise TypeError(f"Unsupported ttl type: {type(ttl)!r}")
+    if isinstance(ttl, (int, float)):
+        return float(ttl)
+    if isinstance(ttl, str):
+        s = ttl.strip().lower()
+        if len(s) >= 2:
+            unit = s[-1]
+            number_part = s[:-1]
+            if unit in _TTL_UNIT_SECONDS:
+                try:
+                    value = float(number_part)
+                except ValueError:
+                    pass
+                else:
+                    return value * _TTL_UNIT_SECONDS[unit]
+        raise ValueError(
+            f"Invalid ttl string {ttl!r}: expected a number followed by "
+            "'s' (seconds), 'm' (minutes), 'h' (hours), or 'd' (days), "
+            "e.g. '30m', '24h', '7d'."
+        )
+    raise TypeError(f"Unsupported ttl type: {type(ttl)!r}")
+
+
+# ============================================================================
+# Public config / stats types
+# ============================================================================
+
+
+@dataclass
+class ResponseCache:
+    """Configuration for a persistent, cross-job response cache.
+
+    Parameters
+    ----------
+    path : str or Path
+        Sidecar directory holding the cache's Parquet parts + metadata
+        (same on-disk layout as `polar_llama.checkpoint.Checkpoint` --
+        see `ResponseCacheStore`). Created if it doesn't already exist.
+    ttl : str, int, float, timedelta, or None
+        How long a cached entry stays servable. `None` (default) means
+        entries never expire. A number is seconds; a string is
+        `"<number><unit>"` with unit `s`/`m`/`h`/`d` (e.g. `"24h"`).
+        Enforced lazily on read (`ResponseCacheStore.load_index`) -- an
+        expired entry sits inert on disk until `prune()` reclaims it.
+    on_mismatch : {"restart", "error"}
+        What to do when the store's recorded fingerprint doesn't match the
+        current run's configuration. Same semantics as
+        `polar_llama.checkpoint.Checkpoint.on_mismatch`: content keys embed
+        the fingerprint already, so `"restart"` (default) is nearly a
+        no-op -- old entries simply can never match new keys.
+
+    Passing `response_cache=` to `inference_async`/`inference_messages`
+    implies in-run dedupe (`dedupe=True`) automatically -- computing content
+    keys to consult the store already does the grouping work, so serving a
+    cache without also collapsing in-batch duplicates would be wasteful.
+    """
+
+    path: Union[str, Path]
+    ttl: Optional[Union[str, int, float, datetime.timedelta]] = None
+    on_mismatch: str = "restart"
+
+    def __post_init__(self) -> None:
+        self.path = Path(self.path)
+        if self.on_mismatch not in ("restart", "error"):
+            raise ValueError(
+                "ResponseCache.on_mismatch must be 'restart' or 'error', got "
+                f"{self.on_mismatch!r}"
+            )
+        _parse_ttl(self.ttl)  # validate eagerly -- fail at construction, not at collect
+
+    def clear(self) -> None:
+        """Delete every stored entry (full invalidation). `_meta.json` is left as-is."""
+        ResponseCacheStore.for_admin(self.path).clear()
+
+    def prune(self, now: Optional[datetime.datetime] = None) -> int:
+        """Compact the store: drop expired + superseded entries, rewrite as one part.
+
+        Expired entries (per `self.ttl`) and stale duplicates (an older
+        entry superseded by a newer one under the same key) are dropped;
+        the remainder is rewritten as a single new part file and the old
+        part files are deleted. Safe to call at any time -- it is pure
+        housekeeping, never required for correctness (TTL is already
+        enforced lazily on every read).
+
+        Returns
+        -------
+        int
+            Number of entries retained after compaction.
+        """
+        return ResponseCacheStore.for_admin(
+            self.path, ttl_seconds=_parse_ttl(self.ttl)
+        ).prune(now=now)
+
+
+@dataclass
+class DedupeStats:
+    """Mutable accumulator for in-run dedupe / response-cache aggregates.
+
+    Pass a fresh (or `.reset()`) instance as `dedupe_stats=` to
+    `inference_async`/`inference_messages`; it is updated in place (under an
+    internal lock, so it's safe to share across concurrently-collecting
+    LazyFrames) once per batch the underlying `map_batches` UDF processes.
+    Values only populate at *collect* time -- reading them before `.collect()`
+    (or `with_columns`, for an eager DataFrame) sees zeros. Re-collecting the
+    same LazyFrame accumulates again; call `.reset()` first if that's not
+    what you want.
+
+    Attributes
+    ----------
+    rows_total : int
+        Every row seen across all batches (including null rows).
+    rows_null : int
+        Null input rows (never hashed, never sent, never counted below).
+    cache_hits : int
+        Rows served from a persistent `response_cache` store.
+    rows_collapsed : int
+        Non-null, non-cache-hit rows that shared a content key with another
+        row in the same batch and so were folded into that row's single
+        call (i.e. computed rows minus unique calls made).
+    calls_made : int
+        Unique requests actually sent to the backend.
+    """
+
+    rows_total: int = 0
+    rows_null: int = 0
+    cache_hits: int = 0
+    rows_collapsed: int = 0
+    calls_made: int = 0
+    _lock: threading.Lock = field(
+        default_factory=threading.Lock, repr=False, compare=False
+    )
+
+    @property
+    def saved_calls(self) -> int:
+        """Total calls avoided: persistent cache hits plus in-run collapses."""
+        return self.cache_hits + self.rows_collapsed
+
+    @property
+    def hit_rate(self) -> float:
+        """`saved_calls / max(non-null rows seen, 1)`."""
+        denom = max(self.rows_total - self.rows_null, 1)
+        return self.saved_calls / denom
+
+    def estimated_savings(self, avg_cost_per_call: float) -> float:
+        """Estimate USD saved: `saved_calls * avg_cost_per_call`."""
+        return self.saved_calls * avg_cost_per_call
+
+    def reset(self) -> None:
+        """Zero every counter (thread-safe)."""
+        with self._lock:
+            self.rows_total = 0
+            self.rows_null = 0
+            self.cache_hits = 0
+            self.rows_collapsed = 0
+            self.calls_made = 0
+
+
+# ============================================================================
+# Persistent store: thin subclass of CheckpointStore
+# ============================================================================
+
+
+class ResponseCacheStore(CheckpointStore):
+    """`CheckpointStore` + TTL-on-read filtering + manual invalidation.
+
+    Reuses the parent's Parquet-part layout, atomic writes, fingerprint
+    filtering, and latest-`ts`-wins read-side dedup verbatim -- cross-job
+    reuse needs exactly what checkpoint resume already built. See the
+    `polar_llama.checkpoint.CheckpointStore` docstring for the on-disk
+    layout.
+    """
+
+    def __init__(
+        self,
+        path: Union[str, Path],
+        fingerprint: Optional[str],
+        on_mismatch: str = "restart",
+        fingerprint_inputs: Optional[Dict[str, Any]] = None,
+        ttl_seconds: Optional[float] = None,
+    ) -> None:
+        super().__init__(
+            path, fingerprint, on_mismatch, fingerprint_inputs=fingerprint_inputs
+        )
+        self.ttl_seconds = ttl_seconds
+
+    @classmethod
+    def for_admin(
+        cls, path: Union[str, Path], ttl_seconds: Optional[float] = None
+    ) -> "ResponseCacheStore":
+        """Construct a store for `clear()`/`prune()` -- not tied to any run's
+        fingerprint (`fingerprint=None`), so `_meta.json` is left untouched.
+        """
+        return cls(path, fingerprint=None, ttl_seconds=ttl_seconds)
+
+    def load_index(
+        self, ttl_seconds: Optional[float] = None
+    ) -> Dict[str, Tuple[bool, str]]:
+        """Load the index, TTL-filtered.
+
+        `ttl_seconds` overrides `self.ttl_seconds` when explicitly passed;
+        otherwise the store's own configured TTL applies.
+        """
+        effective_ttl = ttl_seconds if ttl_seconds is not None else self.ttl_seconds
+        return super().load_index(ttl_seconds=effective_ttl)
+
+    def prune(self, now: Optional[datetime.datetime] = None) -> int:
+        """Drop expired + superseded entries, compact to a single part file.
+
+        Reads every part, drops entries older than `self.ttl_seconds` (if
+        set), keeps only the latest `ts` per key -- across **all**
+        fingerprints, so other jobs' (or other configs') entries sharing
+        this directory survive -- and rewrites the survivors as one new
+        part before deleting the old parts. Returns the number of entries
+        kept.
+        """
+        parts = self._part_paths()
+        if not parts:
+            return 0
+
+        frames = []
+        for p in parts:
+            try:
+                frames.append(pl.read_parquet(p))
+            except Exception:
+                continue  # same defensive skip as load_index
+        if not frames:
+            return 0
+
+        df = pl.concat(frames, how="vertical_relaxed")
+
+        if self.ttl_seconds is not None:
+            cutoff = (now or _now_utc()) - datetime.timedelta(seconds=self.ttl_seconds)
+            df = df.filter(pl.col("ts") >= cutoff)
+
+        if df.height == 0:
+            for p in parts:
+                p.unlink(missing_ok=True)
+            return 0
+
+        # Keep latest ts per key (ties prefer ok=True), same rule as
+        # load_index -- but across every fingerprint present in this
+        # directory, not just self.fingerprint.
+        df = df.sort(["key", "ts", "ok"])
+        df = df.group_by("key", maintain_order=True).tail(1)
+
+        part_name = f"part-{uuid.uuid4().hex}.parquet"
+        final_path = self.path / part_name
+        tmp_path = self.path / (part_name + ".tmp")
+        df.write_parquet(tmp_path)
+        os.replace(tmp_path, final_path)
+
+        for p in parts:
+            p.unlink(missing_ok=True)
+
+        return df.height
+
+    def clear(self) -> None:
+        """Delete every part file (full invalidation). `_meta.json` untouched."""
+        for p in self._part_paths():
+            p.unlink(missing_ok=True)
+
+
+# ============================================================================
+# The expression wrapper
+# ============================================================================
+
+
+def deduped_expr(
+    expr: pl.Expr,
+    *,
+    run_pending: Callable[[pl.Series], pl.Series],
+    fingerprint: str,
+    canonicalize: Optional[Callable[[Any], str]] = None,
+    store: Optional[ResponseCacheStore] = None,
+    ttl_seconds: Optional[float] = None,
+    stats: Optional[DedupeStats] = None,
+    has_schema: bool = False,
+) -> pl.Expr:
+    """Wrap `expr` (the raw input column) with in-run dedupe (+ optional
+    persistent response cache).
+
+    Parameters
+    ----------
+    expr
+        The expression producing each row's *input* to inference -- same
+        contract as `checkpoint.checkpointed_expr`.
+    run_pending
+        Callable performing the actual inference: given a `pl.Series` of
+        the batch's unique pending inputs, returns a same-length, same-order
+        `pl.Series` of raw output strings. Unlike checkpointing, this is
+        called **once per batch** (no chunking) -- there is no
+        crash-durability contract here, and the Rust plugin already
+        parallelizes internally.
+    fingerprint
+        Run-configuration fingerprint, embedded in every content key.
+    canonicalize
+        Optional row-value-to-hashable-string mapper (see `plan_collapse`).
+    store
+        A `ResponseCacheStore`, or `None` for in-run-only dedupe (zero I/O
+        beyond the inference calls themselves).
+    ttl_seconds
+        TTL passed to `store.load_index()` each batch. Ignored if `store`
+        is `None`.
+    stats
+        Optional `DedupeStats` accumulator, updated (lock-guarded) once per
+        batch.
+    has_schema
+        Whether a `response_model` schema was requested -- passed through to
+        `checkpoint._is_error_row` so only genuinely successful results are
+        ever persisted to `store` (a failed row must recompute next run,
+        never be cached as if it were a real answer).
+
+    Returns
+    -------
+    A lazy `pl.Expr` (`expr.map_batches(...)`), usable exactly like the
+    un-wrapped inference expression.
+    """
+
+    def _udf(s: pl.Series) -> pl.Series:
+        dtype = s.dtype
+        raw_inputs: List[Any] = s.to_list()
+        n = len(raw_inputs)
+        n_null = sum(1 for v in raw_inputs if v is None)
+
+        index = store.load_index(ttl_seconds=ttl_seconds) if store is not None else None
+
+        # response_cache/dedupe never serves a stored failure -- a transient
+        # error must recompute, never be replayed as a real answer.
+        plan: CollapsePlan = plan_collapse(
+            raw_inputs,
+            fingerprint,
+            canonicalize=canonicalize,
+            index=index,
+            serve_failed=False,
+        )
+
+        n_pending = len(plan.unique_pending_keys)
+        if n_pending:
+            pending_series = pl.Series(plan.unique_pending_inputs, dtype=dtype)
+            result_series = run_pending(pending_series)
+            chunk_raws: List[Optional[str]] = result_series.to_list()
+
+            fan_out(plan, plan.unique_pending_keys, chunk_raws)
+
+            if store is not None:
+                ok_keys: List[str] = []
+                ok_raws: List[Optional[str]] = []
+                ok_flags: List[bool] = []
+                ok_errors: List[Optional[str]] = []
+                for key, raw in zip(plan.unique_pending_keys, chunk_raws):
+                    is_err, _err_type = _is_error_row(raw, has_schema)
+                    if not is_err:
+                        ok_keys.append(key)
+                        ok_raws.append(raw)
+                        ok_flags.append(True)
+                        ok_errors.append(None)
+                store.append(ok_keys, ok_raws, ok_flags, ok_errors)
+
+        # Non-null, non-cache-hit rows that shared a pending key with at
+        # least one other row -- i.e. rows folded into another row's call.
+        rows_collapsed = sum(
+            len(positions) - 1 for positions in plan.key_to_positions.values()
+        )
+
+        if stats is not None:
+            with stats._lock:
+                stats.rows_total += n
+                stats.rows_null += n_null
+                stats.cache_hits += plan.n_hits
+                stats.rows_collapsed += rows_collapsed
+                stats.calls_made += n_pending
+
+        logger.debug(
+            "polar_llama.dedup: rows_total=%d rows_null=%d cache_hits=%d "
+            "rows_collapsed=%d calls_made=%d",
+            n,
+            n_null,
+            plan.n_hits,
+            rows_collapsed,
+            n_pending,
+        )
+
+        return pl.Series(s.name, plan.results, dtype=pl.Utf8)
+
+    return expr.map_batches(_udf, return_dtype=pl.Utf8)

--- a/polar_llama/keys.py
+++ b/polar_llama/keys.py
@@ -24,7 +24,8 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-from typing import Any, Optional
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import polars as pl
 
@@ -212,3 +213,169 @@ def canonicalize_messages_input(v: Any) -> str:
         # List(Struct) column via `Series.to_list()`.
         parsed = v
     return json.dumps(parsed, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+# ============================================================================
+# Shared collapse-by-content-key bookkeeping (issue #75 checkpointing and
+# issue #77 dedupe/response-cache both need exactly this bookkeeping; kept
+# here, not in `checkpoint.py`, so #77 can import it without pulling in any
+# checkpoint-store I/O -- see the module docstring).
+# ============================================================================
+
+
+@dataclass
+class CollapsePlan:
+    """The result of grouping a batch's rows by content key.
+
+    Attributes
+    ----------
+    keys
+        Per-row content key, same length/order as the input; `None` for a
+        null row.
+    results
+        Pre-filled per-row results: an index hit's `result_raw` for rows
+        already resolved, `None` for every row still pending (or null).
+        Callers fill in the remaining `None` entries via :func:`fan_out`
+        after computing results for `unique_pending_keys`.
+    unique_pending_keys
+        Distinct keys not resolved by `index`, in first-occurrence order.
+    unique_pending_inputs
+        The *original* (not canonicalized) row value for each entry in
+        `unique_pending_keys`, same order/length -- what an inference call
+        should actually be run on.
+    key_to_positions
+        For every pending key, every row position (in the original batch)
+        that shares it -- including the first occurrence. Used by
+        :func:`fan_out` to broadcast one computed result to every row that
+        asked for it.
+    n_hits
+        Count of rows served directly from `index` (never sent to
+        `unique_pending_keys`).
+    """
+
+    keys: List[Optional[str]]
+    results: List[Optional[str]]
+    unique_pending_keys: List[str]
+    unique_pending_inputs: List[Any]
+    key_to_positions: Dict[str, List[int]] = field(default_factory=dict)
+    n_hits: int = 0
+
+
+def plan_collapse(
+    raw_inputs: List[Any],
+    fingerprint: str,
+    *,
+    canonicalize: Optional[Callable[[Any], str]] = None,
+    index: Optional[Dict[str, Tuple[bool, str]]] = None,
+    serve_failed: bool = False,
+) -> CollapsePlan:
+    """Group `raw_inputs` by content key and split into hits vs. pending.
+
+    Pure/in-memory -- performs no I/O and calls nothing that does. This is
+    the exact bookkeeping `checkpoint._udf` (issue #75) does inline; it is
+    extracted here so `dedup.py` (issue #77) can reuse it byte-for-byte,
+    with `checkpoint.py` refactored to call it instead of duplicating the
+    logic (see `checkpoint.checkpointed_expr`).
+
+    Parameters
+    ----------
+    raw_inputs
+        Row values in original order (e.g. `Series.to_list()`); a `None`
+        entry is a null row and is never hashed, never a hit, never pending.
+    fingerprint
+        Run-configuration fingerprint (`config_fingerprint`) folded into
+        every content key.
+    canonicalize
+        Optional function mapping a raw row value to the string that gets
+        hashed. `None` means the row value is already a hashable string.
+    index
+        Optional `key -> (ok, result_raw)` lookup (e.g. a checkpoint or
+        response-cache store's loaded index). `None`/empty means nothing is
+        pre-resolved -- every non-null row becomes pending.
+    serve_failed
+        Whether a stored `ok=False` entry counts as a hit (served as-is,
+        never re-requested) or is treated as still-pending (re-requested).
+        Checkpoint passes `not checkpoint.retry_failed`; dedupe and the
+        response cache always pass `False` -- a transient failure should
+        never be persisted or replayed as if it were a real answer.
+
+    Returns
+    -------
+    CollapsePlan
+        See the dataclass docstring. Every pending key's `unique_pending_inputs`
+        entry must be run (in whatever chunking the caller prefers) and its
+        result fanned back out via :func:`fan_out`.
+
+    Examples
+    --------
+    >>> plan = plan_collapse(["a", "b", "a", None], "fp")
+    >>> plan.unique_pending_keys == [plan.keys[0], plan.keys[1]]
+    True
+    >>> plan.unique_pending_inputs
+    ['a', 'b']
+    >>> sorted(plan.key_to_positions[plan.keys[0]])
+    [0, 2]
+    >>> plan.results  # nothing resolved yet -- null row stays null
+    [None, None, None, None]
+    """
+    n = len(raw_inputs)
+    keys: List[Optional[str]] = [None] * n
+    for i, v in enumerate(raw_inputs):
+        if v is None:
+            continue
+        hash_source = canonicalize(v) if canonicalize is not None else v
+        keys[i] = content_key(hash_source, fingerprint)
+
+    results: List[Optional[str]] = [None] * n
+    unique_pending_keys: List[str] = []
+    unique_pending_inputs: List[Any] = []
+    seen_pending: Dict[str, int] = {}
+    key_to_positions: Dict[str, List[int]] = {}
+    n_hits = 0
+
+    idx = index or {}
+    for i, key in enumerate(keys):
+        if key is None:
+            continue  # null row: passes through as null, never stored
+        hit = idx.get(key)
+        if hit is not None:
+            ok, stored_raw = hit
+            if ok or serve_failed:
+                results[i] = stored_raw
+                n_hits += 1
+                continue
+        key_to_positions.setdefault(key, []).append(i)
+        if key not in seen_pending:
+            seen_pending[key] = len(unique_pending_keys)
+            unique_pending_keys.append(key)
+            unique_pending_inputs.append(raw_inputs[i])
+
+    return CollapsePlan(
+        keys=keys,
+        results=results,
+        unique_pending_keys=unique_pending_keys,
+        unique_pending_inputs=unique_pending_inputs,
+        key_to_positions=key_to_positions,
+        n_hits=n_hits,
+    )
+
+
+def fan_out(
+    plan: CollapsePlan, chunk_keys: List[str], chunk_raws: List[Optional[str]]
+) -> None:
+    """Write each chunk result into `plan.results` at every position sharing its key.
+
+    Mutates `plan.results` in place. `chunk_keys`/`chunk_raws` are a
+    same-length, same-order pair -- typically a whole or partial slice of
+    `plan.unique_pending_keys` and the corresponding `run_pending` output.
+
+    Examples
+    --------
+    >>> plan = plan_collapse(["a", "b", "a"], "fp")
+    >>> fan_out(plan, plan.unique_pending_keys, ["OUT:a", "OUT:b"])
+    >>> plan.results
+    ['OUT:a', 'OUT:b', 'OUT:a']
+    """
+    for key, raw in zip(chunk_keys, chunk_raws):
+        for pos in plan.key_to_positions[key]:
+            plan.results[pos] = raw

--- a/tests/test_dedupe_cache.py
+++ b/tests/test_dedupe_cache.py
@@ -1,0 +1,755 @@
+#!/usr/bin/env python3
+"""
+Test suite for in-run dedupe / persistent response caching (issue #77).
+
+Layered the same way as `tests/test_checkpointing.py`:
+
+- Unit-level tests drive `polar_llama.dedup.deduped_expr` directly with a
+  hand-written `run_pending` stub -- no network, no API keys, no mlx.
+- An end-to-end test drives the real `inference_async(..., dedupe=True)`
+  wiring against a local stdlib mock OpenAI-compatible HTTP server (same
+  `ThreadingHTTPServer` pattern as `test_checkpointing.py`).
+- A gated real-API proof sits at the bottom, skipped unless `OPENAI_API_KEY`
+  is set.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Callable
+
+import polars as pl
+import pytest
+from pydantic import BaseModel
+
+from polar_llama import (
+    Checkpoint,
+    DedupeStats,
+    Provider,
+    ResponseCache,
+    inference_async,
+    inference_messages,
+)
+from polar_llama.checkpoint import CheckpointStore
+from polar_llama.dedup import ResponseCacheStore, _parse_ttl, deduped_expr
+from polar_llama.keys import config_fingerprint, content_key
+
+# ============================================================================
+# TTL parsing
+# ============================================================================
+
+
+def test_parse_ttl_accepts_all_shapes():
+    assert _parse_ttl(None) is None
+    assert _parse_ttl(90) == 90.0
+    assert _parse_ttl(90.5) == 90.5
+    assert _parse_ttl(datetime.timedelta(minutes=2)) == 120.0
+    assert _parse_ttl("30m") == 1800.0
+    assert _parse_ttl("24h") == 86400.0
+    assert _parse_ttl("7d") == 604800.0
+    assert _parse_ttl("45s") == 45.0
+
+
+def test_parse_ttl_rejects_bad_strings():
+    with pytest.raises(ValueError):
+        _parse_ttl("bogus")
+    with pytest.raises(ValueError):
+        _parse_ttl("10x")
+
+
+def test_response_cache_validates_ttl_at_construction(tmp_path):
+    with pytest.raises(ValueError):
+        ResponseCache(tmp_path / "rc", ttl="not-a-ttl")
+
+
+# ============================================================================
+# Unit tests -- deduped_expr with a stub run_pending, no store
+# ============================================================================
+
+
+def _make_counting_stub(counter: dict) -> Callable[[pl.Series], pl.Series]:
+    def run_pending(s: pl.Series) -> pl.Series:
+        seen = []
+        for v in s.to_list():
+            counter["n"] += 1
+            seen.append(f"OUT:{v}")
+        return pl.Series(seen, dtype=pl.Utf8)
+
+    return run_pending
+
+
+def test_forty_percent_duplicate_acceptance():
+    # 100 rows, 60 unique values -> exactly 60 calls, 40 collapsed.
+    counter = {"n": 0}
+    stats = DedupeStats()
+    fp = "fp-dedupe-40pct"
+
+    unique_values = [f"v{i}" for i in range(60)]
+    # First 60 rows are the unique values themselves; the remaining 40 rows
+    # repeat the first 40 unique values.
+    values = unique_values + unique_values[:40]
+    df = pl.DataFrame({"prompt": values})
+
+    expr = deduped_expr(
+        pl.col("prompt"),
+        run_pending=_make_counting_stub(counter),
+        fingerprint=fp,
+        stats=stats,
+    )
+    out = df.with_columns(out=expr)
+
+    assert out["out"].to_list() == [f"OUT:{v}" for v in values]
+    assert counter["n"] == 60
+    assert stats.calls_made == 60
+    assert stats.rows_collapsed == 40
+    assert stats.rows_total == 100
+    assert stats.rows_null == 0
+    assert stats.cache_hits == 0
+
+
+def test_result_identity_deduped_matches_undeduped():
+    fp = "fp-identity"
+    values = (["alpha"] * 5) + (["beta"] * 4) + (["gamma"] * 3) + ["delta"]
+    df = pl.DataFrame({"prompt": values})
+
+    def deterministic(s: pl.Series) -> pl.Series:
+        return pl.Series([f"out:{v}" for v in s.to_list()], dtype=pl.Utf8)
+
+    undeduped = df.with_columns(
+        out=pl.col("prompt").map_batches(deterministic, return_dtype=pl.Utf8)
+    )
+
+    deduped = df.with_columns(
+        out=deduped_expr(pl.col("prompt"), run_pending=deterministic, fingerprint=fp)
+    )
+
+    assert deduped["out"].to_list() == undeduped["out"].to_list()
+
+
+def test_order_and_null_preservation():
+    counter = {"n": 0}
+    fp = "fp-order-null"
+    values = ["a", None, "b", "a", None, "c", "b"]
+    df = pl.DataFrame({"prompt": values})
+
+    stats = DedupeStats()
+    expr = deduped_expr(
+        pl.col("prompt"),
+        run_pending=_make_counting_stub(counter),
+        fingerprint=fp,
+        stats=stats,
+    )
+    out = df.with_columns(out=expr)
+
+    assert out["out"].to_list() == [
+        "OUT:a",
+        None,
+        "OUT:b",
+        "OUT:a",
+        None,
+        "OUT:c",
+        "OUT:b",
+    ]
+    # 3 unique non-null values -> 3 calls.
+    assert counter["n"] == 3
+    assert stats.rows_total == 7
+    assert stats.rows_null == 2
+    assert stats.calls_made == 3
+    assert stats.rows_collapsed == 2  # "a" and "b" each appear twice
+
+
+def test_stats_correctness_invariant():
+    counter = {"n": 0}
+    fp = "fp-stats-invariant"
+    values = ["a", "b", "a", None, "c", "b", "b", None]
+    df = pl.DataFrame({"prompt": values})
+
+    stats = DedupeStats()
+    expr = deduped_expr(
+        pl.col("prompt"),
+        run_pending=_make_counting_stub(counter),
+        fingerprint=fp,
+        stats=stats,
+    )
+    df.with_columns(out=expr)
+
+    assert stats.rows_total == 8
+    assert stats.rows_null == 2
+    assert stats.cache_hits == 0
+    # unique non-null values: a, b, c -> 3 calls
+    assert stats.calls_made == 3
+    # non-null rows (6) minus unique calls (3) = 3 collapsed
+    assert stats.rows_collapsed == 3
+    assert stats.saved_calls == stats.cache_hits + stats.rows_collapsed == 3
+    non_null = stats.rows_total - stats.rows_null
+    assert stats.hit_rate == stats.saved_calls / non_null
+
+
+def test_stats_reset():
+    stats = DedupeStats()
+    stats.rows_total = 10
+    stats.calls_made = 5
+    stats.reset()
+    assert stats.rows_total == 0
+    assert stats.calls_made == 0
+    assert stats.cache_hits == 0
+    assert stats.rows_collapsed == 0
+    assert stats.rows_null == 0
+
+
+# ============================================================================
+# Persistent response_cache store -- unit tests against deduped_expr + store
+# ============================================================================
+
+
+def test_persistent_cache_hit_across_two_calls(tmp_path):
+    fp = "fp-persist"
+    path = tmp_path / "rcache"
+    df = pl.DataFrame({"prompt": [f"row-{i}" for i in range(10)]})
+
+    counter = {"n": 0}
+    store1 = ResponseCacheStore(path, fp)
+    stats1 = DedupeStats()
+    expr1 = deduped_expr(
+        pl.col("prompt"),
+        run_pending=_make_counting_stub(counter),
+        fingerprint=fp,
+        store=store1,
+        stats=stats1,
+    )
+    out1 = df.with_columns(out=expr1)
+    assert counter["n"] == 10
+    assert stats1.cache_hits == 0
+    assert stats1.calls_made == 10
+
+    # Run 2: a fresh store handle over the same directory, with a stub that
+    # would raise if ever called -- everything should be served from disk.
+    def _boom(s: pl.Series) -> pl.Series:
+        raise AssertionError("run_pending should not be called -- fully cached")
+
+    store2 = ResponseCacheStore(path, fp)
+    stats2 = DedupeStats()
+    expr2 = deduped_expr(
+        pl.col("prompt"), run_pending=_boom, fingerprint=fp, store=store2, stats=stats2
+    )
+    out2 = df.with_columns(out=expr2)
+
+    assert out2["out"].to_list() == out1["out"].to_list()
+    assert stats2.cache_hits == 10
+    assert stats2.calls_made == 0
+    assert stats2.rows_collapsed == 0
+
+
+def test_failed_results_are_not_persisted(tmp_path):
+    fp = "fp-fail-not-cached"
+    path = tmp_path / "rcache"
+    df = pl.DataFrame({"prompt": ["good", "bad"]})
+
+    def flaky(s: pl.Series) -> pl.Series:
+        out = []
+        for v in s.to_list():
+            if v == "bad":
+                out.append(json.dumps({"_error": "api_error", "_details": "boom"}))
+            else:
+                out.append(f"OUT:{v}")
+        return pl.Series(out, dtype=pl.Utf8)
+
+    store = ResponseCacheStore(path, fp)
+    out = df.with_columns(
+        out=deduped_expr(
+            pl.col("prompt"),
+            run_pending=flaky,
+            fingerprint=fp,
+            store=store,
+            has_schema=True,
+        )
+    )
+    assert out["out"][0] == "OUT:good"
+    assert json.loads(out["out"][1])["_error"] == "api_error"
+
+    index = store.load_index()
+    assert len(index) == 1  # only "good" persisted
+    assert content_key("good", fp) in index
+    assert content_key("bad", fp) not in index
+
+    # Resume: "bad" must be re-requested (not silently served as if cached);
+    # "good" must not be.
+    seen = []
+
+    def healthy(s: pl.Series) -> pl.Series:
+        vals = s.to_list()
+        seen.extend(vals)
+        return pl.Series([f"OUT:{v}" for v in vals], dtype=pl.Utf8)
+
+    store2 = ResponseCacheStore(path, fp)
+    out2 = df.with_columns(
+        out=deduped_expr(
+            pl.col("prompt"),
+            run_pending=healthy,
+            fingerprint=fp,
+            store=store2,
+            has_schema=True,
+        )
+    )
+    assert out2["out"].to_list() == ["OUT:good", "OUT:bad"]
+    assert seen == ["bad"]
+
+
+def test_ttl_expiry_and_manual_invalidation(tmp_path):
+    fp = "fp-ttl"
+    path = tmp_path / "rcache"
+
+    store = ResponseCacheStore(path, fp)
+    store.append(["k1"], ["OUT:v1"], [True], [None])
+
+    # Fresh (unexpired): a 1-hour ttl should still see it.
+    idx = store.load_index(ttl_seconds=3600)
+    assert "k1" in idx
+
+    # Backdate the entry beyond a short ttl by rewriting the part file's
+    # `ts` column directly (simulating time having passed).
+    part_files = store._part_paths()
+    assert len(part_files) == 1
+    old_df = pl.read_parquet(part_files[0])
+    backdated = old_df.with_columns(
+        ts=pl.lit(
+            datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=2),
+            dtype=pl.Datetime("us", "UTC"),
+        )
+    )
+    backdated.write_parquet(part_files[0])
+
+    # A 1-hour ttl now treats the entry as expired -> pending, not a hit.
+    idx_expired = store.load_index(ttl_seconds=3600)
+    assert "k1" not in idx_expired
+
+    # No ttl (None) -> the entry is still visible regardless of age.
+    idx_no_ttl = store.load_index(ttl_seconds=None)
+    assert "k1" in idx_no_ttl
+
+    # A deduped_expr run against the expired entry recomputes.
+    def stub(s: pl.Series) -> pl.Series:
+        return pl.Series([f"RECOMPUTED:{v}" for v in s.to_list()], dtype=pl.Utf8)
+
+    df = pl.DataFrame({"prompt": ["v1"]})
+    out = df.with_columns(
+        out=deduped_expr(
+            pl.col("prompt"),
+            run_pending=stub,
+            fingerprint=fp,
+            store=ResponseCacheStore(path, fp, ttl_seconds=3600),
+        )
+    )
+    assert out["out"][0] == "RECOMPUTED:v1"
+
+    # ResponseCache.clear() empties the store entirely.
+    rc = ResponseCache(path)
+    rc.clear()
+    assert ResponseCacheStore(path, fp).load_index() == {}
+
+
+def test_prune_drops_expired_and_compacts(tmp_path):
+    path = tmp_path / "rcache"
+    fp = "fp-prune"
+    store = ResponseCacheStore(path, fp)
+
+    store.append(["k1"], ["OUT:v1"], [True], [None])
+    store.append(["k2"], ["OUT:v2"], [True], [None])
+    assert len(store._part_paths()) == 2
+
+    # Backdate k1 beyond a 1-hour ttl; leave k2 fresh.
+    for p in store._part_paths():
+        df = pl.read_parquet(p)
+        if df["key"][0] == "k1":
+            df = df.with_columns(
+                ts=pl.lit(
+                    datetime.datetime.now(datetime.timezone.utc)
+                    - datetime.timedelta(hours=2),
+                    dtype=pl.Datetime("us", "UTC"),
+                )
+            )
+            df.write_parquet(p)
+
+    rc = ResponseCache(path, ttl="1h")
+    kept = rc.prune()
+    assert kept == 1
+
+    remaining_store = ResponseCacheStore(path, fp)
+    remaining_parts = remaining_store._part_paths()
+    assert len(remaining_parts) == 1  # compacted to a single part
+    index = remaining_store.load_index()
+    assert "k2" in index
+    assert "k1" not in index
+
+
+def test_fingerprint_change_yields_zero_stale_hits(tmp_path):
+    path = tmp_path / "rcache"
+    store_a = ResponseCacheStore(path, "fp-a")
+    store_a.append(["irrelevant"], ["OUT:x"], [True], [None])
+
+    def stub(s: pl.Series) -> pl.Series:
+        return pl.Series([f"OUT:{v}" for v in s.to_list()], dtype=pl.Utf8)
+
+    df = pl.DataFrame({"prompt": ["hello"]})
+    stats = DedupeStats()
+    out = df.with_columns(
+        out=deduped_expr(
+            pl.col("prompt"),
+            run_pending=stub,
+            fingerprint="fp-b",  # different config -> different fingerprint
+            store=ResponseCacheStore(path, "fp-b"),
+            stats=stats,
+        )
+    )
+    assert out["out"][0] == "OUT:hello"
+    assert stats.cache_hits == 0  # no stale hit despite sharing the directory
+
+
+# ============================================================================
+# response_model struct fan-back
+# ============================================================================
+
+
+class _Recommendation(BaseModel):
+    title: str
+    year: int
+
+
+def test_response_model_struct_fan_back_identical_across_duplicates():
+    fp = "fp-struct-fanback"
+    values = ["Alpha", "Beta", "Alpha", "Alpha"]
+    df = pl.DataFrame({"prompt": values})
+
+    def stub(s: pl.Series) -> pl.Series:
+        return pl.Series(
+            [json.dumps({"title": v, "year": 2024}) for v in s.to_list()],
+            dtype=pl.Utf8,
+        )
+
+    struct_dtype = pl.Struct({"title": pl.Utf8, "year": pl.Int64})
+    from polar_llama import _parse_json_to_struct  # internal, but stable enough to test
+
+    raw_expr = deduped_expr(pl.col("prompt"), run_pending=stub, fingerprint=fp)
+    out = df.with_columns(
+        rec=raw_expr.map_batches(
+            lambda s: _parse_json_to_struct(s, struct_dtype), return_dtype=struct_dtype
+        )
+    )
+    recs = out["rec"].to_list()
+    assert recs[0] == {"title": "Alpha", "year": 2024}
+    assert recs[2] == recs[0]
+    assert recs[3] == recs[0]
+    assert recs[1] == {"title": "Beta", "year": 2024}
+
+
+# ============================================================================
+# Interop rules
+# ============================================================================
+
+
+def test_response_cache_and_checkpoint_raises(tmp_path):
+    df = pl.DataFrame({"prompt": ["a"]})
+    with pytest.raises(ValueError, match="response_cache"):
+        df.with_columns(
+            out=inference_async(
+                pl.col("prompt"),
+                model="m",
+                checkpoint=Checkpoint(tmp_path / "ckpt"),
+                response_cache=ResponseCache(tmp_path / "rcache"),
+            )
+        )
+
+
+def test_response_cache_and_usage_raises(tmp_path):
+    df = pl.DataFrame({"prompt": ["a"]})
+    with pytest.raises(ValueError, match="response_cache"):
+        df.with_columns(
+            out=inference_async(
+                pl.col("prompt"),
+                model="m",
+                usage=True,
+                response_cache=ResponseCache(tmp_path / "rcache"),
+            )
+        )
+
+
+def test_inference_messages_response_cache_and_checkpoint_raises(tmp_path):
+    df = pl.DataFrame({"msgs": [json.dumps([{"role": "user", "content": "hi"}])]})
+    with pytest.raises(ValueError, match="response_cache"):
+        df.with_columns(
+            out=inference_messages(
+                pl.col("msgs"),
+                model="m",
+                checkpoint=Checkpoint(tmp_path / "ckpt"),
+                response_cache=ResponseCache(tmp_path / "rcache"),
+            )
+        )
+
+
+def test_dedupe_and_checkpoint_does_not_raise_and_is_subsumed(
+    mock_server, monkeypatch, tmp_path
+):
+    server, base_url = mock_server
+    monkeypatch.setenv("OPENAI_BASE_URL", base_url)
+    ckpt_path = tmp_path / "run.ckpt"
+
+    df = pl.DataFrame({"prompt": ["a", "a", "b"]})
+    out = df.with_columns(
+        answer=inference_async(
+            pl.col("prompt"), model="m", checkpoint=ckpt_path, dedupe=True
+        )
+    )
+    # checkpoint already collapses duplicates on its own; dedupe=True is a
+    # harmless no-op alongside it (no raise, no double-collapsing artifact).
+    assert out["answer"].to_list() == ["ECHO:a", "ECHO:a", "ECHO:b"]
+    assert len(server.requests_received) == 2  # one call per unique prompt
+
+
+def test_dedupe_and_provider_cache_does_not_raise(mock_server, monkeypatch):
+    server, base_url = mock_server
+    monkeypatch.setenv("OPENAI_BASE_URL", base_url)
+
+    df = pl.DataFrame({"prompt": ["a", "a"]})
+    out = df.with_columns(
+        answer=inference_async(pl.col("prompt"), model="m", dedupe=True, cache=True)
+    )
+    assert out["answer"].to_list() == ["ECHO:a", "ECHO:a"]
+
+
+def test_dedupe_with_usage_duplicates_carry_identical_usage_struct(
+    mock_server, monkeypatch
+):
+    server, base_url = mock_server
+    monkeypatch.setenv("OPENAI_BASE_URL", base_url)
+
+    df = pl.DataFrame({"prompt": ["a", "a", "b"]})
+    out = df.with_columns(
+        answer=inference_async(pl.col("prompt"), model="m", dedupe=True, usage=True)
+    )
+    rows = out["answer"].to_list()
+    assert rows[0]["response"] == "ECHO:a"
+    assert rows[1]["response"] == "ECHO:a"
+    # Documented semantics: the collapsed duplicate carries the SAME usage
+    # struct as the row that was actually computed (only one API call was
+    # made for "a"), not a zeroed-out usage.
+    assert rows[0]["usage"] == rows[1]["usage"]
+    assert rows[0]["usage"] is not None
+    # Only 2 API calls were made (one per unique prompt), for 3 rows.
+    assert len(server.requests_received) == 2
+
+
+# ============================================================================
+# End-to-end: inference_async(dedupe=True) against a local mock server
+# ============================================================================
+
+
+class _MockOpenAIHandler(BaseHTTPRequestHandler):
+    def log_message(self, format, *args):  # noqa: A002
+        pass
+
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        raw = self.rfile.read(length) if length else b""
+        body = json.loads(raw.decode("utf-8")) if raw else {}
+
+        with self.server.lock:  # type: ignore[attr-defined]
+            self.server.requests_received.append(body)  # type: ignore[attr-defined]
+
+        status, content = self.server.responder(body)  # type: ignore[attr-defined]
+
+        if status != 200:
+            payload_bytes = json.dumps({"error": {"message": "mock failure"}}).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload_bytes)))
+            self.end_headers()
+            self.wfile.write(payload_bytes)
+            return
+
+        payload = {
+            "id": "chatcmpl-fake",
+            "model": body.get("model", "mock-model"),
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": content},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+        payload_bytes = json.dumps(payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload_bytes)))
+        self.end_headers()
+        self.wfile.write(payload_bytes)
+
+
+def _user_content(body: dict) -> str:
+    for msg in reversed(body.get("messages", [])):
+        if msg.get("role") == "user":
+            return msg.get("content", "")
+    return ""
+
+
+def _echo_responder(body: dict):
+    return 200, f"ECHO:{_user_content(body)}"
+
+
+@pytest.fixture
+def mock_server():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _MockOpenAIHandler)
+    server.lock = threading.Lock()
+    server.requests_received = []
+    server.responder = _echo_responder
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address[:2]
+        yield server, f"http://{host}:{port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+@pytest.fixture(autouse=True)
+def _mock_env(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    yield
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+
+def test_inference_async_dedupe_collapses_duplicate_requests(mock_server, monkeypatch):
+    server, base_url = mock_server
+    monkeypatch.setenv("OPENAI_BASE_URL", base_url)
+
+    # 40% duplicates: 10 unique prompts, repeated to 25 rows total (60% new
+    # + 40% repeats of the first 10).
+    unique_prompts = [f"row-{i}" for i in range(15)]
+    values = unique_prompts + unique_prompts[:10]  # 25 rows, 15 unique
+    df = pl.DataFrame({"prompt": values})
+
+    stats = DedupeStats()
+    out = df.with_columns(
+        answer=inference_async(
+            pl.col("prompt"), model="mock-model", dedupe=True, dedupe_stats=stats
+        )
+    )
+    assert out["answer"].to_list() == [f"ECHO:{p}" for p in values]
+    assert len(server.requests_received) == 15
+    assert stats.calls_made == 15
+    assert stats.rows_collapsed == 10
+
+
+def test_inference_async_response_cache_end_to_end(mock_server, monkeypatch, tmp_path):
+    server, base_url = mock_server
+    monkeypatch.setenv("OPENAI_BASE_URL", base_url)
+    rc = ResponseCache(tmp_path / "rcache")
+
+    df = pl.DataFrame({"prompt": [f"row-{i}" for i in range(5)]})
+    stats1 = DedupeStats()
+    out1 = df.with_columns(
+        answer=inference_async(
+            pl.col("prompt"),
+            model="mock-model",
+            response_cache=rc,
+            dedupe_stats=stats1,
+        )
+    )
+    assert len(server.requests_received) == 5
+    assert stats1.cache_hits == 0
+
+    # Second call, fresh DataFrame, same response_cache -- zero new requests.
+    stats2 = DedupeStats()
+    out2 = df.with_columns(
+        answer=inference_async(
+            pl.col("prompt"),
+            model="mock-model",
+            response_cache=rc,
+            dedupe_stats=stats2,
+        )
+    )
+    assert len(server.requests_received) == 5  # unchanged
+    assert stats2.cache_hits == 5
+    assert out2["answer"].to_list() == out1["answer"].to_list()
+
+
+def test_inference_messages_dedupe_shares_keys_across_input_shapes(
+    mock_server, monkeypatch
+):
+    server, base_url = mock_server
+    monkeypatch.setenv("OPENAI_BASE_URL", base_url)
+
+    conversation = [{"role": "user", "content": "hello"}]
+    df = pl.DataFrame(
+        {
+            "msgs": pl.Series(
+                [conversation, conversation],
+                dtype=pl.List(pl.Struct({"role": pl.Utf8, "content": pl.Utf8})),
+            )
+        }
+    )
+    out = df.with_columns(
+        answer=inference_messages(pl.col("msgs"), model="m", dedupe=True)
+    )
+    assert out["answer"].to_list() == ["ECHO:hello", "ECHO:hello"]
+    assert len(server.requests_received) == 1
+
+
+def test_dedupe_none_is_unchanged_behavior(mock_server, monkeypatch):
+    server, base_url = mock_server
+    monkeypatch.setenv("OPENAI_BASE_URL", base_url)
+
+    df = pl.DataFrame({"prompt": ["hi", "hi"]})
+    out = df.with_columns(answer=inference_async(pl.col("prompt"), model="m"))
+    # dedupe=False (default) is byte-identical to pre-#77: every row hits
+    # the backend independently, even exact duplicates.
+    assert out["answer"].to_list() == ["ECHO:hi", "ECHO:hi"]
+    assert len(server.requests_received) == 2
+
+
+# ============================================================================
+# Gated real-API smoke test
+# ============================================================================
+
+
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
+)
+def test_dedupe_real_openai_identical_to_uncached(tmp_path):
+    """End-to-end proof against the real OpenAI API.
+
+    Duplicated prompts at temperature 0 -- the deduped run's output must
+    equal an uncached run's output, and must have made fewer calls.
+    """
+    prompts = ["Reply with just the number 7."] * 3 + [
+        "Reply with just the number 8."
+    ] * 2
+    df = pl.DataFrame({"prompt": prompts})
+
+    uncached = df.with_columns(
+        answer=inference_async(
+            pl.col("prompt"),
+            provider=Provider.OPENAI,
+            model="gpt-4o-mini",
+        )
+    )
+
+    stats = DedupeStats()
+    deduped = df.with_columns(
+        answer=inference_async(
+            pl.col("prompt"),
+            provider=Provider.OPENAI,
+            model="gpt-4o-mini",
+            dedupe=True,
+            dedupe_stats=stats,
+        )
+    )
+
+    assert deduped["answer"].to_list() == uncached["answer"].to_list()
+    assert stats.calls_made < len(prompts)
+    assert stats.calls_made == 2


### PR DESCRIPTION
Closes #77. Ships as **0.6.3** (version bump + CHANGELOG included). Reuses the #75 hashing primitives + Parquet store.

## What
- **`dedupe=True`** — collapse exact-duplicate rows by content hash, infer only the unique rows, fan each result back to every row sharing its key (order + nulls preserved). A frame with 40% duplicate prompts makes ~60% of the API calls.
- **`response_cache="path"`** (implies dedupe) — a persistent cross-job cache reusing the checkpoint Parquet store, with TTL-on-read expiry and `ResponseCache.clear()` / `.prune()` manual invalidation.
- **`dedupe_stats=DedupeStats()`** — optional side channel (hit rate, rows collapsed, calls made, estimated savings); never touches the returned column.

Distinct from the existing `cache=` (provider prompt caching) and `checkpoint=` (resume) kwargs.

## How
The in-batch collapse bookkeeping shared with checkpointing is **extracted into `keys.py`** (`plan_collapse` / `fan_out`), and `checkpoint._udf` now calls it — behavior-preserving. Keyed by the same request fingerprint as #75 (prompt+system+model+params+schema+endpoint), so a stale-config hit can't happen.

## Adversarial review (Opus): **APPROVE**
- Shared-helper refactor behavior-preserving — `test_checkpointing.py` passes **unmodified** (36).
- Hash-key soundness confirmed: no per-row sampling param (temperature/max_tokens) exists that could wrongly collapse two different requests; the content key is the prompt itself.
- Diff is **feature-only** (no repo-wide reformat).

## Tests & proof
- `tests/test_dedupe_cache.py`: **24 pass, 1 gated** — 40%-dup→60% calls, identical-to-uncached, order/null preservation, `response_model` fan-back, cross-job cache hit, TTL expiry + clear/prune, stats correctness. No key/no mlx.
- `test_checkpointing.py`: **36 pass** after the refactor (no regression).
- **Verified live** on OpenAI: 10 rows / 6 unique → `calls_made=6, rows_collapsed=4` with duplicates byte-identical to their twin; `response_cache` second run = **0 calls** (all 10 from cache), identical results.

Interop: dedupe+`response_model` fans structs back; dedupe+`usage=True` carries identical usage structs (documented SUM caveat); `response_cache` + `checkpoint`/`usage` raise `ValueError`. Streaming out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnthn-ai/codesmith/polar_llama/pr/91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786607806&installation_id=141504833&pr_number=91&repository=pnthn-ai%2Fpolar_llama&return_to=https%3A%2F%2Fgithub.com%2Fpnthn-ai%2Fpolar_llama%2Fpull%2F91&signature=24018dbc6cba7ff2260971b15ca37d415d11b78d1e256316510d31d029e45aa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->