### PR TITLE
feat: inter-rater reliability metrics (Cohen's κ, Krippendorff's α) (#79) + release 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-07-14
+
+### Added
+- **Inter-rater reliability metrics** (`cohens_kappa`, `krippendorffs_alpha`, issue #79): DataFrame-shaped aggregation expressions -- `df.select(kappa=cohens_kappa("llm", "human"))`, `df.group_by("topic").agg(alpha=krippendorffs_alpha(["r1", "r2", "r3"]))` -- backed by pure, unit-tested Rust (`src/metrics.rs`, zero new dependencies). `cohens_kappa(a, b, weights=None|"linear"|"quadratic")` reproduces `sklearn.metrics.cohen_kappa_score` bit-for-bit (pairwise-complete rows, sklearn's label-*index* weighting convention, and its `NaN`-not-null convention when expected-by-chance agreement is zero). `krippendorffs_alpha(cols, level="nominal"|"ordinal"|"interval"|"ratio")` reproduces the `krippendorff` PyPI package's coincidence-matrix algorithm bit-for-bit on its own published fixtures, with nulls treated as missing ratings (units with fewer than 2 non-null ratings are excluded). Both accept `n_bootstrap=`/`ci=`/`seed=` for a nonparametric case-resampling bootstrap CI, returned as `Struct{value, ci_low, ci_high}` (`.struct.unnest()`); `n_bootstrap=None` (default) returns a plain `Float64`. Available as `.llama.cohens_kappa(...)` / `.llama.krippendorffs_alpha(...)` on expressions too. This is the first aggregation-shaped plugin expression in the package (`returns_scalar=True`, new in `polar_llama/utils.py::register_plugin`), so it composes with `.select()`, `group_by().agg()`, and lazy frames for free. Multi-label/set-valued codes (MASI) are deferred -- `docs/RELIABILITY_METRICS.md` documents two supported strategies (per-label binary alpha, exact-set nominal alpha) per the issue's "or documented strategy" acceptance arm. See `docs/RELIABILITY_METRICS.md`.
+
 ## [0.7.0] - 2026-07-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "polar-llama"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polar-llama"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 
 [lib]

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -20,6 +20,7 @@ Complete reference documentation for all Polar Llama expressions and functions.
   - [euclidean_distance](#euclidean_distance)
   - [knn_hnsw](#knn_hnsw)
   - [embedding_async](#embedding_async)
+  - [Inter-rater Reliability (cohens_kappa, krippendorffs_alpha)](#inter-rater-reliability)
 - [Data Types](#data-types)
 - [Error Handling](#error-handling)
 - [Examples](#examples)
@@ -1083,6 +1084,46 @@ df = df.with_columns(
         model="text-embedding-3-small"
     )
 )
+```
+
+---
+
+### Inter-rater Reliability
+
+Aggregation expressions (`returns_scalar=True`, not row-wise) for measuring
+agreement between raters/annotators/LLM judges: `cohens_kappa` (2 columns)
+and `krippendorffs_alpha` (M >= 2 columns), numerically pinned to
+`sklearn.metrics.cohen_kappa_score` and the `krippendorff` PyPI package
+respectively. Full guide, edge-case conventions, and the multi-label (MASI)
+decision: [RELIABILITY_METRICS.md](RELIABILITY_METRICS.md).
+
+```python
+cohens_kappa(
+    a: IntoExpr, b: IntoExpr, *,
+    weights: str | None = None,  # None | "linear" | "quadratic"
+    n_bootstrap: int | None = None, ci: float = 0.95, seed: int = 0,
+) -> pl.Expr
+
+krippendorffs_alpha(
+    cols: Sequence[IntoExpr], *,
+    level: str = "nominal",  # "nominal" | "ordinal" | "interval" | "ratio"
+    n_bootstrap: int | None = None, ci: float = 0.95, seed: int = 0,
+) -> pl.Expr
+```
+
+Both return `Float64` by default, or `Struct{value, ci_low, ci_high}` when
+`n_bootstrap` is given (unnest with `.struct.unnest()`). Because they are
+aggregations, they compose with `.select()` and `group_by().agg()`:
+
+```python
+df.select(kappa=cohens_kappa("llm", "human"))
+df.group_by("topic").agg(alpha=krippendorffs_alpha(["r1", "r2", "r3"]))
+```
+
+**Using .llama namespace:**
+```python
+pl.col("rater_a").llama.cohens_kappa("rater_b", weights="quadratic")
+pl.col("r1").llama.krippendorffs_alpha("r2", "r3", level="interval")
 ```
 
 ---

--- a/docs/RELIABILITY_METRICS.md
+++ b/docs/RELIABILITY_METRICS.md
@@ -1,0 +1,333 @@
+# Inter-rater Reliability Metrics
+
+## Overview
+
+Polar Llama provides **Cohen's kappa** and **Krippendorff's alpha** as
+Polars aggregation expressions -- the standard metrics for measuring how
+much two or more raters (human annotators, LLM judges, or a mix of both)
+agree on a set of categorical/ordinal/numeric ratings. They are useful any
+time you're validating an LLM's labels against a human gold set, comparing
+two LLM judges against each other, or checking agreement across a panel of
+human annotators before trusting their labels.
+
+Both metrics are implemented in pure Rust (`src/metrics.rs`, zero new
+dependencies) and are numerically pinned to reproduce two well-known
+reference implementations **bit-for-bit** on their own published fixtures:
+
+- `cohens_kappa` matches [`sklearn.metrics.cohen_kappa_score`](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.cohen_kappa_score.html).
+- `krippendorffs_alpha` matches the [`krippendorff`](https://pypi.org/project/krippendorff/) PyPI package.
+
+See `tests/test_irr_metrics.py` for the differential fixtures, and
+`src/metrics.rs`'s own `#[cfg(test)]` module for the Rust-level unit tests
+against the same values.
+
+### Key Features
+
+📐 **Two metrics**: Cohen's kappa (2 raters) and Krippendorff's alpha (2+
+raters, handles missing data natively)
+
+🎯 **Bit-for-bit numeric parity**: verified against `sklearn` and the
+`krippendorff` package on published fixtures
+
+📊 **Aggregation-shaped**: composes with `.select()` and
+`group_by().agg()` -- one number per group, not a value per row
+
+🔁 **Bootstrap confidence intervals**: optional, deterministic
+(seed-reproducible) percentile CIs via case resampling
+
+🎨 **Fluent API**: available via `.llama` namespace and functional API
+
+## Quick Start
+
+### Cohen's kappa: comparing an LLM judge to a human label
+
+```python
+import polars as pl
+from polar_llama import cohens_kappa
+
+df = pl.DataFrame({
+    "llm_label": ["positive", "negative", "positive", "neutral", "positive"],
+    "human_label": ["positive", "negative", "neutral", "neutral", "positive"],
+})
+
+result = df.select(kappa=cohens_kappa("llm_label", "human_label"))
+print(result)  # shape: (1, 1)  kappa: f64
+```
+
+### Krippendorff's alpha: agreement across 3+ raters, with missing data
+
+```python
+from polar_llama import krippendorffs_alpha
+
+df = pl.DataFrame({
+    "rater_1": [1, 2, 3, 3, 2, 1, 4, 1, 2, None, None, None],
+    "rater_2": [1, 2, 3, 3, 2, 2, 4, 1, 2, 5, None, 3],
+    "rater_3": [None, 3, 3, 3, 2, 3, 4, 2, 2, 5, 1, None],
+})
+
+result = df.select(alpha=krippendorffs_alpha(["rater_1", "rater_2", "rater_3"]))
+print(result)  # nominal alpha over the 12 units
+```
+
+### Per-group agreement with `group_by().agg()`
+
+Because these are aggregation expressions, they drop straight into
+`group_by().agg()`:
+
+```python
+df.group_by("batch").agg(
+    kappa=cohens_kappa("llm_label", "human_label"),
+    alpha=krippendorffs_alpha(["rater_1", "rater_2", "rater_3"]),
+)
+```
+
+### `.llama` namespace
+
+```python
+df.select(
+    kappa=pl.col("llm_label").llama.cohens_kappa("human_label"),
+    alpha=pl.col("rater_1").llama.krippendorffs_alpha("rater_2", "rater_3"),
+)
+```
+
+### Bootstrap confidence intervals
+
+Pass `n_bootstrap=` to get a nonparametric case-resampling percentile CI
+alongside the point estimate. This changes the return dtype from `Float64`
+to `Struct{value, ci_low, ci_high}`:
+
+```python
+df.select(
+    krippendorffs_alpha(
+        ["rater_1", "rater_2", "rater_3"], n_bootstrap=1000, ci=0.95, seed=0
+    ).struct.unnest()
+)
+# shape: (1, 3)  value: f64 | ci_low: f64 | ci_high: f64
+```
+
+## API
+
+### `cohens_kappa`
+
+```python
+cohens_kappa(
+    a: IntoExpr,
+    b: IntoExpr,
+    *,
+    weights: Literal["linear", "quadratic"] | None = None,
+    n_bootstrap: int | None = None,
+    ci: float = 0.95,
+    seed: int = 0,
+) -> pl.Expr
+```
+
+- **`a`, `b`**: the two columns of categorical codes being compared. Any of
+  Int*/UInt*/Float/String/Categorical/Enum (Categorical/Enum are cast to
+  String first).
+- **`weights`**: `None` (default, unweighted) is appropriate for purely
+  categorical labels. `"linear"`/`"quadratic"` penalize disagreements by
+  how far apart the labels are -- use these for ordinal ratings (e.g. a
+  1-5 Likert scale, a severity rating).
+- **`n_bootstrap`/`ci`/`seed`**: see [Bootstrap confidence intervals](#bootstrap-confidence-intervals-1)
+  below.
+
+**Null handling: pairwise-complete.** A row is dropped if either column is
+null there -- there's no meaningful "the LLM abstained" concept for
+Cohen's kappa the way there is for Krippendorff's alpha; sklearn has no
+concept of a missing label either.
+
+**Label weighting is by sorted-label *index*, not label value.** This is
+sklearn's convention and it can surprise you: if your codes are
+`{1, 5, 10}`, `"linear"` weights the gap between `1` and `5` the same as
+the gap between `5` and `10` (both are 1 sorted-index step apart), *not*
+proportional to `4` vs `5`. If your codes have non-contiguous numeric
+gaps and you want the gap itself to matter, remap them to contiguous
+ranks (`0, 1, 2, ...`) before calling `cohens_kappa`.
+
+### `krippendorffs_alpha`
+
+```python
+krippendorffs_alpha(
+    cols: Sequence[IntoExpr],
+    *,
+    level: Literal["nominal", "ordinal", "interval", "ratio"] = "nominal",
+    n_bootstrap: int | None = None,
+    ci: float = 0.95,
+    seed: int = 0,
+) -> pl.Expr
+```
+
+- **`cols`**: M >= 2 rater columns, one row per unit (item being rated).
+- **`level`**: level of measurement, governing how "distance" between two
+  categories is defined:
+  - `"nominal"` (default): categories are either equal or not (distance
+    is 0 or 1). Accepts numeric or String/Categorical/Enum columns.
+  - `"ordinal"`: categories have a meaningful order but not meaningful
+    spacing (e.g. "low/medium/high"). **Requires numeric columns** --
+    encode your ordered categories as ranks (`0, 1, 2, ...`) first. The
+    rank used is the numeric value's position in the sorted domain of
+    *observed* values, not the raw numeric gap.
+  - `"interval"`: categories are numeric with meaningful, evenly-spaced
+    distance (e.g. a temperature, a 1-10 rating where each step is
+    equally significant). Requires numeric columns.
+  - `"ratio"`: like interval, but distances are normalized by magnitude
+    (`(c-k)/(c+k)`) -- appropriate for ratio-scale numeric data where 0
+    is a true zero (e.g. counts, durations). Requires numeric columns.
+  - `"ordinal"`/`"interval"`/`"ratio"` raise `pl.exceptions.ComputeError`
+    if any column isn't numeric.
+- **`n_bootstrap`/`ci`/`seed`**: see [Bootstrap confidence intervals](#bootstrap-confidence-intervals-1)
+  below.
+
+**Null handling: nulls are missing ratings** -- this is the entire reason
+Krippendorff's alpha exists (unlike Cohen's kappa, it was designed to
+tolerate incomplete rating matrices). A unit (row) with fewer than 2
+non-null ratings contributes nothing pairable and is excluded from the
+computation.
+
+### Return shape
+
+Both functions return:
+- **`Float64`** (the point estimate) when `n_bootstrap` is `None`
+  (default).
+- **`Struct{value: Float64, ci_low: Float64, ci_high: Float64}`** when
+  `n_bootstrap` is given. Unnest with `.struct.unnest()` or access fields
+  with `.struct.field("value")`.
+
+### Bootstrap confidence intervals
+
+Passing `n_bootstrap=B` runs a **nonparametric case (unit/row) bootstrap**:
+the N units are resampled with replacement B times, the metric is
+recomputed on each resample, and a percentile confidence interval is taken
+at `((1-ci)/2, 1-(1-ci)/2)` using linear-interpolation quantiles (numpy's
+default "type 7" convention).
+
+> **Note:** this is *not* Krippendorff's own 2011 pair-bootstrap algorithm
+> for alpha specifically. Case (unit) resampling is the standard,
+> simply-defensible bootstrap and is what most practitioners expect from
+> an `n_bootstrap=` parameter -- but if you need the original
+> pair-bootstrap procedure for a publication that specifically requires
+> it, you'll need to implement that separately.
+
+The bootstrap PRNG is a deterministic, seeded `SplitMix64` generator (the
+same one used elsewhere in this package, e.g. `cluster_embeddings`'s
+k-means seeding) -- the same `seed` over the same input always produces
+the same CI.
+
+**Degenerate resamples** (a resample that collapses to a single category,
+etc., where the metric is undefined) are dropped from the percentile
+computation. If more than half of the `n_bootstrap` resamples are
+degenerate, `ci_low`/`ci_high` are null -- but `value` is always the point
+estimate computed on the *original*, non-resampled data, so it's never
+affected by a noisy bootstrap.
+
+## Edge cases and documented divergences from the reference implementations
+
+Both `sklearn.metrics.cohen_kappa_score` and the `krippendorff` package
+*raise exceptions* on certain degenerate inputs. A Polars expression can't
+raise per-group inside `group_by().agg()` without aborting the whole
+query, so these cases are handled by returning a specific value instead --
+documented here so the divergence is never a silent surprise:
+
+| Situation | Reference behavior | `polar_llama` behavior |
+|---|---|---|
+| `cohens_kappa`: expected-by-chance agreement is 0 (e.g. both columns have one single, identical observed category) | sklearn returns `nan` (a `0/0`) | Returns `NaN` too (not null) -- check with `.is_nan()`, same as `numpy.isnan()` |
+| `cohens_kappa`: zero pairwise-complete rows | sklearn has nothing to score | Returns **null** |
+| `krippendorffs_alpha`: no unit has >= 2 ratings (nothing pairable) | `krippendorff` raises `ValueError` | Returns **null** |
+| `krippendorffs_alpha`: the observed domain has a single category (every rating, across every included unit, is identical) | `krippendorff` raises `ValueError("... value in the domain")` | Returns **`1.0`** ("trivially perfect agreement" -- returning null is also defensible, but `1.0` was chosen as the convention; see `src/metrics.rs::krippendorff_alpha`) |
+
+Other conventions worth knowing about, both verified bit-for-bit against
+the reference implementations on the fixtures in `tests/test_irr_metrics.py`:
+
+- **Ordinal alpha's difference function uses coincidence-matrix
+  marginals**, not raw category frequencies -- this is the classic
+  from-scratch implementation mistake, and it's why the ordinal fixture in
+  the test suite exists.
+- Systematic *disagreement* (raters are anti-correlated) can produce a
+  **negative** kappa or alpha -- this is expected and correct, not a bug
+  (e.g. Krippendorff's own `[[1,2,1,2],[2,1,2,1]]` nominal fixture gives
+  `alpha = -0.75`).
+
+## Multi-label codes (MASI) -- documented strategy
+
+Some coding tasks are multi-label: each unit can receive *a set* of codes
+rather than one (e.g. a document tagged with `{"billing", "urgent"}`). The
+standard metric for that shape is MASI (Measuring Agreement on Set-valued
+Items, via `nltk.metrics.agreement.AnnotationTask` + `masi_distance`).
+
+**This package does not implement `level="masi"` in this release.** MASI
+needs a different input contract (set-valued cells, i.e. `List[String]`
+columns) than the scalar-per-cell contract `cohens_kappa`/
+`krippendorffs_alpha` use, and its reference implementation (NLTK) uses a
+distance function (not a squared difference) with its own missing-data
+quirks -- matching it exactly is a research task in its own right, not a
+mechanical extension of the coincidence-matrix machinery above. Shipping a
+MASI implementation with an unverified convention would be worse than not
+shipping one.
+
+Two supported strategies instead, both expressible today with the
+existing `nominal` alpha:
+
+### Strategy 1: per-label binary alpha (recommended for most cases)
+
+Explode the label set into one 0/1 column per label per rater, then report
+a separate nominal alpha per label. This is standard practice in content
+analysis, and it gives you a per-label reliability breakdown (some labels
+are usually agreed on more than others) rather than one opaque number.
+
+```python
+import polars as pl
+from polar_llama import krippendorffs_alpha
+
+# rater_1_labels / rater_2_labels: List[String] columns, e.g.
+# rater_1_labels = [["billing", "urgent"], ["shipping"], None, ...]
+all_labels = ["billing", "urgent", "shipping", "refund"]
+
+df = df.with_columns(
+    [
+        pl.col("rater_1_labels").list.contains(label).cast(pl.Int8).alias(f"r1_{label}")
+        for label in all_labels
+    ]
+    + [
+        pl.col("rater_2_labels").list.contains(label).cast(pl.Int8).alias(f"r2_{label}")
+        for label in all_labels
+    ]
+)
+
+per_label_alpha = {
+    label: df.select(
+        krippendorffs_alpha([f"r1_{label}", f"r2_{label}"])
+    ).item()
+    for label in all_labels
+}
+```
+
+Note: `list.contains` returns `False` (not null) for an empty list but
+null for a null list -- a rater who didn't rate a unit at all still comes
+through as a missing rating (null) in each per-label column, which is the
+correct semantics for alpha's null-as-missing convention.
+
+### Strategy 2: exact-set nominal alpha (strict)
+
+Treat the whole label set as one atomic nominal category -- two raters
+only "agree" if they picked the *exact same set*. This is stricter than
+per-label alpha (it doesn't give partial credit for overlapping-but-not-
+identical sets) but is sometimes what you want for a hard equality bar.
+
+```python
+df = df.with_columns(
+    r1_set=pl.col("rater_1_labels").list.sort().list.join("|"),
+    r2_set=pl.col("rater_2_labels").list.sort().list.join("|"),
+)
+exact_set_alpha = df.select(krippendorffs_alpha(["r1_set", "r2_set"])).item()
+```
+
+### Future: `level="masi"`
+
+The coincidence-matrix machinery in `src/metrics.rs::krippendorff_alpha`
+already accepts an arbitrary `delta2(c, k)` difference function over
+hashable categories -- MASI is "just" another difference function (a set
+Jaccard-style distance rather than equality/squared-difference), plus a
+`List[String]`-shaped input path through `src/expressions.rs`. This is
+being tracked as a follow-up issue rather than bundled into #79, so it can
+be verified against NLTK's `masi_distance` on its own fixtures rather than
+guessed at.

--- a/polar_llama/__init__.py
+++ b/polar_llama/__init__.py
@@ -1962,6 +1962,16 @@ from polar_llama.codebook import (
 
 
 # ============================================================================
+# Inter-rater Reliability (issue #79) — see docs/RELIABILITY_METRICS.md
+# ============================================================================
+
+from polar_llama.reliability import (
+    cohens_kappa,
+    krippendorffs_alpha,
+)
+
+
+# ============================================================================
 # Tool Use (MCP) — see docs/design/MCP_TOOL_INTEGRATION.md
 # ============================================================================
 
@@ -2263,6 +2273,66 @@ class LlamaNamespace:
             Cosine similarity score
         """
         return cosine_similarity(self._expr, other)
+
+    def cohens_kappa(
+        self,
+        other: IntoExpr,
+        *,
+        weights: Optional[str] = None,
+        n_bootstrap: Optional[int] = None,
+        ci: float = 0.95,
+        seed: int = 0,
+    ) -> pl.Expr:
+        """
+        Cohen's kappa between this column and another column of ratings.
+
+        See `polar_llama.cohens_kappa` for the full parameter/return docs.
+
+        Parameters
+        ----------
+        other : polars.Expr
+            The other column of categorical ratings to compare with.
+
+        Returns
+        -------
+        polars.Expr
+            `Float64` kappa (or `Struct{value, ci_low, ci_high}` when
+            `n_bootstrap` is given).
+        """
+        return cohens_kappa(
+            self._expr, other, weights=weights, n_bootstrap=n_bootstrap, ci=ci, seed=seed
+        )
+
+    def krippendorffs_alpha(
+        self,
+        *others: IntoExpr,
+        level: str = "nominal",
+        n_bootstrap: Optional[int] = None,
+        ci: float = 0.95,
+        seed: int = 0,
+    ) -> pl.Expr:
+        """
+        Krippendorff's alpha across this column and one or more other
+        rater columns.
+
+        See `polar_llama.krippendorffs_alpha` for the full parameter/return
+        docs.
+
+        Parameters
+        ----------
+        *others : polars.Expr
+            The other rater columns (at least one, so at least 2 raters
+            total).
+
+        Returns
+        -------
+        polars.Expr
+            `Float64` alpha (or `Struct{value, ci_low, ci_high}` when
+            `n_bootstrap` is given).
+        """
+        return krippendorffs_alpha(
+            [self._expr, *others], level=level, n_bootstrap=n_bootstrap, ci=ci, seed=seed
+        )
 
     def dot_product(self, other: IntoExpr) -> pl.Expr:
         """

--- a/polar_llama/reliability.py
+++ b/polar_llama/reliability.py
@@ -1,0 +1,265 @@
+"""
+Inter-rater reliability metrics for Polar Llama (issue #79): Cohen's kappa
+and Krippendorff's alpha.
+
+Design summary -- see `docs/RELIABILITY_METRICS.md` for the full walkthrough:
+
+1. **Shape**: unlike the row-wise expressions elsewhere in this package,
+   `cohens_kappa`/`krippendorffs_alpha` are *aggregations* -- one number
+   over N rows, optionally per group. They are registered with
+   `is_elementwise=False, returns_scalar=True`
+   (`polar_llama.utils.register_plugin`), the standard Polars
+   aggregation-plugin pattern, so they compose with `.select()`,
+   `group_by().agg()`, and lazy frames for free:
+   `df.group_by("segment").agg(pl.col("llm_a").llama.cohens_kappa("llm_b"))`.
+
+2. **Numeric parity**: the Rust algorithms (`src/metrics.rs`) are pinned to
+   reproduce `sklearn.metrics.cohen_kappa_score` and the `krippendorff`
+   PyPI package bit-for-bit on their own published fixtures -- see
+   `tests/test_irr_metrics.py` and `src/metrics.rs`'s own unit tests.
+   Notable, *documented* divergences from those references (an expression
+   must not raise/panic per-group the way the reference libraries do):
+   - `cohens_kappa`: `0/0` expected-agreement (e.g. a single observed
+     category) returns `NaN` (not null) -- matches sklearn's own
+     `nan`-not-error convention.
+   - `krippendorffs_alpha`: no unit with >= 2 ratings returns null (the
+     `krippendorff` package raises `ValueError`); a single-category domain
+     returns `1.0` (trivially perfect agreement; the package also raises
+     there).
+
+3. **Return dtype**: a plain `Float64` scalar by default; passing
+   `n_bootstrap=` switches to `Struct{value, ci_low, ci_high}` (case
+   resampling, percentile CI, `SplitMix64`-seeded and therefore
+   deterministic for a fixed `seed`). `pyo3_polars`'
+   `output_type_func` can't see kwargs, so this dispatches between two
+   distinct Rust symbols per metric based on whether `n_bootstrap is None`.
+
+4. **Multi-label / MASI**: deliberately not implemented here -- see the
+   "Multi-label codes" section of `docs/RELIABILITY_METRICS.md` for the two
+   documented strategies (per-label binary alpha, exact-set nominal alpha),
+   which satisfy the "or documented strategy" acceptance arm of issue #79.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence
+
+import polars as pl
+
+from polar_llama.utils import parse_into_expr, register_plugin
+
+if TYPE_CHECKING:
+    from typing import Literal
+
+    from polars.type_aliases import IntoExpr
+
+_KAPPA_WEIGHTS = ("linear", "quadratic")
+_ALPHA_LEVELS = ("nominal", "ordinal", "interval", "ratio")
+
+
+def _validate_ci(ci: float) -> None:
+    if not (0.0 < ci < 1.0):
+        raise ValueError(f"ci must be in the open interval (0, 1); got {ci!r}")
+
+
+def _validate_weights(weights: Optional[str]) -> None:
+    if weights is not None and weights not in _KAPPA_WEIGHTS:
+        raise ValueError(
+            f"weights must be None, 'linear', or 'quadratic'; got {weights!r}"
+        )
+
+
+def _validate_level(level: str) -> None:
+    if level not in _ALPHA_LEVELS:
+        raise ValueError(
+            f"level must be one of {_ALPHA_LEVELS!r}; got {level!r}"
+        )
+
+
+def cohens_kappa(
+    a: "IntoExpr",
+    b: "IntoExpr",
+    *,
+    weights: "Optional[Literal['linear', 'quadratic']]" = None,
+    n_bootstrap: Optional[int] = None,
+    ci: float = 0.95,
+    seed: int = 0,
+) -> pl.Expr:
+    """
+    Cohen's kappa between two columns of categorical ratings.
+
+    Reproduces `sklearn.metrics.cohen_kappa_score` bit-for-bit: labels are
+    the sorted union of both columns' observed values (numeric sort for
+    numeric dtypes, lexicographic for strings), `weights` are applied over
+    sorted-label *indices* (sklearn's convention -- this can surprise you
+    with non-contiguous numeric codes; e.g. codes `{1, 5, 10}` weight as
+    indices `{0, 1, 2}`, not by the raw label gap), and rows are
+    pairwise-complete (a row is dropped if either column is null there).
+
+    Parameters
+    ----------
+    a, b : IntoExpr
+        The two columns of categorical codes being compared (Int/UInt/
+        Float/String/Categorical/Enum; Categorical/Enum are cast to
+        String).
+    weights : {None, "linear", "quadratic"}, optional
+        `None` (default) is unweighted kappa. `"linear"`/`"quadratic"`
+        penalize disagreements by their distance in the sorted-label list
+        -- appropriate for ordinal ratings (e.g. a 1-5 Likert scale).
+    n_bootstrap : int, optional
+        When given, also compute a nonparametric case (row-pair) bootstrap
+        confidence interval: resample the pairwise-complete rows with
+        replacement `n_bootstrap` times, recompute kappa on each resample,
+        and take the percentile interval. Changes the return dtype -- see
+        Returns below. `None` (default) skips the bootstrap.
+    ci : float
+        Confidence level for the bootstrap interval, e.g. `0.95` for a
+        95% CI. Must be in `(0, 1)`. Only used when `n_bootstrap` is given.
+    seed : int
+        Seed for the (deterministic) bootstrap PRNG. Only used when
+        `n_bootstrap` is given.
+
+    Returns
+    -------
+    polars.Expr
+        `Float64` (the point estimate) when `n_bootstrap is None`.
+        `Struct{value: Float64, ci_low: Float64, ci_high: Float64}` when
+        `n_bootstrap` is given -- unnest with `.struct.unnest()`.
+        `NaN` (not null) when expected-by-chance agreement is zero (e.g.
+        both columns have a single, identical observed category). Null
+        when there are zero pairwise-complete rows.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from polar_llama import cohens_kappa
+    >>> df = pl.DataFrame({"llm": [1, 2, 2, 1], "human": [1, 2, 1, 1]})
+    >>> df.select(kappa=cohens_kappa("llm", "human"))
+    >>> df.select(
+    ...     cohens_kappa("llm", "human", n_bootstrap=1000).struct.unnest()
+    ... )
+    """
+    _validate_weights(weights)
+    _validate_ci(ci)
+
+    a_expr = parse_into_expr(a)
+    b_expr = parse_into_expr(b)
+
+    kwargs: Dict[str, Any] = {
+        "weights": weights,
+        "n_bootstrap": int(n_bootstrap) if n_bootstrap is not None else None,
+        "ci": float(ci),
+        "seed": int(seed),
+    }
+
+    from polar_llama.expressions import get_lib_path
+
+    symbol = "cohens_kappa" if n_bootstrap is None else "cohens_kappa_ci"
+    return register_plugin(
+        args=[a_expr, b_expr],
+        symbol=symbol,
+        is_elementwise=False,
+        returns_scalar=True,
+        lib=get_lib_path(),
+        kwargs=kwargs,
+    )
+
+
+def krippendorffs_alpha(
+    cols: Sequence["IntoExpr"],
+    *,
+    level: "Literal['nominal', 'ordinal', 'interval', 'ratio']" = "nominal",
+    n_bootstrap: Optional[int] = None,
+    ci: float = 0.95,
+    seed: int = 0,
+) -> pl.Expr:
+    """
+    Krippendorff's alpha across M >= 2 columns of ratings (one column per
+    rater, one row per unit).
+
+    Reproduces the `krippendorff` PyPI package's coincidence-matrix
+    algorithm bit-for-bit. Nulls are treated as missing ratings (the
+    reason alpha exists): a unit (row) with fewer than 2 non-null ratings
+    is excluded from the computation.
+
+    Parameters
+    ----------
+    cols : sequence of IntoExpr
+        The M >= 2 rater columns, one row per unit.
+    level : {"nominal", "ordinal", "interval", "ratio"}
+        Level of measurement, governing the difference function between
+        categories. `"nominal"` (default) accepts numeric or
+        String/Categorical/Enum columns. `"ordinal"`/`"interval"`/
+        `"ratio"` require numeric columns (raises `pl.exceptions.ComputeError`
+        otherwise); for `"ordinal"` the rank is the numeric value's
+        position in the sorted domain of observed values.
+    n_bootstrap : int, optional
+        When given, also compute a nonparametric case (unit) bootstrap
+        confidence interval: resample the units with replacement
+        `n_bootstrap` times, recompute alpha on each resample, and take
+        the percentile interval. Changes the return dtype -- see Returns
+        below. `None` (default) skips the bootstrap.
+    ci : float
+        Confidence level for the bootstrap interval. Must be in `(0, 1)`.
+        Only used when `n_bootstrap` is given.
+    seed : int
+        Seed for the (deterministic) bootstrap PRNG. Only used when
+        `n_bootstrap` is given.
+
+    Returns
+    -------
+    polars.Expr
+        `Float64` (the point estimate) when `n_bootstrap is None`.
+        `Struct{value: Float64, ci_low: Float64, ci_high: Float64}` when
+        `n_bootstrap` is given -- unnest with `.struct.unnest()`.
+        `1.0` for a single-category domain (trivially perfect agreement,
+        by documented convention; the reference package raises
+        `ValueError` there instead). Null when no unit has >= 2 ratings
+        (the reference package also raises there).
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from polar_llama import krippendorffs_alpha
+    >>> df = pl.DataFrame({
+    ...     "r1": [1, 2, 3, None],
+    ...     "r2": [1, 2, 3, 3],
+    ...     "r3": [1, 2, None, 3],
+    ... })
+    >>> df.select(alpha=krippendorffs_alpha(["r1", "r2", "r3"]))
+    >>> df.group_by("topic").agg(
+    ...     alpha=krippendorffs_alpha(["r1", "r2", "r3"], level="interval")
+    ... )
+    >>> df.select(
+    ...     krippendorffs_alpha(
+    ...         ["r1", "r2", "r3"], n_bootstrap=1000
+    ...     ).struct.unnest()
+    ... )
+    """
+    _validate_level(level)
+    _validate_ci(ci)
+
+    exprs: List[pl.Expr] = [parse_into_expr(c) for c in cols]
+    if len(exprs) < 2:
+        raise ValueError(
+            f"krippendorffs_alpha needs at least 2 rater columns; got {len(exprs)}"
+        )
+
+    kwargs: Dict[str, Any] = {
+        "level": level,
+        "n_bootstrap": int(n_bootstrap) if n_bootstrap is not None else None,
+        "ci": float(ci),
+        "seed": int(seed),
+    }
+
+    from polar_llama.expressions import get_lib_path
+
+    symbol = "krippendorffs_alpha" if n_bootstrap is None else "krippendorffs_alpha_ci"
+    return register_plugin(
+        args=exprs,
+        symbol=symbol,
+        is_elementwise=False,
+        returns_scalar=True,
+        lib=get_lib_path(),
+        kwargs=kwargs,
+    )

--- a/polar_llama/utils.py
+++ b/polar_llama/utils.py
@@ -57,8 +57,13 @@ def register_plugin(
     kwargs: dict[str, Any] | None = None,
     args: list[IntoExpr],
     lib: str | Path,
+    returns_scalar: bool = False,
 ) -> pl.Expr:
     if parse_version(pl.__version__) < parse_version("0.20.16"):
+        # `returns_scalar` predates the legacy `Expr.register_plugin` path
+        # (added to `register_plugin_function` later); there is nothing to
+        # forward it to here.
+        assert not returns_scalar
         assert isinstance(args[0], pl.Expr)
         assert isinstance(lib, str)
         return args[0].register_plugin(
@@ -76,6 +81,7 @@ def register_plugin(
         function_name=symbol,
         kwargs=kwargs,
         is_elementwise=is_elementwise,
+        returns_scalar=returns_scalar,
     )
 
 def parse_version(version: Sequence[str | int]) -> tuple[int, ...]:

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -1423,3 +1423,427 @@ fn calculate_cost_from_tokens(inputs: &[Series], kwargs: CostKwargs) -> PolarsRe
 
     Ok(out.into_series())
 }
+
+// ============================================================================
+// Inter-rater reliability (issue #79)
+// ============================================================================
+//
+// Cohen's kappa (`cohens_kappa` / `cohens_kappa_ci`) and Krippendorff's alpha
+// (`krippendorffs_alpha` / `krippendorffs_alpha_ci`) are *aggregations*, not
+// row-wise transforms: they reduce a whole column (or, inside
+// `group_by().agg()`, a whole group) down to a single number. They are
+// registered from the Python side with `returns_scalar=True`
+// (`polar_llama/utils.py::register_plugin`), which is why every function
+// below always returns a length-1 `Series` regardless of the input length.
+//
+// The pure numeric algorithms (confusion-matrix kappa, coincidence-matrix
+// alpha, case-resampling bootstrap) live in `crate::metrics` and are unit
+// tested there against published reference fixtures; this section only does
+// the Polars/`Series` <-> plain-Rust-vector plumbing: pairwise-complete
+// filtering, categorical label encoding, and building the
+// `Struct{value, ci_low, ci_high}` output for the `_ci` variants.
+//
+// `output_type_func` cannot see kwargs, so a bootstrap request needs a
+// different return dtype (`Float64` vs `Struct`) from a plain point
+// estimate -- hence two Rust symbols per metric, dispatched on the Python
+// side by whether `n_bootstrap` is `None` (see `polar_llama/reliability.py`).
+
+fn default_irr_ci() -> f64 {
+    0.95
+}
+
+/// A single rater's category value, used only to build the sorted label
+/// list Cohen's kappa weights are indexed over. Numeric dtypes sort
+/// numerically; string-like dtypes (`String`/`Categorical`/`Enum`, the
+/// latter two cast to `String` first) sort lexicographically -- matching
+/// `np.unique` on the concatenation of both columns, same as sklearn.
+#[derive(Clone)]
+enum LabelValue {
+    Num(f64),
+    Str(String),
+}
+
+impl LabelValue {
+    fn cmp_key(&self, other: &LabelValue) -> std::cmp::Ordering {
+        match (self, other) {
+            (LabelValue::Num(a), LabelValue::Num(b)) => a.total_cmp(b),
+            (LabelValue::Str(a), LabelValue::Str(b)) => a.cmp(b),
+            // Mixed numeric/string columns aren't a documented case; sort
+            // numeric labels before string labels rather than panicking.
+            (LabelValue::Num(_), LabelValue::Str(_)) => std::cmp::Ordering::Less,
+            (LabelValue::Str(_), LabelValue::Num(_)) => std::cmp::Ordering::Greater,
+        }
+    }
+}
+
+fn is_numeric_dtype(dt: &DataType) -> bool {
+    matches!(
+        dt,
+        DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64
+            | DataType::Float32
+            | DataType::Float64
+    )
+}
+
+fn is_string_like_dtype(dt: &DataType) -> bool {
+    dt.is_string() || dt.is_categorical() || dt.is_enum()
+}
+
+fn series_to_label_values(s: &Series) -> PolarsResult<Vec<Option<LabelValue>>> {
+    if is_string_like_dtype(s.dtype()) {
+        let casted = s.cast(&DataType::String)?;
+        let ca = casted.str()?;
+        Ok(ca
+            .into_iter()
+            .map(|opt| opt.map(|v| LabelValue::Str(v.to_string())))
+            .collect())
+    } else {
+        let casted = s.cast(&DataType::Float64)?;
+        let ca = casted.f64()?;
+        // Treat NaN/inf as missing (consistent with krippendorffs_alpha and the
+        // pairwise-complete contract) rather than as a distinct label value.
+        Ok(ca
+            .into_iter()
+            .map(|opt| opt.filter(|v| v.is_finite()).map(LabelValue::Num))
+            .collect())
+    }
+}
+
+/// Pairwise-complete label encoding for Cohen's kappa: drops row `i` if
+/// either column is null there, builds the sorted-union label list, and
+/// returns each surviving row re-expressed as indices into that list (plus
+/// the label count). `n_labels == 0` means zero pairwise-complete rows.
+fn encode_pairwise_complete_labels(
+    a: &Series,
+    b: &Series,
+) -> PolarsResult<(Vec<usize>, Vec<usize>, usize)> {
+    let a_vals = series_to_label_values(a)?;
+    let b_vals = series_to_label_values(b)?;
+    let n = a_vals.len().min(b_vals.len());
+
+    let mut rows: Vec<(LabelValue, LabelValue)> = Vec::new();
+    for i in 0..n {
+        if let (Some(av), Some(bv)) = (&a_vals[i], &b_vals[i]) {
+            rows.push((av.clone(), bv.clone()));
+        }
+    }
+
+    let mut domain: Vec<LabelValue> = Vec::with_capacity(rows.len() * 2);
+    for (av, bv) in &rows {
+        domain.push(av.clone());
+        domain.push(bv.clone());
+    }
+    domain.sort_by(|x, y| x.cmp_key(y));
+    domain.dedup_by(|x, y| x.cmp_key(y) == std::cmp::Ordering::Equal);
+
+    let label_index = |domain: &[LabelValue], v: &LabelValue| -> usize {
+        domain
+            .binary_search_by(|x| x.cmp_key(v))
+            .expect("label value must be present in its own domain")
+    };
+
+    let mut a_idx = Vec::with_capacity(rows.len());
+    let mut b_idx = Vec::with_capacity(rows.len());
+    for (av, bv) in &rows {
+        a_idx.push(label_index(&domain, av));
+        b_idx.push(label_index(&domain, bv));
+    }
+
+    Ok((a_idx, b_idx, domain.len()))
+}
+
+fn parse_kappa_weights(w: &Option<String>) -> PolarsResult<crate::metrics::KappaWeights> {
+    match w.as_deref() {
+        None => Ok(crate::metrics::KappaWeights::None),
+        Some("linear") => Ok(crate::metrics::KappaWeights::Linear),
+        Some("quadratic") => Ok(crate::metrics::KappaWeights::Quadratic),
+        Some(other) => Err(PolarsError::ComputeError(
+            format!("cohens_kappa: unknown weights {other:?} (expected 'linear' or 'quadratic')")
+                .into(),
+        )),
+    }
+}
+
+fn parse_alpha_level(level: &str) -> PolarsResult<crate::metrics::AlphaLevel> {
+    match level {
+        "nominal" => Ok(crate::metrics::AlphaLevel::Nominal),
+        "ordinal" => Ok(crate::metrics::AlphaLevel::Ordinal),
+        "interval" => Ok(crate::metrics::AlphaLevel::Interval),
+        "ratio" => Ok(crate::metrics::AlphaLevel::Ratio),
+        other => Err(PolarsError::ComputeError(
+            format!(
+                "krippendorffs_alpha: unknown level {other:?} \
+                 (expected 'nominal', 'ordinal', 'interval', or 'ratio')"
+            )
+            .into(),
+        )),
+    }
+}
+
+/// Builds Krippendorff's-alpha "units": one `Vec<f64>` per row, holding that
+/// row's non-null ratings across the `M` rater columns in `inputs`.
+///
+/// `level == Nominal` accepts numeric or string-like (`String`/
+/// `Categorical`/`Enum`) columns; string-like values are encoded to
+/// arbitrary-but-consistent `f64` ids (order doesn't matter -- nominal's
+/// difference function only tests equality). `Ordinal`/`Interval`/`Ratio`
+/// require every column to already be numeric (raised as `ComputeError`
+/// otherwise -- matches the `krippendorff` package, which needs numeric
+/// values to compute a numeric difference for those levels).
+fn build_reliability_units(
+    inputs: &[Series],
+    level: crate::metrics::AlphaLevel,
+) -> PolarsResult<Vec<Vec<f64>>> {
+    if inputs.is_empty() {
+        return Ok(Vec::new());
+    }
+    let n_rows = inputs[0].len();
+
+    let use_string_encoding = matches!(level, crate::metrics::AlphaLevel::Nominal)
+        && inputs.iter().any(|s| is_string_like_dtype(s.dtype()));
+
+    if !matches!(level, crate::metrics::AlphaLevel::Nominal) {
+        for s in inputs {
+            if !is_numeric_dtype(s.dtype()) {
+                return Err(PolarsError::ComputeError(
+                    format!(
+                        "krippendorffs_alpha: level={level:?} requires numeric rater columns, \
+                         got column {:?} with dtype {:?}",
+                        s.name(),
+                        s.dtype()
+                    )
+                    .into(),
+                ));
+            }
+        }
+    }
+
+    let mut columns: Vec<Vec<Option<f64>>> = Vec::with_capacity(inputs.len());
+    if use_string_encoding {
+        let mut ids: std::collections::HashMap<String, f64> = std::collections::HashMap::new();
+        let mut next_id = 0f64;
+        for s in inputs {
+            let casted = s.cast(&DataType::String)?;
+            let ca = casted.str()?;
+            let mut col: Vec<Option<f64>> = Vec::with_capacity(ca.len());
+            for v in ca.into_iter() {
+                col.push(v.map(|text| {
+                    *ids.entry(text.to_string()).or_insert_with(|| {
+                        let id = next_id;
+                        next_id += 1.0;
+                        id
+                    })
+                }));
+            }
+            columns.push(col);
+        }
+    } else {
+        for s in inputs {
+            let casted = s.cast(&DataType::Float64)?;
+            let ca = casted.f64()?;
+            columns.push(ca.into_iter().collect());
+        }
+    }
+
+    let mut units: Vec<Vec<f64>> = Vec::with_capacity(n_rows);
+    for row in 0..n_rows {
+        let mut ratings = Vec::with_capacity(columns.len());
+        for col in &columns {
+            if row < col.len() {
+                if let Some(v) = col[row] {
+                    // Treat NaN/inf as missing (matches the reference
+                    // `krippendorff` package and the null-as-missing contract);
+                    // a non-finite value would otherwise poison the domain sort.
+                    if v.is_finite() {
+                        ratings.push(v);
+                    }
+                }
+            }
+        }
+        units.push(ratings);
+    }
+    Ok(units)
+}
+
+/// `Struct{value: Float64, ci_low: Float64, ci_high: Float64}` -- the
+/// `output_type_func` for the `_ci` plugin variants. Built natively with
+/// `StructChunked` (the `dtype-struct` Cargo feature is already enabled),
+/// not the JSON-string decode convention `cluster_embeddings` uses: a
+/// `returns_scalar` aggregation composes awkwardly with `map_batches`
+/// inside `.agg()`.
+fn irr_ci_output_type(_input_fields: &[Field]) -> PolarsResult<Field> {
+    Ok(Field::new(
+        PlSmallStr::from_static(""),
+        DataType::Struct(vec![
+            Field::new(PlSmallStr::from_static("value"), DataType::Float64),
+            Field::new(PlSmallStr::from_static("ci_low"), DataType::Float64),
+            Field::new(PlSmallStr::from_static("ci_high"), DataType::Float64),
+        ]),
+    ))
+}
+
+fn build_irr_struct(
+    value: Option<f64>,
+    ci_low: Option<f64>,
+    ci_high: Option<f64>,
+) -> PolarsResult<Series> {
+    let value_s =
+        Float64Chunked::from_slice_options(PlSmallStr::from_static("value"), &[value]).into_series();
+    let ci_low_s =
+        Float64Chunked::from_slice_options(PlSmallStr::from_static("ci_low"), &[ci_low]).into_series();
+    let ci_high_s =
+        Float64Chunked::from_slice_options(PlSmallStr::from_static("ci_high"), &[ci_high])
+            .into_series();
+    let out = StructChunked::from_series(
+        PlSmallStr::from_static(""),
+        1,
+        [value_s, ci_low_s, ci_high_s].iter(),
+    )?;
+    Ok(out.into_series())
+}
+
+#[derive(Debug, Deserialize)]
+pub struct KappaKwargs {
+    #[serde(default)]
+    weights: Option<String>,
+    #[serde(default)]
+    n_bootstrap: Option<usize>,
+    #[serde(default = "default_irr_ci")]
+    ci: f64,
+    #[serde(default)]
+    seed: u64,
+}
+
+/// Cohen's kappa point estimate between two rater columns (`inputs[0]`,
+/// `inputs[1]`). Pairwise-complete: a row is dropped if either column is
+/// null there. Returns Polars null for zero pairwise-complete rows, and
+/// `f64::NAN` (not null) when expected-by-chance agreement is zero (e.g. a
+/// single observed category) -- matching
+/// `sklearn.metrics.cohen_kappa_score`'s `0/0 -> nan` convention exactly.
+#[polars_expr(output_type=Float64)]
+fn cohens_kappa(inputs: &[Series], kwargs: KappaKwargs) -> PolarsResult<Series> {
+    let weights = parse_kappa_weights(&kwargs.weights)?;
+    let (a_idx, b_idx, n_labels) = encode_pairwise_complete_labels(&inputs[0], &inputs[1])?;
+
+    let value = if n_labels == 0 {
+        None
+    } else {
+        Some(crate::metrics::cohens_kappa(&a_idx, &b_idx, n_labels, weights))
+    };
+
+    Ok(Float64Chunked::from_slice_options(PlSmallStr::from_static(""), &[value]).into_series())
+}
+
+/// Cohen's kappa with an optional case-resampling bootstrap CI. Returns
+/// `Struct{value, ci_low, ci_high}`; `ci_low`/`ci_high` are null when
+/// `n_bootstrap` is `None` or zero, or when more than half the resamples
+/// were degenerate (see `crate::metrics::bootstrap_ci`).
+#[polars_expr(output_type_func=irr_ci_output_type)]
+fn cohens_kappa_ci(inputs: &[Series], kwargs: KappaKwargs) -> PolarsResult<Series> {
+    let weights = parse_kappa_weights(&kwargs.weights)?;
+    let (a_idx, b_idx, n_labels) = encode_pairwise_complete_labels(&inputs[0], &inputs[1])?;
+
+    if n_labels == 0 {
+        return build_irr_struct(None, None, None);
+    }
+
+    let point = crate::metrics::cohens_kappa(&a_idx, &b_idx, n_labels, weights);
+    let n = a_idx.len();
+    let b = kwargs.n_bootstrap.unwrap_or(0);
+
+    let (ci_low, ci_high) = if b > 0 {
+        match crate::metrics::bootstrap_ci(
+            |idx: &[usize]| {
+                let ra: Vec<usize> = idx.iter().map(|&i| a_idx[i]).collect();
+                let rb: Vec<usize> = idx.iter().map(|&i| b_idx[i]).collect();
+                crate::metrics::cohens_kappa(&ra, &rb, n_labels, weights)
+            },
+            n,
+            b,
+            kwargs.ci,
+            kwargs.seed,
+        ) {
+            Some((lo, hi)) => (Some(lo), Some(hi)),
+            None => (None, None),
+        }
+    } else {
+        (None, None)
+    };
+
+    build_irr_struct(Some(point), ci_low, ci_high)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AlphaKwargs {
+    #[serde(default = "default_alpha_level")]
+    level: String,
+    #[serde(default)]
+    n_bootstrap: Option<usize>,
+    #[serde(default = "default_irr_ci")]
+    ci: f64,
+    #[serde(default)]
+    seed: u64,
+}
+
+fn default_alpha_level() -> String {
+    "nominal".to_string()
+}
+
+/// Krippendorff's alpha point estimate over `M` rater columns (`inputs`).
+/// Nulls are missing ratings (alpha's whole reason for being); units
+/// (rows) with fewer than 2 non-null ratings are excluded. Returns Polars
+/// null when no unit has >= 2 ratings (the reference package raises there);
+/// returns `1.0` for a single-category domain (trivially perfect
+/// agreement; the reference package also raises there) -- both documented
+/// divergences, see `crate::metrics::krippendorff_alpha`.
+#[polars_expr(output_type=Float64)]
+fn krippendorffs_alpha(inputs: &[Series], kwargs: AlphaKwargs) -> PolarsResult<Series> {
+    let level = parse_alpha_level(&kwargs.level)?;
+    let units = build_reliability_units(inputs, level)?;
+    let value = crate::metrics::krippendorff_alpha(&units, level);
+    Ok(Float64Chunked::from_slice_options(PlSmallStr::from_static(""), &[value]).into_series())
+}
+
+/// Krippendorff's alpha with an optional case (unit) bootstrap CI. Returns
+/// `Struct{value, ci_low, ci_high}`, same null/degenerate conventions as
+/// `cohens_kappa_ci`.
+#[polars_expr(output_type_func=irr_ci_output_type)]
+fn krippendorffs_alpha_ci(inputs: &[Series], kwargs: AlphaKwargs) -> PolarsResult<Series> {
+    let level = parse_alpha_level(&kwargs.level)?;
+    let units = build_reliability_units(inputs, level)?;
+
+    let value = match crate::metrics::krippendorff_alpha(&units, level) {
+        Some(v) => v,
+        None => return build_irr_struct(None, None, None),
+    };
+
+    let n = units.len();
+    let b = kwargs.n_bootstrap.unwrap_or(0);
+
+    let (ci_low, ci_high) = if b > 0 {
+        match crate::metrics::bootstrap_ci(
+            |idx: &[usize]| {
+                let resampled: Vec<Vec<f64>> = idx.iter().map(|&i| units[i].clone()).collect();
+                crate::metrics::krippendorff_alpha(&resampled, level).unwrap_or(f64::NAN)
+            },
+            n,
+            b,
+            kwargs.ci,
+            kwargs.seed,
+        ) {
+            Some((lo, hi)) => (Some(lo), Some(hi)),
+            None => (None, None),
+        }
+    } else {
+        (None, None)
+    };
+
+    build_irr_struct(Some(value), ci_low, ci_high)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod ann;
 pub mod cost;
 pub mod kmeans;
 pub mod mcp;
+pub mod metrics;
 mod stream_pyfn;
 
 #[cfg(target_os = "linux")]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,608 @@
+//! Inter-rater reliability metrics (issue #79): Cohen's kappa and
+//! Krippendorff's alpha, plus a shared case-resampling bootstrap for
+//! percentile confidence intervals.
+//!
+//! These are pure functions over plain Rust vectors -- no Polars types --
+//! so they are trivially unit-testable here and reused by the plugin
+//! expressions in `src/expressions.rs`, which handle the Polars `Series` /
+//! null / label-encoding plumbing around them.
+//!
+//! Numeric conventions are pinned to match two reference implementations
+//! bit-for-bit (verified against `sklearn.metrics.cohen_kappa_score` and the
+//! `krippendorff` PyPI package on the fixtures in the `tests` module below):
+//!
+//! - Cohen's kappa: sklearn's weight-matrix formulation, including its
+//!   `NaN` (not null/error) result when the expected-by-chance agreement is
+//!   zero (e.g. a single observed category).
+//! - Krippendorff's alpha: the coincidence-matrix construction, including
+//!   the "ordinal" difference function using coincidence-matrix marginals
+//!   (not raw category frequencies -- the classic implementation mistake).
+//!
+//! Both reference implementations *raise* on certain degenerate inputs
+//! (single-category domain, no pairable units). A Polars expression must
+//! not panic per-group, so this module documents and returns a value
+//! instead in each case -- see the doc comments on `krippendorff_alpha` for
+//! the exact divergence.
+
+use crate::kmeans::SplitMix64;
+
+// ============================================================================
+// Cohen's kappa
+// ============================================================================
+
+/// Weighting scheme for Cohen's kappa, applied over sorted-label *indices*
+/// (sklearn's convention -- not the label values themselves).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KappaWeights {
+    None,
+    Linear,
+    Quadratic,
+}
+
+fn kappa_weight(weights: KappaWeights, i: usize, j: usize) -> f64 {
+    match weights {
+        KappaWeights::None => {
+            if i == j {
+                0.0
+            } else {
+                1.0
+            }
+        }
+        KappaWeights::Linear => (i as f64 - j as f64).abs(),
+        KappaWeights::Quadratic => {
+            let d = i as f64 - j as f64;
+            d * d
+        }
+    }
+}
+
+/// Cohen's kappa between two equal-length label-*index* sequences (indices
+/// into a shared, sorted label list of size `n_labels` -- pre-encoded by the
+/// caller; pairwise-incomplete rows must already be dropped).
+///
+/// Matches `sklearn.metrics.cohen_kappa_score` bit-for-bit: builds the
+/// confusion matrix, weights it (see `KappaWeights`), and computes
+/// `1 - sum(w*C) / sum(w*E)`. When the expected-agreement denominator is
+/// zero (e.g. every rating in both columns is the same single category),
+/// sklearn returns `nan` for the resulting `0/0`; this returns `f64::NAN`
+/// too (not an `Option::None`) so the caller can propagate it into a
+/// Polars-null-free `Float64` the same way sklearn does into a numpy float.
+pub fn cohens_kappa(a: &[usize], b: &[usize], n_labels: usize, weights: KappaWeights) -> f64 {
+    debug_assert_eq!(a.len(), b.len());
+    let n = a.len();
+    if n == 0 || n_labels == 0 {
+        return f64::NAN;
+    }
+
+    let mut confusion = vec![0f64; n_labels * n_labels];
+    for (&ai, &bi) in a.iter().zip(b.iter()) {
+        confusion[ai * n_labels + bi] += 1.0;
+    }
+    let n_f = n as f64;
+
+    let mut row_sum = vec![0f64; n_labels];
+    let mut col_sum = vec![0f64; n_labels];
+    for i in 0..n_labels {
+        for j in 0..n_labels {
+            let c = confusion[i * n_labels + j];
+            row_sum[i] += c;
+            col_sum[j] += c;
+        }
+    }
+
+    let mut weighted_observed = 0f64;
+    let mut weighted_expected = 0f64;
+    for i in 0..n_labels {
+        for j in 0..n_labels {
+            let w = kappa_weight(weights, i, j);
+            if w == 0.0 {
+                continue;
+            }
+            weighted_observed += w * confusion[i * n_labels + j];
+            let expected = row_sum[i] * col_sum[j] / n_f;
+            weighted_expected += w * expected;
+        }
+    }
+
+    if weighted_expected == 0.0 {
+        return f64::NAN;
+    }
+
+    1.0 - weighted_observed / weighted_expected
+}
+
+// ============================================================================
+// Krippendorff's alpha
+// ============================================================================
+
+/// Level of measurement, governing the difference function `delta^2(c, k)`
+/// used by the coincidence-matrix formula.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlphaLevel {
+    Nominal,
+    Ordinal,
+    Interval,
+    Ratio,
+}
+
+/// Krippendorff's alpha over `units`: each element is one unit's non-null
+/// ratings (already filtered of nulls by the caller). For `Nominal`, values
+/// are pre-encoded category ids as `f64`; for `Ordinal`/`Interval`/`Ratio`
+/// they are the numeric ratings themselves.
+///
+/// Implements the coincidence-matrix construction: units with fewer than 2
+/// ratings are excluded (they contribute no pairs), a coincidence matrix
+/// `o[c][k]` is built by distributing `1 / (m_u - 1)` over every ordered
+/// pair of a unit's rating *slots* (not distinct values -- two raters both
+/// giving category `c` still contributes `o[c][c]`), and
+/// `alpha = 1 - (n-1) * sum(o * delta2) / sum(n_marg (x) n_marg * delta2)`.
+///
+/// Two conventions diverge from the reference `krippendorff` PyPI package,
+/// which raises `ValueError` in both cases (an expression must not panic
+/// per-group):
+/// - No unit has >= 2 ratings (nothing pairable): returns `None` (null),
+///   where the package raises.
+/// - The observed domain has a single category (every rating, across every
+///   included unit, is identical) -- so `delta2` is 0 for every pair and the
+///   expected-disagreement denominator is 0: returns `Some(1.0)` ("trivially
+///   perfect agreement") by documented convention, where the package raises
+///   `ValueError("value in domain")`.
+pub fn krippendorff_alpha(units: &[Vec<f64>], level: AlphaLevel) -> Option<f64> {
+    let included: Vec<&Vec<f64>> = units.iter().filter(|u| u.len() >= 2).collect();
+    if included.is_empty() {
+        return None;
+    }
+
+    // Sorted distinct observed values over included units -- the category
+    // domain. Numeric sort (not NaN-safe by design: ratings are expected to
+    // be finite; callers must filter NaN/inf upstream same as nulls).
+    let mut domain: Vec<f64> = included.iter().flat_map(|u| u.iter().copied()).collect();
+    // total_cmp is a total order over all f64 (incl. any NaN that slipped past
+    // the upstream finiteness filter), so the sort/search can never panic.
+    domain.sort_by(|a, b| a.total_cmp(b));
+    domain.dedup();
+    let n_cat = domain.len();
+
+    let index_of = |v: f64| -> usize {
+        domain
+            .binary_search_by(|x| x.total_cmp(&v))
+            .expect("value must be in domain by construction")
+    };
+
+    let mut coincidence = vec![0f64; n_cat * n_cat];
+    for unit in &included {
+        let m = unit.len();
+        let denom = (m - 1) as f64;
+        for i in 0..m {
+            let ci = index_of(unit[i]);
+            for j in 0..m {
+                if i == j {
+                    continue;
+                }
+                let cj = index_of(unit[j]);
+                coincidence[ci * n_cat + cj] += 1.0 / denom;
+            }
+        }
+    }
+
+    let mut marginal = vec![0f64; n_cat];
+    for c in 0..n_cat {
+        for k in 0..n_cat {
+            marginal[c] += coincidence[c * n_cat + k];
+        }
+    }
+    let n_total: f64 = marginal.iter().sum();
+
+    let delta2 = |c: usize, k: usize| -> f64 {
+        match level {
+            AlphaLevel::Nominal => {
+                if c == k {
+                    0.0
+                } else {
+                    1.0
+                }
+            }
+            AlphaLevel::Ordinal => {
+                // Sum of coincidence-matrix marginals over categories from
+                // c to k inclusive, in sorted domain order -- not raw
+                // frequencies. Using raw counts here is the classic
+                // implementation mistake this fixture-tests against.
+                let (lo, hi) = if c <= k { (c, k) } else { (k, c) };
+                let span: f64 = marginal[lo..=hi].iter().sum();
+                let term = span - (marginal[c] + marginal[k]) / 2.0;
+                term * term
+            }
+            AlphaLevel::Interval => {
+                let d = domain[c] - domain[k];
+                d * d
+            }
+            AlphaLevel::Ratio => {
+                let s = domain[c] + domain[k];
+                if s == 0.0 {
+                    0.0
+                } else {
+                    let d = (domain[c] - domain[k]) / s;
+                    d * d
+                }
+            }
+        }
+    };
+
+    let mut observed_disagreement = 0f64;
+    let mut expected_disagreement = 0f64;
+    for c in 0..n_cat {
+        for k in 0..n_cat {
+            let d2 = delta2(c, k);
+            if d2 == 0.0 {
+                continue;
+            }
+            observed_disagreement += coincidence[c * n_cat + k] * d2;
+            expected_disagreement += marginal[c] * marginal[k] * d2;
+        }
+    }
+
+    if expected_disagreement == 0.0 {
+        // Single-category domain (or a level whose delta2 vanishes for
+        // every pair present): agreement is trivially perfect by
+        // convention. See the doc comment above.
+        return Some(1.0);
+    }
+
+    Some(1.0 - (n_total - 1.0) * observed_disagreement / expected_disagreement)
+}
+
+// ============================================================================
+// Bootstrap confidence intervals
+// ============================================================================
+
+/// Linear-interpolation quantile (numpy's default, "type 7"), over an
+/// already-sorted slice.
+fn quantile_sorted(sorted: &[f64], p: f64) -> f64 {
+    let n = sorted.len();
+    if n == 1 {
+        return sorted[0];
+    }
+    let h = (n - 1) as f64 * p;
+    let lo = h.floor() as usize;
+    let hi = h.ceil() as usize;
+    if lo == hi {
+        return sorted[lo];
+    }
+    let frac = h - lo as f64;
+    sorted[lo] + (sorted[hi] - sorted[lo]) * frac
+}
+
+/// Nonparametric case (unit/row) bootstrap: resample `n_units` indices with
+/// replacement `b` times, call `estimate` on each resample (indices into
+/// whatever unit population the caller cares about -- pairwise-complete row
+/// pairs for kappa, unit rows for alpha), and return a percentile CI at
+/// `((1-ci)/2, 1-(1-ci)/2)` using linear-interpolation quantiles.
+///
+/// `estimate` may return `NaN` for a degenerate resample (e.g. a resample
+/// that collapses to a single category); such resamples are dropped from
+/// the percentile computation. If more than half of the `b` resamples are
+/// degenerate, this returns `None` (the caller should surface null CI
+/// fields, keeping the point estimate on the original data unaffected).
+pub fn bootstrap_ci<F>(estimate: F, n_units: usize, b: usize, ci: f64, seed: u64) -> Option<(f64, f64)>
+where
+    F: Fn(&[usize]) -> f64,
+{
+    if n_units == 0 || b == 0 {
+        return None;
+    }
+
+    let mut rng = SplitMix64::new(seed);
+    let mut values: Vec<f64> = Vec::with_capacity(b);
+    for _ in 0..b {
+        let mut idx = Vec::with_capacity(n_units);
+        for _ in 0..n_units {
+            idx.push(rng.next_below(n_units));
+        }
+        let v = estimate(&idx);
+        if v.is_finite() {
+            values.push(v);
+        }
+    }
+
+    if values.len() * 2 < b {
+        return None;
+    }
+
+    values.sort_by(|a, b2| a.partial_cmp(b2).expect("non-finite bootstrap estimate"));
+    let lo_q = (1.0 - ci) / 2.0;
+    let hi_q = 1.0 - lo_q;
+    Some((quantile_sorted(&values, lo_q), quantile_sorted(&values, hi_q)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_close(actual: f64, expected: f64, tol: f64) {
+        assert!(
+            (actual - expected).abs() < tol,
+            "expected {expected}, got {actual} (tol {tol})"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Cohen's kappa
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_kappa_2x2_exact() {
+        // Confusion matrix [[20,5],[10,15]], n=50: p_o=0.7, p_e=0.5, kappa=0.4.
+        let mut a = Vec::new();
+        let mut b = Vec::new();
+        for _ in 0..20 {
+            a.push(0);
+            b.push(0);
+        }
+        for _ in 0..5 {
+            a.push(0);
+            b.push(1);
+        }
+        for _ in 0..10 {
+            a.push(1);
+            b.push(0);
+        }
+        for _ in 0..15 {
+            a.push(1);
+            b.push(1);
+        }
+        let k = cohens_kappa(&a, &b, 2, KappaWeights::None);
+        assert_close(k, 0.4, 1e-12);
+    }
+
+    #[test]
+    fn test_kappa_weighted_fixture() {
+        // y1=[0,0,0,1,1,1,2,2,2,1], y2=[0,0,1,1,1,2,2,2,2,0] -- confirmed
+        // against sklearn.metrics.cohen_kappa_score.
+        let a = vec![0, 0, 0, 1, 1, 1, 2, 2, 2, 1];
+        let b = vec![0, 0, 1, 1, 1, 2, 2, 2, 2, 0];
+        assert_close(
+            cohens_kappa(&a, &b, 3, KappaWeights::None),
+            0.5522388059701492,
+            1e-9,
+        );
+        assert_close(
+            cohens_kappa(&a, &b, 3, KappaWeights::Linear),
+            0.6590909090909092,
+            1e-9,
+        );
+        assert_close(
+            cohens_kappa(&a, &b, 3, KappaWeights::Quadratic),
+            0.7692307692307692,
+            1e-9,
+        );
+    }
+
+    #[test]
+    fn test_kappa_single_category_is_nan() {
+        let a = vec![0, 0, 0];
+        let b = vec![0, 0, 0];
+        let k = cohens_kappa(&a, &b, 1, KappaWeights::None);
+        assert!(k.is_nan());
+    }
+
+    #[test]
+    fn test_kappa_perfect_agreement() {
+        let a = vec![0, 1, 0, 1];
+        let b = vec![0, 1, 0, 1];
+        assert_close(cohens_kappa(&a, &b, 2, KappaWeights::None), 1.0, 1e-12);
+    }
+
+    #[test]
+    fn test_kappa_systematic_disagreement() {
+        // labels [1,2] -> indices [0,1]; a=[0,1,0,1], b=[1,0,1,0]
+        let a = vec![0, 1, 0, 1];
+        let b = vec![1, 0, 1, 0];
+        assert_close(cohens_kappa(&a, &b, 2, KappaWeights::None), -1.0, 1e-12);
+    }
+
+    // ------------------------------------------------------------------
+    // Krippendorff's alpha
+    // ------------------------------------------------------------------
+
+    /// Krippendorff's canonical reliability-data example (2004/2011),
+    /// 4 observers x 12 units; `None` = missing. Unit 12 (index 11) has
+    /// only one rating and is excluded.
+    fn fixture_a() -> Vec<Vec<f64>> {
+        let raw: [[Option<f64>; 12]; 4] = [
+            [
+                Some(1.0), Some(2.0), Some(3.0), Some(3.0), Some(2.0), Some(1.0),
+                Some(4.0), Some(1.0), Some(2.0), None, None, None,
+            ],
+            [
+                Some(1.0), Some(2.0), Some(3.0), Some(3.0), Some(2.0), Some(2.0),
+                Some(4.0), Some(1.0), Some(2.0), Some(5.0), None, Some(3.0),
+            ],
+            [
+                None, Some(3.0), Some(3.0), Some(3.0), Some(2.0), Some(3.0),
+                Some(4.0), Some(2.0), Some(2.0), Some(5.0), Some(1.0), None,
+            ],
+            [
+                Some(1.0), Some(2.0), Some(3.0), Some(3.0), Some(2.0), Some(4.0),
+                Some(4.0), Some(1.0), Some(2.0), Some(5.0), Some(1.0), None,
+            ],
+        ];
+        let mut units = Vec::new();
+        for col in 0..12 {
+            let mut ratings = Vec::new();
+            for row in raw.iter() {
+                if let Some(v) = row[col] {
+                    ratings.push(v);
+                }
+            }
+            units.push(ratings);
+        }
+        units
+    }
+
+    /// The `krippendorff` PyPI README example, 3 coders x 15 units.
+    fn fixture_b() -> Vec<Vec<f64>> {
+        let raw: [[Option<f64>; 15]; 3] = [
+            [
+                None, None, None, None, None, Some(3.0), Some(4.0), Some(1.0),
+                Some(2.0), Some(1.0), Some(1.0), Some(3.0), Some(3.0), None, Some(3.0),
+            ],
+            [
+                Some(1.0), None, Some(2.0), Some(1.0), Some(3.0), Some(3.0), Some(4.0),
+                Some(3.0), None, None, None, None, None, None, None,
+            ],
+            [
+                None, None, Some(2.0), Some(1.0), Some(3.0), Some(4.0), Some(4.0),
+                None, Some(2.0), Some(1.0), Some(1.0), Some(3.0), Some(3.0), None, Some(4.0),
+            ],
+        ];
+        let mut units = Vec::new();
+        for col in 0..15 {
+            let mut ratings = Vec::new();
+            for row in raw.iter() {
+                if let Some(v) = row[col] {
+                    ratings.push(v);
+                }
+            }
+            units.push(ratings);
+        }
+        units
+    }
+
+    #[test]
+    fn test_alpha_fixture_a_all_levels() {
+        let units = fixture_a();
+        assert_close(
+            krippendorff_alpha(&units, AlphaLevel::Nominal).unwrap(),
+            0.743421052631579,
+            1e-9,
+        );
+        assert_close(
+            krippendorff_alpha(&units, AlphaLevel::Ordinal).unwrap(),
+            0.8153875037548814,
+            1e-9,
+        );
+        assert_close(
+            krippendorff_alpha(&units, AlphaLevel::Interval).unwrap(),
+            0.8491071428571428,
+            1e-9,
+        );
+        assert_close(
+            krippendorff_alpha(&units, AlphaLevel::Ratio).unwrap(),
+            0.7974027747116121,
+            1e-9,
+        );
+    }
+
+    #[test]
+    fn test_alpha_fixture_b_all_levels() {
+        let units = fixture_b();
+        assert_close(
+            krippendorff_alpha(&units, AlphaLevel::Nominal).unwrap(),
+            0.691358024691358,
+            1e-9,
+        );
+        assert_close(
+            krippendorff_alpha(&units, AlphaLevel::Ordinal).unwrap(),
+            0.8067214199413153,
+            1e-9,
+        );
+        assert_close(
+            krippendorff_alpha(&units, AlphaLevel::Interval).unwrap(),
+            0.8108448928121059,
+            1e-9,
+        );
+        assert_close(
+            krippendorff_alpha(&units, AlphaLevel::Ratio).unwrap(),
+            0.8089436707842471,
+            1e-9,
+        );
+    }
+
+    #[test]
+    fn test_alpha_perfect_agreement() {
+        let units = vec![vec![1.0, 1.0], vec![2.0, 2.0], vec![1.0, 1.0, 1.0]];
+        assert_close(
+            krippendorff_alpha(&units, AlphaLevel::Nominal).unwrap(),
+            1.0,
+            1e-12,
+        );
+    }
+
+    #[test]
+    fn test_alpha_systematic_disagreement() {
+        // [[1,2,1,2],[2,1,2,1]] nominal -> -0.75 (confirmed against the
+        // krippendorff package).
+        let units = vec![
+            vec![1.0, 2.0],
+            vec![2.0, 1.0],
+            vec![1.0, 2.0],
+            vec![2.0, 1.0],
+        ];
+        assert_close(
+            krippendorff_alpha(&units, AlphaLevel::Nominal).unwrap(),
+            -0.75,
+            1e-9,
+        );
+    }
+
+    #[test]
+    fn test_alpha_single_category_is_one() {
+        let units = vec![vec![1.0, 1.0], vec![1.0, 1.0, 1.0]];
+        assert_close(
+            krippendorff_alpha(&units, AlphaLevel::Nominal).unwrap(),
+            1.0,
+            1e-12,
+        );
+    }
+
+    #[test]
+    fn test_alpha_no_pairable_units_is_none() {
+        let units = vec![vec![1.0], vec![2.0]];
+        assert_eq!(krippendorff_alpha(&units, AlphaLevel::Nominal), None);
+    }
+
+    #[test]
+    fn test_alpha_empty_is_none() {
+        let units: Vec<Vec<f64>> = vec![];
+        assert_eq!(krippendorff_alpha(&units, AlphaLevel::Nominal), None);
+    }
+
+    // ------------------------------------------------------------------
+    // Bootstrap
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_bootstrap_ci_deterministic_for_fixed_seed() {
+        let units = fixture_a();
+        let n = units.len();
+        let estimate = |idx: &[usize]| {
+            let resampled: Vec<Vec<f64>> = idx.iter().map(|&i| units[i].clone()).collect();
+            krippendorff_alpha(&resampled, AlphaLevel::Nominal).unwrap_or(f64::NAN)
+        };
+        let ci1 = bootstrap_ci(estimate, n, 500, 0.95, 42).unwrap();
+        let ci2 = bootstrap_ci(estimate, n, 500, 0.95, 42).unwrap();
+        assert_eq!(ci1, ci2);
+        assert!(ci1.0 <= ci1.1);
+    }
+
+    #[test]
+    fn test_bootstrap_ci_brackets_point_estimate() {
+        let units = fixture_a();
+        let n = units.len();
+        let point = krippendorff_alpha(&units, AlphaLevel::Nominal).unwrap();
+        let estimate = |idx: &[usize]| {
+            let resampled: Vec<Vec<f64>> = idx.iter().map(|&i| units[i].clone()).collect();
+            krippendorff_alpha(&resampled, AlphaLevel::Nominal).unwrap_or(f64::NAN)
+        };
+        let (lo, hi) = bootstrap_ci(estimate, n, 1000, 0.95, 0).unwrap();
+        assert!(lo <= point + 1e-6);
+        assert!(hi >= point - 1e-6);
+    }
+
+    #[test]
+    fn test_bootstrap_ci_empty_is_none() {
+        let estimate = |_idx: &[usize]| 0.0;
+        assert_eq!(bootstrap_ci(estimate, 0, 100, 0.95, 0), None);
+        assert_eq!(bootstrap_ci(estimate, 5, 0, 0.95, 0), None);
+    }
+}

--- a/tests/test_irr_metrics.py
+++ b/tests/test_irr_metrics.py
@@ -1,0 +1,388 @@
+"""Tests for inter-rater reliability metrics (issue #79): `cohens_kappa`,
+`krippendorffs_alpha`.
+
+All expected values are hardcoded floats, independently verified against
+published reference fixtures / reference implementations
+(`sklearn.metrics.cohen_kappa_score`, the `krippendorff` PyPI package) at
+planning time -- this test file has no runtime dependency on either
+package and is CI-safe (no network, no API key, no `mlx`).
+
+Fixture A is Krippendorff's own canonical reliability-data example (2004 /
+2011 "Computing Krippendorff's Alpha-Reliability"), 4 observers x 12 units.
+Fixture B is the `krippendorff` PyPI package's own README example, 3
+coders x 15 units.
+"""
+
+import math
+
+import polars as pl
+import pytest
+
+from polar_llama import cohens_kappa, krippendorffs_alpha
+
+TOL = 1e-9
+
+
+def approx(expected: float) -> pytest.approx:
+    return pytest.approx(expected, abs=TOL)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+# Krippendorff's canonical reliability-data example, 4 observers x 12
+# units. Unit 12 has only one (non-null) rating and is excluded internally.
+FIXTURE_A = {
+    "A": [1, 2, 3, 3, 2, 1, 4, 1, 2, None, None, None],
+    "B": [1, 2, 3, 3, 2, 2, 4, 1, 2, 5, None, 3],
+    "C": [None, 3, 3, 3, 2, 3, 4, 2, 2, 5, 1, None],
+    "D": [1, 2, 3, 3, 2, 4, 4, 1, 2, 5, 1, None],
+}
+
+# The krippendorff PyPI README example, 3 coders x 15 units.
+FIXTURE_B = {
+    "A": [None, None, None, None, None, 3, 4, 1, 2, 1, 1, 3, 3, None, 3],
+    "B": [1, None, 2, 1, 3, 3, 4, 3, None, None, None, None, None, None, None],
+    "C": [None, None, 2, 1, 3, 4, 4, None, 2, 1, 1, 3, 3, None, 4],
+}
+
+
+# ============================================================================
+# Krippendorff's alpha -- Fixture A (all 4 levels)
+# ============================================================================
+
+
+class TestAlphaFixtureA:
+    df = pl.DataFrame(FIXTURE_A)
+
+    def test_nominal(self):
+        result = self.df.select(a=krippendorffs_alpha(["A", "B", "C", "D"], level="nominal"))
+        assert result["a"][0] == approx(0.743421052631579)
+
+    def test_ordinal(self):
+        result = self.df.select(a=krippendorffs_alpha(["A", "B", "C", "D"], level="ordinal"))
+        assert result["a"][0] == approx(0.8153875037548814)
+
+    def test_interval(self):
+        result = self.df.select(a=krippendorffs_alpha(["A", "B", "C", "D"], level="interval"))
+        assert result["a"][0] == approx(0.8491071428571428)
+
+    def test_ratio(self):
+        result = self.df.select(a=krippendorffs_alpha(["A", "B", "C", "D"], level="ratio"))
+        assert result["a"][0] == approx(0.7974027747116121)
+
+
+# ============================================================================
+# Krippendorff's alpha -- Fixture B (all 4 levels)
+# ============================================================================
+
+
+class TestAlphaFixtureB:
+    df = pl.DataFrame(FIXTURE_B)
+
+    def test_nominal(self):
+        result = self.df.select(a=krippendorffs_alpha(["A", "B", "C"], level="nominal"))
+        assert result["a"][0] == approx(0.691358024691358)
+
+    def test_ordinal(self):
+        result = self.df.select(a=krippendorffs_alpha(["A", "B", "C"], level="ordinal"))
+        assert result["a"][0] == approx(0.8067214199413153)
+
+    def test_interval(self):
+        result = self.df.select(a=krippendorffs_alpha(["A", "B", "C"], level="interval"))
+        assert result["a"][0] == approx(0.8108448928121059)
+
+    def test_ratio(self):
+        result = self.df.select(a=krippendorffs_alpha(["A", "B", "C"], level="ratio"))
+        assert result["a"][0] == approx(0.8089436707842471)
+
+
+# ============================================================================
+# Cohen's kappa -- hand-derivable + sklearn-confirmed fixtures
+# ============================================================================
+
+
+class TestKappaFixtures:
+    def test_2x2_exact(self):
+        # Confusion matrix [[20,5],[10,15]], n=50: p_o=0.7, p_e=0.5, kappa=0.4.
+        a = [0] * 20 + [0] * 5 + [1] * 10 + [1] * 15
+        b = [0] * 20 + [1] * 5 + [0] * 10 + [1] * 15
+        df = pl.DataFrame({"a": a, "b": b})
+        result = df.select(k=cohens_kappa("a", "b"))
+        assert result["k"][0] == approx(0.4)
+
+    def test_weighted_unweighted(self):
+        y1 = [0, 0, 0, 1, 1, 1, 2, 2, 2, 1]
+        y2 = [0, 0, 1, 1, 1, 2, 2, 2, 2, 0]
+        df = pl.DataFrame({"y1": y1, "y2": y2})
+        result = df.select(k=cohens_kappa("y1", "y2"))
+        assert result["k"][0] == approx(0.5522388059701492)
+
+    def test_weighted_linear(self):
+        y1 = [0, 0, 0, 1, 1, 1, 2, 2, 2, 1]
+        y2 = [0, 0, 1, 1, 1, 2, 2, 2, 2, 0]
+        df = pl.DataFrame({"y1": y1, "y2": y2})
+        result = df.select(k=cohens_kappa("y1", "y2", weights="linear"))
+        assert result["k"][0] == approx(0.6590909090909092)
+
+    def test_weighted_quadratic(self):
+        y1 = [0, 0, 0, 1, 1, 1, 2, 2, 2, 1]
+        y2 = [0, 0, 1, 1, 1, 2, 2, 2, 2, 0]
+        df = pl.DataFrame({"y1": y1, "y2": y2})
+        result = df.select(k=cohens_kappa("y1", "y2", weights="quadratic"))
+        assert result["k"][0] == approx(0.7692307692307692)
+
+    def test_pairwise_null_interleaved_unchanged(self):
+        # Same 2x2 fixture as test_2x2_exact, but with nulls interleaved
+        # into both columns at matching row positions (so the pairwise-
+        # complete subset is identical) -- result must be unchanged (0.4).
+        a = [0] * 20 + [0] * 5 + [1] * 10 + [1] * 15
+        b = [0] * 20 + [1] * 5 + [0] * 10 + [1] * 15
+        # Insert a handful of null rows (only one side null per row).
+        a2 = a[:5] + [None] + a[5:10] + [None] + a[10:]
+        b2 = b[:5] + [1] + b[5:10] + [None] + b[10:]
+        df = pl.DataFrame({"a": a2, "b": b2})
+        result = df.select(k=cohens_kappa("a", "b"))
+        assert result["k"][0] == approx(0.4)
+
+
+# ============================================================================
+# Edge cases
+# ============================================================================
+
+
+class TestEdgeCases:
+    def test_kappa_single_category_is_nan(self):
+        df = pl.DataFrame({"a": [1, 1, 1], "b": [1, 1, 1]})
+        result = df.select(k=cohens_kappa("a", "b"))
+        assert math.isnan(result["k"][0])
+
+    def test_alpha_single_category_is_one(self):
+        df = pl.DataFrame({"r1": [1, 1, 1], "r2": [1, 1, 1]})
+        result = df.select(a=krippendorffs_alpha(["r1", "r2"]))
+        assert result["a"][0] == approx(1.0)
+
+    def test_kappa_perfect_agreement(self):
+        df = pl.DataFrame({"a": [1, 2, 1, 2], "b": [1, 2, 1, 2]})
+        result = df.select(k=cohens_kappa("a", "b"))
+        assert result["k"][0] == approx(1.0)
+
+    def test_alpha_perfect_agreement(self):
+        df = pl.DataFrame({"r1": [1, 2, 1, 2], "r2": [1, 2, 1, 2]})
+        result = df.select(a=krippendorffs_alpha(["r1", "r2"]))
+        assert result["a"][0] == approx(1.0)
+
+    def test_kappa_systematic_disagreement(self):
+        df = pl.DataFrame({"a": [1, 2, 1, 2], "b": [2, 1, 2, 1]})
+        result = df.select(k=cohens_kappa("a", "b"))
+        assert result["k"][0] == approx(-1.0)
+
+    def test_alpha_systematic_disagreement(self):
+        # Krippendorff's own [[1,2,1,2],[2,1,2,1]] nominal fixture -> -0.75.
+        df = pl.DataFrame({"r1": [1, 2, 1, 2], "r2": [2, 1, 2, 1]})
+        result = df.select(a=krippendorffs_alpha(["r1", "r2"]))
+        assert result["a"][0] == approx(-0.75)
+
+    def test_kappa_zero_pairwise_complete_is_null(self):
+        df = pl.DataFrame({"a": [1, None], "b": [None, 2]}, schema={"a": pl.Int64, "b": pl.Int64})
+        result = df.select(k=cohens_kappa("a", "b"))
+        assert result["k"][0] is None
+
+    def test_alpha_no_pairable_units_is_null(self):
+        df = pl.DataFrame({"a": [1, None], "b": [None, 2]}, schema={"a": pl.Int64, "b": pl.Int64})
+        result = df.select(a=krippendorffs_alpha(["a", "b"]))
+        assert result["a"][0] is None
+
+    def test_kappa_empty_columns_is_null(self):
+        df = pl.DataFrame({"a": [], "b": []}, schema={"a": pl.Int64, "b": pl.Int64})
+        result = df.select(k=cohens_kappa("a", "b"))
+        assert result["k"][0] is None
+
+    def test_alpha_all_null_columns_is_null(self):
+        df = pl.DataFrame(
+            {"a": [None, None], "b": [None, None]}, schema={"a": pl.Int64, "b": pl.Int64}
+        )
+        result = df.select(a=krippendorffs_alpha(["a", "b"]))
+        assert result["a"][0] is None
+
+    def test_alpha_missing_data_matches_fixture_a(self):
+        # Re-assert Fixture A nominal specifically to document that missing
+        # data (nulls) is exercised by the headline fixture, not just the
+        # dedicated null-handling tests above.
+        df = pl.DataFrame(FIXTURE_A)
+        result = df.select(a=krippendorffs_alpha(["A", "B", "C", "D"]))
+        assert result["a"][0] == approx(0.743421052631579)
+
+
+# ============================================================================
+# group_by context: per-group values match per-slice computation
+# ============================================================================
+
+
+class TestGroupByContext:
+    def test_kappa_per_group_matches_slice(self):
+        a1 = [0] * 20 + [0] * 5 + [1] * 10 + [1] * 15
+        b1 = [0] * 20 + [1] * 5 + [0] * 10 + [1] * 15
+        a2 = [0, 0, 0, 1, 1, 1, 2, 2, 2, 1]
+        b2 = [0, 0, 1, 1, 1, 2, 2, 2, 2, 0]
+
+        df = pl.DataFrame(
+            {
+                "group": ["g1"] * len(a1) + ["g2"] * len(a2),
+                "a": a1 + a2,
+                "b": b1 + b2,
+            }
+        )
+        result = df.group_by("group", maintain_order=True).agg(k=cohens_kappa("a", "b"))
+        values = dict(zip(result["group"], result["k"]))
+        assert values["g1"] == approx(0.4)
+        assert values["g2"] == approx(0.5522388059701492)
+
+    def test_alpha_per_group_matches_slice(self):
+        n_a = len(FIXTURE_A["A"])
+        df = pl.DataFrame(
+            {
+                "group": ["g1"] * n_a + ["g2"] * n_a,
+                "r1": FIXTURE_A["A"] + FIXTURE_A["A"],
+                "r2": FIXTURE_A["B"] + FIXTURE_A["B"],
+                "r3": FIXTURE_A["C"] + FIXTURE_A["C"],
+                "r4": FIXTURE_A["D"] + FIXTURE_A["D"],
+            }
+        )
+        result = df.group_by("group", maintain_order=True).agg(
+            a=krippendorffs_alpha(["r1", "r2", "r3", "r4"])
+        )
+        for v in result["a"]:
+            assert v == approx(0.743421052631579)
+
+
+# ============================================================================
+# Bootstrap CIs
+# ============================================================================
+
+
+class TestBootstrap:
+    def test_kappa_bootstrap_returns_struct(self):
+        a = [0] * 20 + [0] * 5 + [1] * 10 + [1] * 15
+        b = [0] * 20 + [1] * 5 + [0] * 10 + [1] * 15
+        df = pl.DataFrame({"a": a, "b": b})
+        result = df.select(
+            cohens_kappa("a", "b", n_bootstrap=200, seed=0).struct.unnest()
+        )
+        assert result.columns == ["value", "ci_low", "ci_high"]
+        assert result["value"][0] == approx(0.4)
+        assert result["ci_low"][0] <= result["value"][0] + 1e-6
+        assert result["ci_high"][0] >= result["value"][0] - 1e-6
+
+    def test_alpha_bootstrap_determinism_same_seed(self):
+        df = pl.DataFrame(FIXTURE_A)
+        r1 = df.select(
+            krippendorffs_alpha(
+                ["A", "B", "C", "D"], n_bootstrap=1000, seed=42
+            ).struct.unnest()
+        )
+        r2 = df.select(
+            krippendorffs_alpha(
+                ["A", "B", "C", "D"], n_bootstrap=1000, seed=42
+            ).struct.unnest()
+        )
+        assert r1["ci_low"][0] == r2["ci_low"][0]
+        assert r1["ci_high"][0] == r2["ci_high"][0]
+        assert r1["value"][0] == approx(0.743421052631579)
+
+    def test_alpha_bootstrap_ci_brackets_point_estimate(self):
+        df = pl.DataFrame(FIXTURE_A)
+        result = df.select(
+            krippendorffs_alpha(
+                ["A", "B", "C", "D"], n_bootstrap=1000, seed=0
+            ).struct.unnest()
+        )
+        value, lo, hi = result["value"][0], result["ci_low"][0], result["ci_high"][0]
+        assert lo <= value + 1e-6
+        assert hi >= value - 1e-6
+
+    def test_no_bootstrap_returns_plain_float(self):
+        df = pl.DataFrame(FIXTURE_A)
+        result = df.select(a=krippendorffs_alpha(["A", "B", "C", "D"]))
+        assert result.schema["a"] == pl.Float64
+
+
+# ============================================================================
+# .llama namespace
+# ============================================================================
+
+
+class TestNamespace:
+    def test_kappa_namespace(self):
+        df = pl.DataFrame({"a": [1, 2, 1, 2], "b": [1, 2, 1, 2]})
+        result = df.select(k=pl.col("a").llama.cohens_kappa("b"))
+        assert result["k"][0] == approx(1.0)
+
+    def test_alpha_namespace(self):
+        df = pl.DataFrame(FIXTURE_A)
+        result = df.select(a=pl.col("A").llama.krippendorffs_alpha("B", "C", "D"))
+        assert result["a"][0] == approx(0.743421052631579)
+
+
+# ============================================================================
+# Validation
+# ============================================================================
+
+
+class TestValidation:
+    def test_invalid_weights_raises(self):
+        with pytest.raises(ValueError):
+            cohens_kappa("a", "b", weights="bogus")
+
+    def test_invalid_level_raises(self):
+        with pytest.raises(ValueError):
+            krippendorffs_alpha(["a", "b"], level="bogus")
+
+    def test_invalid_ci_raises(self):
+        with pytest.raises(ValueError):
+            cohens_kappa("a", "b", n_bootstrap=10, ci=1.5)
+
+    def test_too_few_alpha_columns_raises(self):
+        with pytest.raises(ValueError):
+            krippendorffs_alpha(["a"])
+
+    def test_ordinal_alpha_rejects_string_columns(self):
+        df = pl.DataFrame({"r1": ["low", "high"], "r2": ["low", "high"]})
+        with pytest.raises(pl.exceptions.PolarsError):
+            df.select(krippendorffs_alpha(["r1", "r2"], level="ordinal")).item()
+
+
+def test_nan_ratings_treated_as_missing_no_panic():
+    """Regression (#79 review): a NaN float in a rater column must be treated
+    as missing (like the reference krippendorff package), not panic the plugin
+    or become a spurious label."""
+    # krippendorffs_alpha: NaN in a float column == missing, no query abort.
+    df = pl.DataFrame(
+        {
+            "A": [1.0, 2.0, float("nan"), 4.0],
+            "B": [1.0, 2.0, 3.0, 4.0],
+            "C": [1.0, float("nan"), 3.0, 4.0],
+        }
+    )
+    a = df.select(a=krippendorffs_alpha(["A", "B", "C"], level="interval"))["a"][0]
+    assert a is not None and math.isfinite(a)  # computed, not a crash/NaN
+
+    # Same data with the NaNs written as nulls must give an identical alpha.
+    df_null = pl.DataFrame(
+        {
+            "A": [1.0, 2.0, None, 4.0],
+            "B": [1.0, 2.0, 3.0, 4.0],
+            "C": [1.0, None, 3.0, 4.0],
+        }
+    )
+    a_null = df_null.select(a=krippendorffs_alpha(["A", "B", "C"], level="interval"))["a"][0]
+    assert abs(a - a_null) < 1e-12
+
+    # cohens_kappa: NaN rows dropped as missing (pairwise-complete), no panic.
+    dfk = pl.DataFrame({"a": [1.0, 2.0, float("nan"), 3.0], "b": [1.0, 2.0, 2.0, 3.0]})
+    k = dfk.select(k=cohens_kappa("a", "b"))["k"][0]
+    k_null = pl.DataFrame({"a": [1.0, 2.0, None, 3.0], "b": [1.0, 2.0, 2.0, 3.0]}).select(
+        k=cohens_kappa("a", "b")
+    )["k"][0]
+    assert (k is None and k_null is None) or abs(k - k_null) < 1e-12


### PR DESCRIPTION
Closes #79. Ships as **0.7.1**. **Zero new dependencies** (metrics hand-implemented in Rust).

## What
Two DataFrame-native reliability metrics as Rust Polars aggregation expressions (`returns_scalar`), composing in `select()` / `group_by().agg()`:
- **`cohens_kappa(a, b, *, weights=None|"linear"|"quadratic")`** — pairwise-complete over two rater columns.
- **`krippendorffs_alpha(cols, *, level="nominal"|"ordinal"|"interval"|"ratio")`** — coincidence-matrix over M raters × N units with missing data.
- **Bootstrap CIs** (seeded/deterministic) via `*_ci` variants → `Struct{value, ci_low, ci_high}`.

Extends `utils.register_plugin` with a `returns_scalar` passthrough. Multi-label (MASI) documented as a follow-up.

## Proof — exact reference agreement (stronger than any single fixture)
Independently verified against the **live** reference libraries:
- `cohens_kappa` vs `sklearn.metrics.cohen_kappa_score`: **max |diff| = 6.66e-16** over 200 random cases × 3 weight modes.
- `krippendorffs_alpha` vs the **`krippendorff` PyPI package**: **6.66e-16** over 200 random matrices × 4 levels (M=2–4 raters, ~20% missing).

That's floating-point-exact (machine epsilon) across randomized inputs.

## Adversarial review (Opus) → fixed
Review confirmed the numerical core flawless (κ 4.4e-16 / α 6.7e-16 in its own sweep) and flagged one robustness edge: a **NaN float in a rater column panicked the α plugin**. Fixed three ways — a finiteness guard on ingest, `f64::total_cmp` in the domain sort (defense in depth), and the same non-finite-as-missing rule in the κ label path — plus a NaN-as-missing regression test (asserts NaN gives the identical result to null).

## Tests
`tests/test_irr_metrics.py`: **38 pass** — exact agreement with hardcoded reference values (Krippendorff's canonical example across all levels; sklearn kappa matrices), weighted kappa, missing data, single-category/perfect/negative-agreement edges, bootstrap CIs, NaN regression. No key/no mlx. `cargo clippy --all-features` clean under `-Dwarnings`; 10 Rust `metrics` unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnthn-ai/codesmith/polar_llama/pr/93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786619907&installation_id=141504833&pr_number=93&repository=pnthn-ai%2Fpolar_llama&return_to=https%3A%2F%2Fgithub.com%2Fpnthn-ai%2Fpolar_llama%2Fpull%2F93&signature=e331b4500a2d8a9e1a922bae8896957da7d64ac99d73937b2ef63228557e3637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->