### PR TITLE
feat: survey data-quality flags (quality_report) (#80) + release 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-07-14
+
+### Added
+- **Survey data-quality flags** (`quality_report`, `QualityConfig`, issue #80): a DataFrame-shaped pipeline that scores every respondent for common survey data-quality problems and returns a per-flag summary, without ever dropping a row. Every score is a graded `Float64` in `[0, 1]` (higher = more suspicious); booleans are derived by thresholding, and a null score (not enough signal) always resolves to `flag = False`. Heuristic tier (zero API calls): `straightlining_score`, `gibberish_score`, and `duplicate_answer_score` are new Rust plugin expressions (`src/quality.rs` pure functions, unit-tested there, mirroring the `src/metrics.rs`/issue #79 split); `response_length_score` (robust z-score of answer length) and `speeder_score` (percentile- or median-fraction-based) are pure Polars. All five are available standalone and via the `.llama` namespace (`pl.col("g1").llama.straightlining_score([...])`, etc.). Embedding/LLM tier (opt-in, `QualityConfig(llm_tier=True)`, default off): cross-respondent `near_duplicate` detection (`embedding_async` + `knn_hnsw` + `cosine_similarity`) and a `likely_ai` stylistic-heuristic flag (`inference_messages(..., response_model=...)`, also exposed standalone as `ai_likelihood`) -- both carry a mandatory "flag, not verdict" framing; `likely_ai` additionally documents the false-positive risk of AI-text detectors, including their documented bias against non-native English speakers, and states it must never be sole grounds for exclusion or panelist sanction. `quality_report(df, config)` returns `QualityReport(df, summary)`: `.df` is `df` plus a `quality` struct column (schema reflects which inputs were configured -- unconfigured sub-structs are omitted, not null-filled); `.summary` is one row per active flag plus a final `any_flag` row. All default thresholds are documented, subjective conventions -- see `docs/QUALITY_FLAGS.md`.
+
 ## [0.7.1] - 2026-07-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "polar-llama"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polar-llama"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -624,6 +624,35 @@ coded = result.df.with_columns(
 
 See `docs/CODEBOOK_INDUCTION.md` for the full walkthrough.
 
+#### Survey Data-Quality Flags
+
+Score every respondent in a survey DataFrame for common data-quality problems — straightlining, gibberish open-ends, duplicate answers, response-length outliers, speeding — and get a per-flag summary back, without ever dropping a row. Every score is graded (`Float64` in `[0, 1]`, higher = more suspicious); a null score (not enough signal) always resolves to `flag = False`. The heuristic tier is zero-API; an opt-in embedding/LLM tier adds cross-respondent near-duplicate detection and a stylistic likely-AI-generated-text flag.
+
+```python
+from polar_llama import QualityConfig, quality_report
+
+config = QualityConfig(
+    id_column="respondent_id",
+    grid_columns=["g1", "g2", "g3", "g4", "g5"],   # Likert grid
+    text_columns=["oe1", "oe2"],                    # open-ends
+    duration_column="duration_s",                   # seconds
+)
+result = quality_report(survey_df, config)
+
+result.df.height == survey_df.height   # True — quality_report never drops a row
+result.df.select("respondent_id", "quality").unnest("quality")
+result.summary   # one row per flag: flag, n_scored, n_flagged, rate, threshold, mean_score
+```
+
+**Key Features:**
+- **Never drops a row**: every flag is a threshold on a graded `[0, 1]` score; missing data scores null, which always resolves to `flag = False` — never dropped, never force-flagged.
+- **Zero-API heuristic tier**: `straightlining_score`, `gibberish_score`, and `duplicate_answer_score` are Rust plugin expressions (`src/quality.rs`); `response_length_score` (robust z-score of length) and `speeder_score` (percentile- or median-fraction-based) are pure Polars. All five also work standalone and via `.llama` (`pl.col("g1").llama.straightlining_score([...])`).
+- **Opt-in embedding/LLM tier**: `QualityConfig(llm_tier=True)` adds `near_duplicate` (cross-respondent, via `embedding_async` + `knn_hnsw` + `cosine_similarity`) and `likely_ai` (via `inference_messages(..., response_model=...)`, also exposed standalone as `ai_likelihood`) — off by default, zero network calls unless requested.
+- **Flag, not verdict**: `likely_ai` carries a mandatory limitation warning — AI-text detectors are unreliable and biased against non-native English speakers; treat it as a review-prioritization signal only, never as sole grounds for exclusion or panelist sanction.
+- **Documented, tunable thresholds**: every default threshold is a subjective convention, not a validated cutoff — see `docs/QUALITY_FLAGS.md` section 7.
+
+See `docs/QUALITY_FLAGS.md` for the full formulas, every default threshold, and the AI-detection limitation discussion.
+
 #### Tool Use and MCP
 
 Polar Llama supports tool calling without hiding an agent loop inside your rows. The loop is unrolled into the dataframe: the LLM *emits* tool calls as structured output, `execute_tool_calls` runs every call of every row concurrently (against an MCP server or any Python callable), and a second inference pass synthesizes the results — every intermediate step is an ordinary column.

--- a/docs/QUALITY_FLAGS.md
+++ b/docs/QUALITY_FLAGS.md
@@ -1,0 +1,319 @@
+# Survey Data-Quality Flags
+
+## Overview
+
+`quality_report` scores every respondent (row) in a survey DataFrame for
+common data-quality problems -- straightlining, gibberish/keyboard-mash
+open-ends, duplicate answers, response-length outliers, speeding through
+the survey, cross-respondent near-duplicates, and (opt-in) likely-AI-generated
+text -- and returns a per-flag summary. It is DataFrame-in/DataFrame-out,
+the same shape as `induce_codebook`: a single Polars expression can't return
+both per-row flags and a per-flag summary table (two different heights) at
+once.
+
+**Every score is graded, in `[0, 1]`, higher = more suspicious. Booleans
+(`flag`) are derived by thresholding a score; a null score (not enough
+signal -- too few grid answers, too little text, missing duration) always
+resolves to `flag = False`, never `True`. `quality_report` never drops a
+row.**
+
+Two tiers:
+
+- **Heuristic tier** (always available, zero API calls): `straightlining_score`,
+  `gibberish_score`, `duplicate_answer_score` are Rust plugin expressions
+  (`src/quality.rs` pure functions, unit-tested there, plus the Polars
+  `Series`/null plumbing in `src/expressions.rs` -- mirrors the
+  `src/metrics.rs` / issue #79 split). `response_length_score` and
+  `speeder_score` are a few lines of pure Polars (median/quantile/rank) --
+  there is nothing for a Rust plugin to buy there.
+- **Embedding/LLM tier** (opt-in, `QualityConfig(llm_tier=True)`, default
+  `False`): cross-respondent near-duplicate detection (`embedding_async` +
+  `knn_hnsw` + `cosine_similarity`) and a likely-AI-generated-text flag
+  (`inference_messages(..., response_model=...)`), pure Python composition
+  of existing primitives -- exactly the `induce_codebook` pattern.
+
+## Quick start
+
+```python
+import polars as pl
+from polar_llama import QualityConfig, quality_report
+
+df = pl.DataFrame({
+    "respondent_id": ["r1", "r2", "r3"],
+    "g1": [4, 2, 3], "g2": [4, 4, 2], "g3": [4, 3, 5], "g4": [4, 5, 1], "g5": [4, 1, 4],
+    "oe1": ["fine", "The delivery was quick and the packaging held up well.", "Support was slow but eventually helpful."],
+    "duration_s": [40, 305, 298],
+})
+
+config = QualityConfig(
+    id_column="respondent_id",
+    grid_columns=["g1", "g2", "g3", "g4", "g5"],
+    text_columns=["oe1"],
+    duration_column="duration_s",
+)
+
+result = quality_report(df, config)
+result.df.height == df.height  # True -- never drops a row
+result.df.select("respondent_id", "quality").unnest("quality")
+result.summary
+```
+
+`result.df` gains one struct column (`quality` by default, override with
+`quality_report(df, config, output_column=...)`):
+
+```
+Struct{
+    straightlining:    Struct{score, flag},
+    gibberish:         Struct{score, flag},          # max over text_columns
+    length_outlier:    Struct{score, z, flag},        # max over text_columns
+    duplicate_answers: Struct{score, flag},
+    speeder:           Struct{score, flag},
+    near_duplicate:    Struct{score, neighbor_id, flag},   # only when llm_tier=True
+    likely_ai:         Struct{score, rationale, flag},     # only when llm_tier=True
+    any_flag: bool,
+    n_flags: u32,
+}
+```
+
+Sub-structs for unconfigured inputs are **omitted from the schema
+entirely**, not null-filled -- e.g. no `duration_column` means no `speeder`
+field at all.
+
+`result.summary` is one row per active flag, plus a final `any_flag` row:
+
+| flag | n_scored | n_flagged | rate | threshold | mean_score |
+|---|---|---|---|---|---|
+
+## Heuristic tier: formulas and default thresholds
+
+All scores are Float64 in `[0, 1]`, higher = more suspicious. **Every
+default threshold below is a documented, SUBJECTIVE convention** -- not a
+validated statistical cutoff. Tune them to your own panel.
+
+### `straightlining_score` (default threshold `0.85`)
+
+Over a respondent's non-null grid (Likert) answers `x_1..x_m` (requires
+`m >= min_answers`, default `3`, else null):
+
+- `mode_frac = count(most frequent value) / m`.
+- `var_norm = variance(x) / max_var`, where `max_var = ((scale_max - scale_min) / 2)^2`
+  -- the maximum possible variance for a value bouncing between the scale's
+  endpoints, clipped to `[0, 1]`.
+- **score `= max(mode_frac, 1 - var_norm)`**, clipped to `[0, 1]`.
+
+A pure straightliner (all 4s on a 1-5 scale) scores `1.0` on both
+components. An alternating pattern (1, 5, 1, 5) has few distinct values but
+*maximal* variance, so `1 - var_norm` is near 0 and the row is correctly
+**not** flagged despite the low distinct-value count.
+
+`scale_min`/`scale_max` are inferred from the observed min/max across the
+configured grid columns when not given explicitly in `QualityConfig`.
+
+### `gibberish_score` (default threshold `0.65`)
+
+**English-only heuristic** -- normalizes to lowercase `[a-z ]` (strips
+digits/punctuation/non-Latin scripts); text with fewer than `min_chars`
+(default `8`) surviving letters scores **null**, not a false flag. Three
+weighted components (weights `0.5`/`0.3`/`0.2` -- SUBJECTIVE, unit-tested
+for ordering, not exact values):
+
+- `consonant_run` (weight `0.5`): longest run of consecutive consonants,
+  normalized by a 6-char cap.
+- `vowel_dev` (weight `0.3`): relative deviation of the letter-only vowel
+  ratio from English's ~0.38.
+- `entropy_term` (weight `0.2`): normalized Shannon entropy of character
+  bigrams -- weak alone (English isn't low-entropy either), a tie-breaker.
+
+`gibberish_score("asdkjfhaslkdjf") > gibberish_score(<normal English sentence>) + 0.3`
+is a pinned regression fixture (`src/quality.rs` and
+`tests/test_quality_flags.py`).
+
+**Non-Latin scripts normalize to ~nothing and score null** -- this
+heuristic cannot judge non-English text and deliberately does not
+false-flag it as gibberish. If your panel is multilingual, treat
+`gibberish` as English-open-end-only and don't rely on it for other
+languages.
+
+### `duplicate_answer_score` (default threshold `0.8`)
+
+Normalizes each non-null answer (lowercase, collapse whitespace/
+punctuation) and drops answers shorter than `min_answer_chars` (default
+`10` -- so legitimate short repeats like "yes"/"n/a" across several
+open-ends don't trip this). **score `= max pairwise token-set Jaccard
+similarity`** (`|A ∩ B| / |A ∪ B|`) over the survivors -- `1.0` for a
+verbatim (post-normalization) repeat. One mechanism catches both "exact"
+and "near" duplicates; requires >= 2 surviving answers, else null.
+
+### `response_length_score` (default threshold `1.0`, i.e. `|robust z| >= 3`)
+
+Pure Polars (median/quantile -- no Rust plugin). Robust z-score of
+character length: `rz = (len - median) / (IQR / 1.349)` (`IQR == 0` scores
+`0.0` for every length, since there's no spread to be an outlier from).
+**score `= min(1, |rz| / rz_cap)`**, `rz_cap = 3.0` (SUBJECTIVE) -- `|rz| >= 3`
+saturates at `1.0`. Symmetric: catches both suspiciously short *and*
+suspiciously long answers. The signed `rz` is exposed as `length_outlier.z`
+in the report struct so you can tell which direction tripped it.
+
+### `speeder_score` (flags when `score > 0`, default `percentile = 0.05`)
+
+Pure Polars. Two modes:
+
+- **Percentile mode** (default): `p = rank(duration) / count`,
+  **score `= clamp((percentile - p) / percentile, 0, 1)`**. The fastest
+  respondent scores near `1.0`; anyone at or above the `percentile`-th
+  percentile scores `0.0`. `percentile = 0.05` is SUBJECTIVE -- some panels
+  instead use "faster than a fraction of median LOI"
+  (`median_fraction=1/3`, say), available via the `median_fraction=`
+  alternative mode: **score `= clamp(1 - duration / (median * median_fraction), 0, 1)`**.
+- `min_duration_seconds`, if set, forces the score to `1.0` for any
+  duration below that absolute floor, in either mode.
+
+Note the flag rule for `speeder` is `score > 0` (not `score >= threshold`
+like the others) -- the summary row reports `threshold = 0.0` accordingly.
+
+## Standalone expressions and the `.llama` namespace
+
+Every heuristic-tier score is also a standalone Polars expression (used
+internally by `quality_report`, and directly usable on their own):
+
+```python
+from polar_llama import (
+    straightlining_score, gibberish_score, duplicate_answer_score,
+    response_length_score, speeder_score,
+)
+
+df.select(
+    sl=straightlining_score(["g1", "g2", "g3", "g4", "g5"]),
+    gib=gibberish_score("oe1"),
+    dup=duplicate_answer_score(["oe1", "oe2", "oe3"]),
+    len_out=response_length_score("oe1"),
+    speed=speeder_score("duration_s"),
+)
+```
+
+And via the `.llama` namespace (multi-column ones take an `others:`
+sequence, mirroring `.llama.krippendorffs_alpha`):
+
+```python
+pl.col("g1").llama.straightlining_score(["g2", "g3", "g4", "g5"])
+pl.col("oe1").llama.gibberish_score()
+pl.col("oe1").llama.duplicate_answer_score(["oe2", "oe3"])
+pl.col("oe1").llama.response_length_score()
+pl.col("duration_s").llama.speeder_score()
+```
+
+## Embedding/LLM tier (opt-in)
+
+Set `QualityConfig(llm_tier=True, text_columns=[...], ...)`. Requires
+`text_columns` to be configured (raised as `ValueError` in
+`QualityConfig.__post_init__` otherwise). Makes API calls -- embeddings for
+every respondent (unless `embedding_column=` points at a precomputed
+column) plus one structured-output call per respondent for `likely_ai`.
+
+### `near_duplicate` (default threshold `0.97`)
+
+Concatenates each respondent's open-end answers, embeds them
+(`embedding_async`), finds each respondent's nearest *other* respondent by
+cosine similarity (`knn_hnsw` + `cosine_similarity`), and scores
+`near_duplicate.score = cosine_similarity(self, nearest_other)`.
+`near_duplicate.neighbor_id` carries that nearest respondent's
+`id_column` value (or row index if `id_column` isn't set).
+
+`0.97` is **embedding-model-specific** (SUBJECTIVE) -- for
+`text-embedding-3-small`, paraphrases typically land ~0.85-0.93 and
+verbatim copies > 0.98; recalibrate for other embedding models.
+
+### `likely_ai` (default threshold `0.75`) -- flag, not verdict
+
+One `inference_messages(..., response_model=AILikelihood)` call per
+respondent, scoring stylistic markers (hedged both-sides framing, uniform
+sentence length, absence of typos/colloquialisms, list-like structure) and
+calibrated to `0.5` when the model is uncertain. Also exposed standalone as
+`ai_likelihood(col, provider=..., model=...)`, returning
+`Struct{score, rationale}`.
+
+> **AI-text detection is unreliable. This score is a stylistic heuristic,
+> not evidence.** Published detectors (including OpenAI's own, withdrawn in
+> 2023) show high false-positive rates, especially for non-native English
+> speakers, formal registers, and short texts. Treat `likely_ai` as a
+> review-prioritization signal only -- **never** as sole grounds for
+> exclusion or panelist sanction.
+
+This warning is not optional decoration: non-native-English-speaker text
+tends to read as "unusually uniform" or "less colloquial" to these
+heuristics, which is exactly the false-positive failure mode documented
+above. Use `likely_ai` to prioritize which responses a human reviews, never
+to auto-exclude a respondent or flag a panelist for sanction on its own.
+
+## Config reference (`QualityConfig`)
+
+```python
+@dataclass
+class QualityConfig:
+    id_column: Optional[str] = None
+    grid_columns: Sequence[str] = ()
+    text_columns: Sequence[str] = ()
+    duration_column: Optional[str] = None
+    scale_min: Optional[float] = None       # None = infer from grid_columns
+    scale_max: Optional[float] = None
+    straightlining_threshold: float = 0.85  # SUBJECTIVE
+    length_outlier_threshold: float = 1.0   # == |robust z| >= 3, SUBJECTIVE
+    gibberish_threshold: float = 0.65       # SUBJECTIVE
+    duplicate_threshold: float = 0.8        # SUBJECTIVE
+    speeder_percentile: float = 0.05        # SUBJECTIVE
+    min_duration_seconds: Optional[float] = None
+    speeder_median_fraction: Optional[float] = None
+    straightlining_min_answers: int = 3     # SUBJECTIVE floor
+    gibberish_min_chars: int = 8
+    duplicate_min_answer_chars: int = 10    # SUBJECTIVE floor
+    response_length_rz_cap: float = 3.0
+    llm_tier: bool = False                  # off by default => zero API calls
+    near_duplicate_threshold: float = 0.97  # SUBJECTIVE, embedding-model-specific
+    ai_likelihood_threshold: float = 0.75   # SUBJECTIVE
+    embedding_column: Optional[str] = None
+    embedding_provider: Optional[Union[str, Provider]] = None
+    embedding_model: Optional[str] = None
+    provider: Optional[Union[str, Provider]] = None   # for likely_ai
+    model: Optional[str] = None
+```
+
+Validated in `__post_init__`: every threshold must be in `(0, 1]`; at least
+one of `grid_columns`/`text_columns`/`duration_column` must be configured;
+`scale_max` must be `> scale_min` when both are given; `llm_tier=True`
+requires `text_columns`. Column-existence is checked in `quality_report`
+itself (raises `ValueError` naming the missing column(s), since it needs
+the DataFrame to check against).
+
+## Section 7: subjective choices (must-read before tuning)
+
+1. **All five heuristic-tier thresholds** (`0.85` straightlining / `|z| >= 3`
+   length outlier / `0.65` gibberish / `0.8` duplicate / 5th-percentile
+   speeder) are conventions, not validated cutoffs. Expect to tune every
+   one of them against your own panel's false-positive rate.
+2. **Gibberish component weights** (`0.5`/`0.3`/`0.2`) and the English
+   vowel-ratio anchor (`0.38`) are English-only and subjective. Non-Latin
+   scripts return **null** (normalization strips them below `min_chars`)
+   rather than a false gibberish flag -- this heuristic simply cannot judge
+   non-English text.
+3. **`near_duplicate_threshold = 0.97`** is specific to the embedding model
+   in use (documented for `text-embedding-3-small`; recalibrate for others).
+4. **`ai_likelihood_threshold = 0.75` and the entire `likely_ai` flag**
+   carry the false-positive limitation above, including the
+   non-native-speaker bias warning, in every docstring that mentions it.
+   Flag-not-verdict framing is mandatory wherever this score is surfaced.
+5. **`straightlining_min_answers = 3`** and **`duplicate_min_answer_chars = 10`**
+   are floors below which there's judged to be "not enough signal" -- both
+   subjective, both documented here.
+
+## Testing
+
+- `tests/test_quality_flags.py`: CI-safe (zero API calls, no `mlx`), covers
+  the full heuristic tier -- synthetic respondents each engineered to trip
+  exactly one flag, graded-score ordering, height/order preservation,
+  config validation, null-safety, and summary shape.
+- `tests/test_quality_llm.py`: gated on `OPENAI_API_KEY`
+  (`@pytest.mark.skipif`), exercises `near_duplicate` and `likely_ai`
+  against the real API.
+- `src/quality.rs`: `#[cfg(test)]` unit tests for the three Rust pure
+  functions, including edge cases (empty input, all-null, unicode/non-Latin
+  text, exact duplicates, degenerate scale bounds).

--- a/polar_llama/__init__.py
+++ b/polar_llama/__init__.py
@@ -1972,6 +1972,24 @@ from polar_llama.reliability import (
 
 
 # ============================================================================
+# Survey Data-Quality Flags (issue #80) — see docs/QUALITY_FLAGS.md
+# ============================================================================
+
+from polar_llama.quality import (
+    AI_DETECTION_LIMITATION,
+    QualityConfig,
+    QualityReport,
+    ai_likelihood,
+    duplicate_answer_score,
+    gibberish_score,
+    quality_report,
+    response_length_score,
+    speeder_score,
+    straightlining_score,
+)
+
+
+# ============================================================================
 # Tool Use (MCP) — see docs/design/MCP_TOOL_INTEGRATION.md
 # ============================================================================
 
@@ -2333,6 +2351,81 @@ class LlamaNamespace:
         return krippendorffs_alpha(
             [self._expr, *others], level=level, n_bootstrap=n_bootstrap, ci=ci, seed=seed
         )
+
+    def straightlining_score(
+        self,
+        others: List[IntoExpr],
+        *,
+        scale_min: Optional[float] = None,
+        scale_max: Optional[float] = None,
+        min_answers: int = 3,
+    ) -> pl.Expr:
+        """
+        Straightlining suspicion score across this column and other grid
+        (Likert) columns. See `polar_llama.straightlining_score`.
+        """
+        return straightlining_score(
+            [self._expr, *others],
+            scale_min=scale_min,
+            scale_max=scale_max,
+            min_answers=min_answers,
+        )
+
+    def gibberish_score(self, *, min_chars: int = 8) -> pl.Expr:
+        """
+        Keyboard-mash / gibberish suspicion score for this text column.
+        See `polar_llama.gibberish_score`.
+        """
+        return gibberish_score(self._expr, min_chars=min_chars)
+
+    def duplicate_answer_score(
+        self, others: List[IntoExpr], *, min_answer_chars: int = 10
+    ) -> pl.Expr:
+        """
+        Cross-answer near-duplicate suspicion score across this column and
+        other open-end text columns. See `polar_llama.duplicate_answer_score`.
+        """
+        return duplicate_answer_score(
+            [self._expr, *others], min_answer_chars=min_answer_chars
+        )
+
+    def response_length_score(self, *, rz_cap: float = 3.0) -> pl.Expr:
+        """
+        Response-length outlier suspicion score for this text column. See
+        `polar_llama.response_length_score`.
+        """
+        return response_length_score(self._expr, rz_cap=rz_cap)
+
+    def speeder_score(
+        self,
+        *,
+        percentile: float = 0.05,
+        min_duration_seconds: Optional[float] = None,
+        median_fraction: Optional[float] = None,
+    ) -> pl.Expr:
+        """
+        Speeder suspicion score for this duration column. See
+        `polar_llama.speeder_score`.
+        """
+        return speeder_score(
+            self._expr,
+            percentile=percentile,
+            min_duration_seconds=min_duration_seconds,
+            median_fraction=median_fraction,
+        )
+
+    def ai_likelihood(
+        self,
+        *,
+        provider: Optional[Union[str, Provider]] = None,
+        model: Optional[str] = None,
+    ) -> pl.Expr:
+        """
+        AI-generated-text likelihood score for this text column (flag, not
+        verdict -- see `polar_llama.ai_likelihood` for the mandatory
+        limitation discussion).
+        """
+        return ai_likelihood(self._expr, provider=provider, model=model)
 
     def dot_product(self, other: IntoExpr) -> pl.Expr:
         """

--- a/polar_llama/quality.py
+++ b/polar_llama/quality.py
@@ -1,0 +1,1088 @@
+"""
+Survey data-quality flags for Polar Llama (issue #80).
+
+Design summary -- see `docs/QUALITY_FLAGS.md` for the full walkthrough:
+
+1. **Two tiers, one contract.** Every score in this module is a graded
+   `Float64` in `[0, 1]` (higher = more suspicious), never a hard filter.
+   Booleans (`flag`) are derived by thresholding a score in `quality_report`
+   -- a null score (not enough signal: too few grid answers, too little
+   text, missing duration) always resolves to `flag = False`, never `True`.
+   **No function in this module ever drops a row.**
+
+   - **Heuristic tier** (`straightlining_score`, `gibberish_score`,
+     `duplicate_answer_score`, `response_length_score`, `speeder_score`):
+     zero API calls. The first three are Rust plugin expressions
+     (`src/quality.rs` pure functions + `src/expressions.rs` plumbing,
+     mirroring the `src/metrics.rs` / issue #79 split); the last two are a
+     few lines of pure Polars (median/quantile/rank) -- there is nothing
+     for Rust to buy here.
+   - **Embedding/LLM tier** (`near_duplicate`, `likely_ai` via
+     `ai_likelihood`): opt-in (`QualityConfig.llm_tier=True`, default
+     `False`), pure Python composition of existing primitives
+     (`embedding_async`, `cosine_similarity`, `knn_hnsw`,
+     `inference_messages(..., response_model=...)`) -- exactly the
+     `induce_codebook` pattern (`polar_llama/codebook.py`).
+
+2. **`quality_report(df, config) -> QualityReport(df, summary)`** is a
+   DataFrame-in/DataFrame-out orchestration function, not a Polars
+   expression, because a single expression cannot return two different
+   heights (per-row flags *and* a per-flag summary) at once -- same
+   reasoning as `induce_codebook`. `.df` is the input DataFrame plus one
+   struct column (`quality` by default); `.summary` is one row per active
+   flag (+ a final `any_flag` row). Row count and order are always
+   preserved (`assert out.height == df.height` internally) -- flagging
+   never filters.
+
+3. **All default thresholds are SUBJECTIVE conventions**, not validated
+   statistical cutoffs -- tune them to your own panel. This is called out
+   per-threshold below and centrally in `docs/QUALITY_FLAGS.md`.
+
+4. **AI-text detection is a flag, not a verdict.** `likely_ai`/
+   `ai_likelihood` carry a mandatory limitation warning (see their
+   docstrings and `docs/QUALITY_FLAGS.md` section 7): published AI-text
+   detectors have high false-positive rates, especially for non-native
+   English speakers, formal registers, and short texts. Never use this
+   score as sole grounds for excluding a respondent or sanctioning a
+   panelist.
+
+`embedding_async`, `cosine_similarity`, `knn_hnsw`, `inference_messages`,
+`combine_messages`, and `string_to_message` are imported lazily inside
+function bodies (not at module scope) to avoid a circular import with
+`polar_llama/__init__.py`, which imports this module -- the same pattern
+`polar_llama/codebook.py` and `polar_llama/reliability.py` use.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+)
+
+import polars as pl
+
+from polar_llama.utils import parse_into_expr, register_plugin
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+    from polars.type_aliases import IntoExpr
+
+    from polar_llama import Provider
+
+
+# ============================================================================
+# Heuristic tier -- Rust plugin expressions (straightlining / gibberish /
+# duplicate-answer) -- src/quality.rs + src/expressions.rs
+# ============================================================================
+
+
+def straightlining_score(
+    grid_cols: Sequence["IntoExpr"],
+    *,
+    scale_min: Optional[float] = None,
+    scale_max: Optional[float] = None,
+    min_answers: int = 3,
+) -> pl.Expr:
+    """
+    Straightlining/flatlining suspicion score across a Likert grid battery.
+
+    Zero API calls. Backed by `crate::quality::straightline_score`
+    (`src/quality.rs`): for each respondent's non-null answers across
+    `grid_cols`, combines `mode_frac` (share of answers equal to the most
+    frequent value) and `1 - var_norm` (variance normalized by the maximum
+    possible variance for the scale) via `max` -- either component alone is
+    enough to be suspicious. An alternating pattern (e.g. 1,5,1,5) has high
+    variance, so it is *not* flagged despite having few distinct values.
+
+    Parameters
+    ----------
+    grid_cols : sequence of IntoExpr
+        The Likert grid columns (numeric), one row per respondent.
+    scale_min, scale_max : float, optional
+        The Likert scale's bounds (e.g. 1.0/5.0), used to normalize the
+        variance component. When `None` (default), each call infers them
+        from the observed min/max across every value in every column
+        passed to *that call* -- a whole-batch computation. `quality_report`
+        always computes and passes explicit bounds once over the full
+        configured column set so this inference is never actually
+        exercised by the DataFrame-level API; pass `scale_min`/`scale_max`
+        explicitly yourself for the same determinism when calling this
+        standalone.
+    min_answers : int
+        Minimum number of non-null grid answers required to score a row;
+        below this, the score is null (not enough signal) -- never `0.0`.
+        Default `3` (SUBJECTIVE -- see `docs/QUALITY_FLAGS.md`).
+
+    Returns
+    -------
+    polars.Expr
+        `Float64` in `[0, 1]`, higher = more suspicious. Null when fewer
+        than `min_answers` non-null grid answers are present.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from polar_llama import straightlining_score
+    >>> df = pl.DataFrame({
+    ...     "g1": [4, 2], "g2": [4, 4], "g3": [4, 3], "g4": [4, 5], "g5": [4, 1],
+    ... })
+    >>> df.select(score=straightlining_score(["g1", "g2", "g3", "g4", "g5"]))
+    """
+    exprs = [parse_into_expr(c) for c in grid_cols]
+    if not exprs:
+        raise ValueError("straightlining_score: grid_cols must have at least 1 column")
+
+    kwargs: Dict[str, Any] = {
+        "scale_min": float(scale_min) if scale_min is not None else None,
+        "scale_max": float(scale_max) if scale_max is not None else None,
+        "min_answers": int(min_answers),
+    }
+
+    from polar_llama.expressions import get_lib_path
+
+    return register_plugin(
+        args=exprs,
+        symbol="straightlining_score",
+        is_elementwise=True,
+        lib=get_lib_path(),
+        kwargs=kwargs,
+    )
+
+
+def gibberish_score(col: "IntoExpr", *, min_chars: int = 8) -> pl.Expr:
+    """
+    Keyboard-mash / gibberish suspicion score for one open-end text column.
+
+    Zero API calls. Backed by `crate::quality::gibberish_score`
+    (`src/quality.rs`): an **English-only** heuristic combining a
+    consecutive-consonant-run score, a deviation from English's ~0.38
+    letter-level vowel ratio, and normalized character-bigram entropy
+    (weights `0.5`/`0.3`/`0.2` respectively -- SUBJECTIVE, pinned in
+    `docs/QUALITY_FLAGS.md`; unit-tested for *ordering* against a fixture,
+    not for the exact weight values).
+
+    Text that normalizes to fewer than `min_chars` Latin letters (including
+    non-Latin scripts, which strip to ~nothing) scores null rather than
+    being false-flagged as gibberish -- see `docs/QUALITY_FLAGS.md` section
+    7 for this documented limitation.
+
+    Parameters
+    ----------
+    col : IntoExpr
+        The open-end text column.
+    min_chars : int
+        Minimum surviving letters (after normalization) required to score a
+        row. Default `8` (SUBJECTIVE).
+
+    Returns
+    -------
+    polars.Expr
+        `Float64` in `[0, 1]`, higher = more suspicious. Null for null
+        input or too-short/non-Latin text.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from polar_llama import gibberish_score
+    >>> df = pl.DataFrame({"oe": ["asdkjfhaslkdjf", "The service was great"]})
+    >>> df.select(score=gibberish_score("oe"))
+    """
+    expr = parse_into_expr(col)
+    kwargs: Dict[str, Any] = {"min_chars": int(min_chars)}
+
+    from polar_llama.expressions import get_lib_path
+
+    return register_plugin(
+        args=[expr],
+        symbol="gibberish_score",
+        is_elementwise=True,
+        lib=get_lib_path(),
+        kwargs=kwargs,
+    )
+
+
+def duplicate_answer_score(
+    text_cols: Sequence["IntoExpr"], *, min_answer_chars: int = 10
+) -> pl.Expr:
+    """
+    Cross-answer near-duplicate suspicion score across a respondent's
+    open-end answers.
+
+    Zero API calls. Backed by `crate::quality::duplicate_answer_score`
+    (`src/quality.rs`): normalizes each non-null answer (lowercase, collapse
+    whitespace/punctuation), drops answers shorter than `min_answer_chars`
+    (so legitimate short repeats like "yes"/"n/a" across several open-ends
+    don't trip this), and scores the maximum pairwise token-set Jaccard
+    similarity over the survivors. `1.0` = a verbatim (post-normalization)
+    repeat; the same mechanism catches "near" duplicates via partial
+    Jaccard overlap.
+
+    Parameters
+    ----------
+    text_cols : sequence of IntoExpr
+        The open-end text columns to compare pairwise, one row per
+        respondent.
+    min_answer_chars : int
+        Minimum normalized length for an answer to be compared. Default
+        `10` (SUBJECTIVE).
+
+    Returns
+    -------
+    polars.Expr
+        `Float64` in `[0, 1]`, higher = more suspicious. Null when fewer
+        than 2 answers survive the length filter.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from polar_llama import duplicate_answer_score
+    >>> df = pl.DataFrame({
+    ...     "oe1": ["The product is great and I would recommend it"],
+    ...     "oe2": ["the product is great and I would recommend it."],
+    ... })
+    >>> df.select(score=duplicate_answer_score(["oe1", "oe2"]))
+    """
+    exprs = [parse_into_expr(c) for c in text_cols]
+    if not exprs:
+        raise ValueError("duplicate_answer_score: text_cols must have at least 1 column")
+
+    kwargs: Dict[str, Any] = {"min_answer_chars": int(min_answer_chars)}
+
+    from polar_llama.expressions import get_lib_path
+
+    return register_plugin(
+        args=exprs,
+        symbol="duplicate_answer_score",
+        is_elementwise=True,
+        lib=get_lib_path(),
+        kwargs=kwargs,
+    )
+
+
+# ============================================================================
+# Heuristic tier -- pure Polars (response length / speeder)
+# ============================================================================
+
+
+def _response_length_score_and_z(
+    col: "IntoExpr", rz_cap: float
+) -> Tuple[pl.Expr, pl.Expr]:
+    """Shared implementation for `response_length_score` and the
+    `length_outlier` sub-struct in `quality_report` (which also needs the
+    signed `z` alongside the score). A robust z-score over the whole
+    (non-null) column: `(len - median) / (IQR / 1.349)`, so a single
+    extreme value can't blow out the scale the way a mean/stddev z-score
+    would.
+    """
+    expr = parse_into_expr(col)
+    lengths = expr.str.len_chars().cast(pl.Float64)
+    median = lengths.median()
+    iqr = lengths.quantile(0.75) - lengths.quantile(0.25)
+
+    rz = (
+        pl.when(lengths.is_null())
+        .then(None)
+        .when(iqr == 0)
+        .then(0.0)
+        .otherwise((lengths - median) / (iqr / 1.349))
+    )
+    score = (
+        pl.when(rz.is_null())
+        .then(None)
+        .otherwise(pl.min_horizontal(rz.abs() / rz_cap, pl.lit(1.0)))
+    )
+    return score, rz
+
+
+def response_length_score(col: "IntoExpr", *, rz_cap: float = 3.0) -> pl.Expr:
+    """
+    Response-length outlier suspicion score for one open-end text column.
+
+    Zero API calls, pure Polars (median/quantile -- there is nothing for a
+    Rust plugin to buy here). A robust z-score of character length --
+    `(len - median) / (IQR / 1.349)` -- so a single extreme value can't
+    distort the scale (unlike a mean/stddev z-score). Symmetric: catches
+    both suspiciously short *and* suspiciously long answers.
+
+    Parameters
+    ----------
+    col : IntoExpr
+        The open-end text column.
+    rz_cap : float
+        `|robust z| >= rz_cap` saturates the score at `1.0`. Default `3.0`
+        (SUBJECTIVE).
+
+    Returns
+    -------
+    polars.Expr
+        `Float64` in `[0, 1]`, higher = more suspicious. Null for null
+        input, or for the whole column when its interquartile range is 0
+        (every non-null answer the same length, other than length 0 which
+        legitimately scores 0 via the IQR==0 branch).
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from polar_llama import response_length_score
+    >>> df = pl.DataFrame({"oe": ["fine"] * 10 + ["x" * 2000]})
+    >>> df.select(score=response_length_score("oe"))
+    """
+    if rz_cap <= 0:
+        raise ValueError(f"response_length_score: rz_cap must be > 0; got {rz_cap!r}")
+    score, _z = _response_length_score_and_z(col, rz_cap)
+    return score
+
+
+def speeder_score(
+    duration_col: "IntoExpr",
+    *,
+    percentile: float = 0.05,
+    min_duration_seconds: Optional[float] = None,
+    median_fraction: Optional[float] = None,
+) -> pl.Expr:
+    """
+    Speeder ("rushed through the survey") suspicion score for a duration
+    column.
+
+    Zero API calls, pure Polars. Two modes:
+
+    - **Percentile mode** (default): `p = rank(duration) / count`, score
+      `= clamp((percentile - p) / percentile, 0, 1)`. The fastest
+      respondent scores near `1.0`; a respondent at (or above) the
+      `percentile`-th percentile scores `0.0`.
+    - **Median-fraction mode** (`median_fraction` given): score
+      `= clamp(1 - duration / (median * median_fraction), 0, 1)` -- the
+      "faster than a fraction of median LOI" industry convention (e.g.
+      `median_fraction=1/3`).
+
+    `min_duration_seconds`, if given, forces the score to `1.0` for any
+    duration below that absolute floor, regardless of mode.
+
+    Parameters
+    ----------
+    duration_col : IntoExpr
+        Survey completion duration in seconds (numeric).
+    percentile : float
+        Percentile-mode cutoff, in `(0, 1]`. Default `0.05` (SUBJECTIVE --
+        `docs/QUALITY_FLAGS.md` notes the median-fraction alternative is
+        also a common industry convention).
+    min_duration_seconds : float, optional
+        Absolute floor; durations below it always score `1.0`.
+    median_fraction : float, optional
+        Switches to median-fraction mode when given (must be > 0).
+
+    Returns
+    -------
+    polars.Expr
+        `Float64` in `[0, 1]`, higher = more suspicious ("more of a
+        speeder"). Null for null input.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from polar_llama import speeder_score
+    >>> df = pl.DataFrame({"duration_s": [300, 310, 295, 12, 305]})
+    >>> df.select(score=speeder_score("duration_s"))
+    """
+    if not (0.0 < percentile <= 1.0):
+        raise ValueError(f"speeder_score: percentile must be in (0, 1]; got {percentile!r}")
+    if median_fraction is not None and median_fraction <= 0:
+        raise ValueError(
+            f"speeder_score: median_fraction must be > 0; got {median_fraction!r}"
+        )
+
+    expr = parse_into_expr(duration_col)
+
+    if median_fraction is not None:
+        med = expr.median()
+        raw = 1.0 - expr / (med * median_fraction)
+    else:
+        n = expr.count()
+        rank = expr.rank(method="average")
+        p = rank / n
+        raw = (percentile - p) / percentile
+
+    score = (
+        pl.when(expr.is_null())
+        .then(None)
+        .otherwise(pl.min_horizontal(pl.max_horizontal(raw, pl.lit(0.0)), pl.lit(1.0)))
+    )
+
+    if min_duration_seconds is not None:
+        score = (
+            pl.when(expr.is_null())
+            .then(None)
+            .when(expr < min_duration_seconds)
+            .then(1.0)
+            .otherwise(score)
+        )
+
+    return score
+
+
+# ============================================================================
+# Embedding/LLM tier -- response model + prompt
+# ============================================================================
+
+#: Mandatory limitation wording (issue #80, section 2.2) -- must also appear
+#: (verbatim or near-verbatim) in `docs/QUALITY_FLAGS.md` section 7 and in
+#: every docstring that discusses `likely_ai`/`ai_likelihood`.
+AI_DETECTION_LIMITATION = (
+    "AI-text detection is unreliable. This score is a stylistic heuristic, "
+    "not evidence. Published detectors (including OpenAI's own, withdrawn "
+    "in 2023) show high false-positive rates, especially for non-native "
+    "English speakers, formal registers, and short texts. Treat `likely_ai` "
+    "as a review-prioritization signal only -- never as sole grounds for "
+    "exclusion or panelist sanction."
+)
+
+
+def _ai_likelihood_model() -> Type["BaseModel"]:
+    """Response model for `ai_likelihood`/`likely_ai`. Every field required,
+    no `Dict`-typed field -- OpenAI-strict-mode compliant by construction
+    (see `_validate_strict_mode_schema`, the issue #51 lesson).
+    """
+    try:
+        from pydantic import BaseModel, Field
+    except ImportError:
+        raise ImportError(
+            "Pydantic is required for the quality-flags LLM tier. Install with: "
+            "pip install pydantic>=2.0.0"
+        )
+
+    class AILikelihood(BaseModel):
+        score: float = Field(
+            ...,
+            description=(
+                "Likelihood this text is AI-generated, 0.0 to 1.0. Calibrate "
+                "to 0.5 when you cannot tell -- never claim certainty in "
+                "either direction."
+            ),
+        )
+        rationale: str = Field(
+            ...,
+            description=(
+                "At most two sentences citing concrete stylistic markers "
+                "(or their absence) that informed the score."
+            ),
+        )
+
+    return AILikelihood
+
+
+def _build_ai_likelihood_system_prompt() -> str:
+    return "\n".join(
+        [
+            "You are assessing whether a short survey open-end response was",
+            "written by an AI language model rather than a human respondent.",
+            "",
+            "Score stylistic markers only -- you cannot verify authorship:",
+            "- Hedged, both-sides framing ('on one hand... on the other hand')",
+            "- Unusually uniform sentence length and structure",
+            "- Absence of typos, fragments, slang, or colloquialisms",
+            "- List-like or formulaic structure (e.g. 'firstly... secondly...')",
+            "- Generic, non-specific phrasing with no concrete personal detail",
+            "",
+            "Calibrate `score` to 0.5 when you genuinely cannot tell -- do not",
+            "default to a high or low score out of a desire to seem decisive.",
+            "Never claim certainty in either direction; this is a stylistic",
+            "signal for human review, not a verdict.",
+            "",
+            AI_DETECTION_LIMITATION,
+        ]
+    )
+
+
+def ai_likelihood(
+    col: "IntoExpr",
+    *,
+    provider: Optional[Union[str, "Provider"]] = None,
+    model: Optional[str] = None,
+) -> pl.Expr:
+    """
+    AI-generated-text likelihood score for one text column (flag, not
+    verdict).
+
+    One `inference_messages(..., response_model=...)` structured-output
+    call per row, scoring stylistic markers (hedged both-sides framing,
+    uniform sentence length, absence of typos/colloquialisms, list-like
+    structure) and calibrated to `0.5` when the model is uncertain.
+
+    **AI-text detection is unreliable. This score is a stylistic heuristic,
+    not evidence.** Published detectors (including OpenAI's own, withdrawn
+    in 2023) show high false-positive rates, especially for non-native
+    English speakers, formal registers, and short texts. Treat this as a
+    review-prioritization signal only -- never as sole grounds for
+    exclusion or panelist sanction. See `docs/QUALITY_FLAGS.md` section 7.
+
+    Parameters
+    ----------
+    col : IntoExpr
+        The text column to assess.
+    provider, model : optional
+        Provider/model for the structured-output call.
+
+    Returns
+    -------
+    polars.Expr
+        `Struct{score: Float64, rationale: Utf8}`. `score` is clamped to
+        `[0, 1]`; both fields are null on a parse/inference failure for that
+        row (never an error, never a dropped row).
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from polar_llama import ai_likelihood, Provider  # doctest: +SKIP
+    >>> df = pl.DataFrame({"oe": ["On one hand... on the other hand, overall satisfactory."]})  # doctest: +SKIP
+    >>> df.with_columns(ai=ai_likelihood("oe", provider=Provider.OPENAI))  # doctest: +SKIP
+    """
+    expr = parse_into_expr(col)
+
+    from polar_llama import combine_messages, inference_messages, string_to_message
+
+    system_prompt = _build_ai_likelihood_system_prompt()
+    system_message_expr = expr.map_batches(
+        lambda s: pl.Series([system_prompt] * len(s)), return_dtype=pl.Utf8
+    ).pipe(string_to_message, message_type="system")
+    user_message_expr = expr.pipe(string_to_message, message_type="user")
+    messages_expr = combine_messages(system_message_expr, user_message_expr)
+
+    response_model = _ai_likelihood_model()
+    result = inference_messages(
+        messages_expr, provider=provider, model=model, response_model=response_model
+    )
+
+    ok = result.struct.field("_error").is_null()
+    score = (
+        pl.when(ok)
+        .then(pl.min_horizontal(pl.max_horizontal(result.struct.field("score"), pl.lit(0.0)), pl.lit(1.0)))
+        .otherwise(None)
+    )
+    rationale = pl.when(ok).then(result.struct.field("rationale")).otherwise(None)
+    return pl.struct([score.alias("score"), rationale.alias("rationale")])
+
+
+# ============================================================================
+# QualityConfig / QualityReport
+# ============================================================================
+
+_THRESHOLD_FIELDS = (
+    "straightlining_threshold",
+    "length_outlier_threshold",
+    "gibberish_threshold",
+    "duplicate_threshold",
+    "speeder_percentile",
+    "near_duplicate_threshold",
+    "ai_likelihood_threshold",
+)
+
+
+@dataclass
+class QualityConfig:
+    """
+    Configuration for `quality_report`. All thresholds default to
+    documented, SUBJECTIVE conventions -- see `docs/QUALITY_FLAGS.md`
+    section 7 and tune to your own panel.
+
+    The heuristic tier (grid/text/duration scoring) needs zero API calls
+    and never drops a row. The embedding/LLM tier (`llm_tier=True`) is
+    strictly opt-in -- default `False`, zero network calls.
+    """
+
+    id_column: Optional[str] = None
+    grid_columns: Sequence[str] = field(default_factory=tuple)
+    text_columns: Sequence[str] = field(default_factory=tuple)
+    duration_column: Optional[str] = None
+
+    # Likert scale bounds for straightlining's variance normalization.
+    # None (default) infers the bounds from the observed data.
+    scale_min: Optional[float] = None
+    scale_max: Optional[float] = None
+
+    # Thresholds: score >= threshold => flag (speeder is `score > 0`
+    # instead -- see `speeder_score`'s docstring). All SUBJECTIVE defaults.
+    straightlining_threshold: float = 0.85
+    length_outlier_threshold: float = 1.0  # == |robust z| >= 3
+    gibberish_threshold: float = 0.65
+    duplicate_threshold: float = 0.8
+    speeder_percentile: float = 0.05
+    min_duration_seconds: Optional[float] = None
+    speeder_median_fraction: Optional[float] = None
+
+    # Scoring knobs (rarely need tuning; see the standalone functions).
+    straightlining_min_answers: int = 3
+    gibberish_min_chars: int = 8
+    duplicate_min_answer_chars: int = 10
+    response_length_rz_cap: float = 3.0
+
+    # Embedding/LLM tier -- off by default (zero API calls).
+    llm_tier: bool = False
+    near_duplicate_threshold: float = 0.97
+    ai_likelihood_threshold: float = 0.75
+    embedding_column: Optional[str] = None
+    embedding_provider: Optional[Union[str, "Provider"]] = None
+    embedding_model: Optional[str] = None
+    provider: Optional[Union[str, "Provider"]] = None  # for likely_ai
+    model: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        for name in _THRESHOLD_FIELDS:
+            value = getattr(self, name)
+            if not (0.0 < value <= 1.0):
+                raise ValueError(
+                    f"QualityConfig.{name} must be in the open-closed interval "
+                    f"(0, 1]; got {value!r}"
+                )
+
+        if not (self.grid_columns or self.text_columns or self.duration_column):
+            raise ValueError(
+                "QualityConfig: at least one of grid_columns, text_columns, "
+                "or duration_column must be configured"
+            )
+
+        if (
+            self.scale_min is not None
+            and self.scale_max is not None
+            and self.scale_max <= self.scale_min
+        ):
+            raise ValueError(
+                f"QualityConfig: scale_max ({self.scale_max!r}) must be > "
+                f"scale_min ({self.scale_min!r})"
+            )
+
+        if self.llm_tier and not self.text_columns:
+            raise ValueError(
+                "QualityConfig: llm_tier=True requires text_columns to be "
+                "configured (near_duplicate and likely_ai both operate on "
+                "open-end text)"
+            )
+
+
+@dataclass
+class QualityReport:
+    """Return value of `quality_report`.
+
+    `df`: the input DataFrame plus one struct column (`quality` by
+    default) -- same height and row order as the input, always (flagging
+    never filters). `summary`: one row per active flag, plus a final
+    `any_flag` row.
+    """
+
+    df: pl.DataFrame
+    summary: pl.DataFrame
+
+
+# ============================================================================
+# Embedding/LLM tier -- DataFrame-shaped private helpers
+# ============================================================================
+
+
+def _near_duplicate_flags(df: pl.DataFrame, config: QualityConfig) -> pl.DataFrame:
+    """Cross-respondent near-duplicate detection over the concatenated
+    open-end answers (or a precomputed `config.embedding_column`). Returns
+    `df` plus `__q_near_duplicate_score`/`__q_near_duplicate_neighbor_id`
+    columns, same height and order as `df`.
+    """
+    from polar_llama import cosine_similarity, embedding_async, knn_hnsw
+
+    work = df.with_columns(__q_row_nr=pl.int_range(pl.len()))
+    id_expr = pl.col(config.id_column) if config.id_column is not None else pl.col("__q_row_nr")
+
+    if config.embedding_column is not None:
+        work = work.with_columns(__nd_emb=pl.col(config.embedding_column))
+    else:
+        concat_expr = pl.concat_str(
+            [pl.col(c).fill_null("") for c in config.text_columns], separator=" || "
+        )
+        work = work.with_columns(__nd_text=concat_expr).with_columns(
+            __nd_emb=embedding_async(
+                pl.col("__nd_text"),
+                provider=config.embedding_provider,
+                model=config.embedding_model,
+            )
+        )
+
+    non_null = work.filter(
+        pl.col("__nd_emb").is_not_null() & (pl.col("__nd_emb").list.len() > 0)
+    )
+
+    if non_null.height < 2:
+        return df.with_columns(
+            pl.lit(None, dtype=pl.Float64).alias("__q_near_duplicate_score"),
+            pl.lit(None).alias("__q_near_duplicate_neighbor_id"),
+        )
+
+    non_null = non_null.with_columns(
+        __nd_neighbors=knn_hnsw(pl.col("__nd_emb"), pl.col("__nd_emb"), k=2)
+    ).with_columns(
+        __nd_neighbor_idx=pl.when(pl.col("__nd_neighbors").list.len() >= 2)
+        .then(pl.col("__nd_neighbors").list.get(1))
+        .otherwise(None)
+    )
+    non_null = non_null.with_columns(
+        __nd_neighbor_idx_filled=pl.col("__nd_neighbor_idx").fill_null(0)
+    ).with_columns(
+        __nd_neighbor_emb=pl.col("__nd_emb").gather(pl.col("__nd_neighbor_idx_filled")),
+        __nd_neighbor_id=id_expr.gather(pl.col("__nd_neighbor_idx_filled")),
+    )
+    non_null = non_null.with_columns(
+        __q_near_duplicate_score=pl.when(pl.col("__nd_neighbor_idx").is_not_null())
+        .then(cosine_similarity(pl.col("__nd_emb"), pl.col("__nd_neighbor_emb")))
+        .otherwise(None),
+        __q_near_duplicate_neighbor_id=pl.when(pl.col("__nd_neighbor_idx").is_not_null())
+        .then(pl.col("__nd_neighbor_id"))
+        .otherwise(None),
+    )
+
+    keyed = non_null.select(
+        "__q_row_nr", "__q_near_duplicate_score", "__q_near_duplicate_neighbor_id"
+    )
+    joined = work.select("__q_row_nr").join(keyed, on="__q_row_nr", how="left")
+    assert joined.height == df.height
+
+    return df.with_columns(
+        joined["__q_near_duplicate_score"].alias("__q_near_duplicate_score"),
+        joined["__q_near_duplicate_neighbor_id"].alias("__q_near_duplicate_neighbor_id"),
+    )
+
+
+def _ai_likelihood_flags(df: pl.DataFrame, config: QualityConfig) -> pl.DataFrame:
+    """Per-respondent AI-likelihood scoring over the concatenated open-end
+    answers. Returns `df` plus `__q_likely_ai_score`/`__q_likely_ai_rationale`
+    columns, same height and order as `df`. Rows with no non-empty text
+    across `config.text_columns` score null without an inference call
+    happening to matter for their result (never flagged on missing data).
+    """
+    concat_expr = pl.concat_str(
+        [pl.col(c).fill_null("") for c in config.text_columns], separator="\n\n"
+    )
+    has_text_expr = pl.any_horizontal(
+        [
+            pl.col(c).is_not_null() & (pl.col(c).str.len_chars() > 0)
+            for c in config.text_columns
+        ]
+    )
+
+    work = df.with_columns(__ai_text=concat_expr, __ai_has_text=has_text_expr)
+    work = work.with_columns(
+        __ai_result=ai_likelihood(
+            pl.col("__ai_text"), provider=config.provider, model=config.model
+        )
+    )
+    work = work.with_columns(
+        __q_likely_ai_score=pl.when(pl.col("__ai_has_text"))
+        .then(pl.col("__ai_result").struct.field("score"))
+        .otherwise(None),
+        __q_likely_ai_rationale=pl.when(pl.col("__ai_has_text"))
+        .then(pl.col("__ai_result").struct.field("rationale"))
+        .otherwise(None),
+    )
+
+    return df.with_columns(
+        work["__q_likely_ai_score"].alias("__q_likely_ai_score"),
+        work["__q_likely_ai_rationale"].alias("__q_likely_ai_rationale"),
+    )
+
+
+# ============================================================================
+# quality_report: DataFrame-in / DataFrame-out orchestration
+# ============================================================================
+
+
+def _validate_columns(df: pl.DataFrame, config: QualityConfig) -> None:
+    missing: List[str] = []
+    for c in (*config.grid_columns, *config.text_columns):
+        if c not in df.columns:
+            missing.append(c)
+    if config.duration_column is not None and config.duration_column not in df.columns:
+        missing.append(config.duration_column)
+    if config.id_column is not None and config.id_column not in df.columns:
+        missing.append(config.id_column)
+    if config.embedding_column is not None and config.embedding_column not in df.columns:
+        missing.append(config.embedding_column)
+    if missing:
+        raise ValueError(
+            f"quality_report: column(s) not found in dataframe: {sorted(set(missing))!r}"
+        )
+
+
+def _infer_grid_scale(df: pl.DataFrame, config: QualityConfig) -> Tuple[Optional[float], Optional[float]]:
+    if config.scale_min is not None and config.scale_max is not None:
+        return config.scale_min, config.scale_max
+    stacked = pl.concat([df[c].cast(pl.Float64, strict=False) for c in config.grid_columns])
+    inferred_min = stacked.min()
+    inferred_max = stacked.max()
+    scale_min = config.scale_min if config.scale_min is not None else inferred_min
+    scale_max = config.scale_max if config.scale_max is not None else inferred_max
+    return scale_min, scale_max
+
+
+def quality_report(
+    df: pl.DataFrame,
+    config: QualityConfig,
+    *,
+    output_column: str = "quality",
+) -> QualityReport:
+    """
+    Score every respondent (row) in `df` for common survey data-quality
+    issues and return a per-flag summary. DataFrame-in / DataFrame-out.
+
+    **Never drops a row.** Every flag is derived from a graded `[0, 1]`
+    score (`score >= threshold`, except `speeder` which is `score > 0`);
+    a null score (not enough signal) always resolves to `flag = False`.
+    The heuristic tier (grid/text/duration scoring) makes zero API calls;
+    the embedding/LLM tier (`config.llm_tier=True`) is strictly opt-in.
+
+    Parameters
+    ----------
+    df : polars.DataFrame
+        Input data, one row per respondent.
+    config : QualityConfig
+        Which columns to score and every threshold. See `QualityConfig`.
+    output_column : str
+        Name of the appended struct column. Default `"quality"`.
+
+    Returns
+    -------
+    QualityReport
+        `.df`: `df` plus the `output_column` struct (same height and row
+        order as `df`, always). Sub-structs for unconfigured inputs (e.g.
+        no `duration_column`) are omitted entirely, not null-filled --
+        the struct's schema reflects `config`. `.summary`: one row per
+        active flag (`flag, n_scored, n_flagged, rate, threshold,
+        mean_score`), plus a final `any_flag` row.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from polar_llama import QualityConfig, quality_report
+    >>> df = pl.DataFrame({
+    ...     "g1": [4, 2], "g2": [4, 4], "g3": [4, 3], "g4": [4, 5], "g5": [4, 1],
+    ...     "oe1": ["fine", "The product exceeded my expectations, truly"],
+    ...     "duration_s": [300, 290],
+    ... })
+    >>> config = QualityConfig(
+    ...     grid_columns=["g1", "g2", "g3", "g4", "g5"],
+    ...     text_columns=["oe1"],
+    ...     duration_column="duration_s",
+    ... )
+    >>> result = quality_report(df, config)
+    >>> result.df.height == df.height
+    True
+    >>> result.summary.columns
+    ['flag', 'n_scored', 'n_flagged', 'rate', 'threshold', 'mean_score']
+    """
+    _validate_columns(df, config)
+
+    work = df
+    # name -> {"score_col", "threshold", "extra": {field_name: col_name}, "flag_rule"}
+    active: "Dict[str, Dict[str, Any]]" = {}
+
+    if config.grid_columns:
+        scale_min, scale_max = _infer_grid_scale(df, config)
+        work = work.with_columns(
+            straightlining_score(
+                list(config.grid_columns),
+                scale_min=scale_min,
+                scale_max=scale_max,
+                min_answers=config.straightlining_min_answers,
+            ).alias("__q_straightlining_score")
+        )
+        active["straightlining"] = {
+            "score_col": "__q_straightlining_score",
+            "threshold": config.straightlining_threshold,
+        }
+
+    if config.text_columns:
+        gib_cols = []
+        for i, c in enumerate(config.text_columns):
+            colname = f"__q_gibberish_{i}"
+            work = work.with_columns(
+                gibberish_score(pl.col(c), min_chars=config.gibberish_min_chars).alias(colname)
+            )
+            gib_cols.append(colname)
+        work = work.with_columns(
+            pl.max_horizontal(*[pl.col(c) for c in gib_cols]).alias("__q_gibberish_score")
+        )
+        active["gibberish"] = {
+            "score_col": "__q_gibberish_score",
+            "threshold": config.gibberish_threshold,
+        }
+
+        len_score_cols, len_z_cols = [], []
+        for i, c in enumerate(config.text_columns):
+            s_col, z_col = f"__q_len_score_{i}", f"__q_len_z_{i}"
+            s_expr, z_expr = _response_length_score_and_z(
+                pl.col(c), config.response_length_rz_cap
+            )
+            work = work.with_columns(s_expr.alias(s_col), z_expr.alias(z_col))
+            len_score_cols.append(s_col)
+            len_z_cols.append(z_col)
+        work = work.with_columns(
+            pl.max_horizontal(*[pl.col(c) for c in len_score_cols]).alias(
+                "__q_length_outlier_score"
+            )
+        )
+        work = work.with_columns(
+            pl.coalesce(
+                [
+                    pl.when(pl.col(sc) == pl.col("__q_length_outlier_score")).then(pl.col(zc))
+                    for sc, zc in zip(len_score_cols, len_z_cols)
+                ]
+            ).alias("__q_length_outlier_z")
+        )
+        active["length_outlier"] = {
+            "score_col": "__q_length_outlier_score",
+            "threshold": config.length_outlier_threshold,
+            "extra": {"z": "__q_length_outlier_z"},
+        }
+
+        work = work.with_columns(
+            duplicate_answer_score(
+                list(config.text_columns), min_answer_chars=config.duplicate_min_answer_chars
+            ).alias("__q_duplicate_score")
+        )
+        active["duplicate_answers"] = {
+            "score_col": "__q_duplicate_score",
+            "threshold": config.duplicate_threshold,
+        }
+
+    if config.duration_column:
+        work = work.with_columns(
+            speeder_score(
+                pl.col(config.duration_column),
+                percentile=config.speeder_percentile,
+                min_duration_seconds=config.min_duration_seconds,
+                median_fraction=config.speeder_median_fraction,
+            ).alias("__q_speeder_score")
+        )
+        active["speeder"] = {
+            "score_col": "__q_speeder_score",
+            "threshold": 0.0,
+            "flag_rule": "gt",
+        }
+
+    if config.llm_tier:
+        nd = _near_duplicate_flags(df, config)
+        ai = _ai_likelihood_flags(df, config)
+        assert nd.height == df.height, "near-duplicate helper must preserve row count"
+        assert ai.height == df.height, "ai-likelihood helper must preserve row count"
+
+        work = work.with_columns(
+            nd["__q_near_duplicate_score"].alias("__q_near_duplicate_score"),
+            nd["__q_near_duplicate_neighbor_id"].alias("__q_near_duplicate_neighbor_id"),
+            ai["__q_likely_ai_score"].alias("__q_likely_ai_score"),
+            ai["__q_likely_ai_rationale"].alias("__q_likely_ai_rationale"),
+        )
+        active["near_duplicate"] = {
+            "score_col": "__q_near_duplicate_score",
+            "threshold": config.near_duplicate_threshold,
+            "extra": {"neighbor_id": "__q_near_duplicate_neighbor_id"},
+        }
+        active["likely_ai"] = {
+            "score_col": "__q_likely_ai_score",
+            "threshold": config.ai_likelihood_threshold,
+            "extra": {"rationale": "__q_likely_ai_rationale"},
+        }
+
+    # -- Flag columns: score >= threshold (speeder: score > 0), null-safe --
+    for name, info in active.items():
+        score_col = info["score_col"]
+        threshold = info["threshold"]
+        if info.get("flag_rule") == "gt":
+            flag_expr = (pl.col(score_col) > threshold).fill_null(False)
+        else:
+            flag_expr = (pl.col(score_col) >= threshold).fill_null(False)
+        flag_col = f"{score_col}__flag"
+        work = work.with_columns(flag_expr.alias(flag_col))
+        info["flag_col"] = flag_col
+
+    # -- Assemble the nested `quality` struct --
+    struct_field_exprs = []
+    for name, info in active.items():
+        parts = {"score": pl.col(info["score_col"]), "flag": pl.col(info["flag_col"])}
+        extra = info.get("extra", {})
+        for field_name, col_name in extra.items():
+            parts[field_name] = pl.col(col_name)
+        ordered = ["score", *extra.keys(), "flag"]
+        struct_field_exprs.append(
+            pl.struct([parts[n].alias(n) for n in ordered]).alias(name)
+        )
+
+    if active:
+        flag_cols = [pl.col(info["flag_col"]) for info in active.values()]
+        any_flag_expr = pl.any_horizontal(*flag_cols)
+        n_flags_expr = pl.sum_horizontal(*[c.cast(pl.UInt32) for c in flag_cols])
+    else:
+        any_flag_expr = pl.lit(False)
+        n_flags_expr = pl.lit(0).cast(pl.UInt32)
+
+    work = work.with_columns(
+        any_flag_expr.alias("__q_any_flag"), n_flags_expr.alias("__q_n_flags")
+    )
+
+    final_struct = pl.struct(
+        [*struct_field_exprs, pl.col("__q_any_flag").alias("any_flag"), pl.col("__q_n_flags").alias("n_flags")]
+    ).alias(output_column)
+    work = work.with_columns(final_struct)
+
+    result_df = df.with_columns(**{output_column: work[output_column]})
+    assert result_df.height == df.height, "quality_report must never change row count"
+
+    # -- Summary: one row per active flag + a final any_flag row --
+    summary_rows: List[Dict[str, Any]] = []
+    for name, info in active.items():
+        score_col, flag_col = info["score_col"], info["flag_col"]
+        stats = work.select(
+            n_scored=pl.col(score_col).is_not_null().sum(),
+            n_flagged=pl.col(flag_col).sum(),
+            mean_score=pl.col(score_col).mean(),
+        ).row(0, named=True)
+        n_scored = int(stats["n_scored"])
+        n_flagged = int(stats["n_flagged"])
+        summary_rows.append(
+            {
+                "flag": name,
+                "n_scored": n_scored,
+                "n_flagged": n_flagged,
+                "rate": (n_flagged / n_scored) if n_scored else 0.0,
+                "threshold": float(info["threshold"]),
+                "mean_score": stats["mean_score"],
+            }
+        )
+
+    n_scored_any = df.height
+    n_flagged_any = int(work.select(pl.col("__q_any_flag").sum()).item())
+    summary_rows.append(
+        {
+            "flag": "any_flag",
+            "n_scored": n_scored_any,
+            "n_flagged": n_flagged_any,
+            "rate": (n_flagged_any / n_scored_any) if n_scored_any else 0.0,
+            "threshold": None,
+            "mean_score": None,
+        }
+    )
+
+    summary_df = pl.DataFrame(
+        summary_rows,
+        schema={
+            "flag": pl.Utf8,
+            "n_scored": pl.UInt32,
+            "n_flagged": pl.UInt32,
+            "rate": pl.Float64,
+            "threshold": pl.Float64,
+            "mean_score": pl.Float64,
+        },
+    )
+
+    return QualityReport(df=result_df, summary=summary_df)

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -1847,3 +1847,189 @@ fn krippendorffs_alpha_ci(inputs: &[Series], kwargs: AlphaKwargs) -> PolarsResul
 
     build_irr_struct(Some(value), ci_low, ci_high)
 }
+
+// ============================================================================
+// Survey data quality (issue #80)
+// ============================================================================
+//
+// Three row-wise plugin expressions backed by the pure, unit-tested
+// functions in `crate::quality` (mirrors the `src/metrics.rs` split for
+// issue #79): `straightlining_score` (N numeric grid columns),
+// `gibberish_score` (1 string column), `duplicate_answer_score` (N string
+// columns). Every one of these is a *scoring* function, never a filter --
+// null inputs (or "not enough signal") produce a null score, not an error
+// and not a dropped row; thresholding into a boolean flag happens entirely
+// on the Python side (`polar_llama/quality.py::quality_report`).
+//
+// `straightlining_score` needs the Likert scale's `[min, max]` bounds to
+// normalize its variance component. When the caller doesn't supply
+// `scale_min`/`scale_max` explicitly, this infers them from the observed
+// min/max across *all* values in *all* grid columns passed to this one
+// call -- a whole-batch computation, registered `is_elementwise=True`
+// anyway so it composes inside `with_columns` (same documented precedent as
+// `cluster_embeddings` above). `quality_report` always passes explicit
+// bounds computed once over the whole configured column set, precisely so
+// this batch-inference fallback (which could vary with a lazy engine's
+// chunking) is never actually exercised by the DataFrame-level API -- it
+// only matters for a caller using the raw expression standalone.
+
+fn default_min_answers() -> usize {
+    3
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StraightlineKwargs {
+    #[serde(default)]
+    scale_min: Option<f64>,
+    #[serde(default)]
+    scale_max: Option<f64>,
+    #[serde(default = "default_min_answers")]
+    min_answers: usize,
+}
+
+/// Casts every input `Series` to `Float64` and returns one `Vec<f64>` of
+/// finite, non-null values per row (grid answers for that respondent), plus
+/// the flattened set of all finite values across every row/column (used for
+/// batch-wide scale inference when the caller didn't pin `scale_min`/`scale_max`).
+fn gather_numeric_rows(inputs: &[Series]) -> PolarsResult<(Vec<Vec<f64>>, Vec<f64>)> {
+    if inputs.is_empty() {
+        return Ok((Vec::new(), Vec::new()));
+    }
+    let n_rows = inputs[0].len();
+
+    let mut columns: Vec<Vec<Option<f64>>> = Vec::with_capacity(inputs.len());
+    for s in inputs {
+        let casted = s.cast(&DataType::Float64)?;
+        let ca = casted.f64()?;
+        columns.push(
+            ca.into_iter()
+                .map(|opt| opt.filter(|v| v.is_finite()))
+                .collect(),
+        );
+    }
+
+    let mut rows: Vec<Vec<f64>> = Vec::with_capacity(n_rows);
+    let mut all_values: Vec<f64> = Vec::new();
+    for row in 0..n_rows {
+        let mut vals = Vec::with_capacity(columns.len());
+        for col in &columns {
+            if let Some(Some(v)) = col.get(row) {
+                vals.push(*v);
+                all_values.push(*v);
+            }
+        }
+        rows.push(vals);
+    }
+    Ok((rows, all_values))
+}
+
+/// Straightlining suspicion score across N grid (Likert) columns -- one
+/// score per respondent (row). See `crate::quality::straightline_score` for
+/// the formula. Rows with fewer than `min_answers` non-null grid answers
+/// score null (never flagged, never dropped).
+#[polars_expr(output_type=Float64)]
+fn straightlining_score(inputs: &[Series], kwargs: StraightlineKwargs) -> PolarsResult<Series> {
+    if inputs.is_empty() {
+        return Ok(Float64Chunked::from_slice_options(PlSmallStr::from_static(""), &[])
+            .into_series());
+    }
+    let name = inputs[0].name().clone();
+    let (rows, all_values) = gather_numeric_rows(inputs)?;
+
+    let (scale_min, scale_max) = match (kwargs.scale_min, kwargs.scale_max) {
+        (Some(lo), Some(hi)) => (lo, hi),
+        _ => {
+            if all_values.is_empty() {
+                (0.0, 0.0)
+            } else {
+                let lo = all_values.iter().cloned().fold(f64::INFINITY, f64::min);
+                let hi = all_values
+                    .iter()
+                    .cloned()
+                    .fold(f64::NEG_INFINITY, f64::max);
+                (
+                    kwargs.scale_min.unwrap_or(lo),
+                    kwargs.scale_max.unwrap_or(hi),
+                )
+            }
+        }
+    };
+
+    let scores: Vec<Option<f64>> = rows
+        .iter()
+        .map(|row| crate::quality::straightline_score(row, scale_min, scale_max, kwargs.min_answers))
+        .collect();
+
+    Ok(Float64Chunked::from_slice_options(name, &scores).into_series())
+}
+
+fn default_gibberish_min_chars() -> usize {
+    8
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GibberishKwargs {
+    #[serde(default = "default_gibberish_min_chars")]
+    min_chars: usize,
+}
+
+/// Keyboard-mash / gibberish suspicion score for one text column. See
+/// `crate::quality::gibberish_score` for the formula and its documented
+/// English-only limitation. Null input, or fewer than `min_chars` letters
+/// surviving normalization, scores null.
+#[polars_expr(output_type=Float64)]
+fn gibberish_score(inputs: &[Series], kwargs: GibberishKwargs) -> PolarsResult<Series> {
+    let ca = inputs[0].str()?;
+    if ca.is_empty() {
+        return Ok(Float64Chunked::from_slice_options(ca.name().clone(), &[]).into_series());
+    }
+    let scores: Vec<Option<f64>> = ca
+        .into_iter()
+        .map(|opt| opt.and_then(|text| crate::quality::gibberish_score(text, kwargs.min_chars)))
+        .collect();
+    Ok(Float64Chunked::from_slice_options(ca.name().clone(), &scores).into_series())
+}
+
+fn default_min_answer_chars() -> usize {
+    10
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DuplicateKwargs {
+    #[serde(default = "default_min_answer_chars")]
+    min_answer_chars: usize,
+}
+
+/// Cross-answer near-duplicate suspicion score across N open-end text
+/// columns -- one score per respondent (row). See
+/// `crate::quality::duplicate_answer_score` for the formula. Rows with
+/// fewer than 2 surviving (non-null, >= `min_answer_chars`) answers score
+/// null.
+#[polars_expr(output_type=Float64)]
+fn duplicate_answer_score(inputs: &[Series], kwargs: DuplicateKwargs) -> PolarsResult<Series> {
+    if inputs.is_empty() {
+        return Ok(Float64Chunked::from_slice_options(PlSmallStr::from_static(""), &[])
+            .into_series());
+    }
+    let name = inputs[0].name().clone();
+    let n_rows = inputs[0].len();
+
+    let string_cols: Vec<&StringChunked> = inputs
+        .iter()
+        .map(|s| s.str())
+        .collect::<PolarsResult<Vec<_>>>()?;
+
+    let mut scores: Vec<Option<f64>> = Vec::with_capacity(n_rows);
+    for row in 0..n_rows {
+        let answers: Vec<&str> = string_cols
+            .iter()
+            .filter_map(|ca| ca.get(row))
+            .collect();
+        scores.push(crate::quality::duplicate_answer_score(
+            &answers,
+            kwargs.min_answer_chars,
+        ));
+    }
+
+    Ok(Float64Chunked::from_slice_options(name, &scores).into_series())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod cost;
 pub mod kmeans;
 pub mod mcp;
 pub mod metrics;
+pub mod quality;
 mod stream_pyfn;
 
 #[cfg(target_os = "linux")]

--- a/src/quality.rs
+++ b/src/quality.rs
@@ -1,0 +1,426 @@
+//! Survey data-quality heuristics (issue #80): straightlining, gibberish,
+//! and duplicate-answer scoring.
+//!
+//! These are pure functions over plain Rust values -- no Polars types --
+//! so they are trivially unit-testable here and reused by the plugin
+//! expressions in `src/expressions.rs`, which handle the Polars `Series` /
+//! null plumbing around them (mirrors `src/metrics.rs`'s split for the
+//! inter-rater-reliability metrics, issue #79).
+//!
+//! Every score is `Option<f64>` in `[0, 1]` when `Some`, higher = more
+//! suspicious. `None` means "not enough signal to judge" (too few answers,
+//! too little text) -- callers must treat `None` as "do not flag", never as
+//! zero. **These functions never drop or reject a row; they only ever
+//! return a score (or a null score) for it.**
+
+use std::collections::HashMap;
+
+// ============================================================================
+// Straightlining
+// ============================================================================
+
+/// Straightlining/flatlining suspicion score for one respondent's grid
+/// answers (a Likert-style battery, e.g. 5 columns on a 1-5 scale).
+///
+/// `row` holds that respondent's non-null numeric answers across the grid
+/// columns (arbitrary order -- grid column order is not meaningful, so this
+/// looks at value distribution, not run-length). Returns `None` when fewer
+/// than `min_answers` answers are present (not enough signal).
+///
+/// Two components, combined by `max` (either alone is enough to be
+/// suspicious):
+/// - `mode_frac`: share of answers equal to the most frequent value. A pure
+///   straightliner (all identical) scores `1.0` here.
+/// - `1 - var_norm`: `var_norm` is the row's population variance normalized
+///   by `max_var = ((scale_max - scale_min) / 2)^2` (the maximum possible
+///   variance for a value bouncing between the scale's endpoints), clipped
+///   to `[0, 1]`. A respondent alternating between endpoints (e.g. 1,5,1,5)
+///   has near-maximal variance, so `1 - var_norm` is near 0 -- correctly
+///   *not* flagged as straightlining even though it isn't varied in the
+///   "many distinct values" sense.
+///
+/// `scale_min`/`scale_max` are the Likert scale's bounds (e.g. `1.0`/`5.0`);
+/// when `scale_max <= scale_min` (a degenerate/unconfigured scale), the
+/// variance component is skipped (`var_norm = 0`) and the score falls back
+/// to `mode_frac` alone.
+pub fn straightline_score(
+    row: &[f64],
+    scale_min: f64,
+    scale_max: f64,
+    min_answers: usize,
+) -> Option<f64> {
+    let m = row.len();
+    if m < min_answers.max(1) {
+        return None;
+    }
+
+    // mode_frac: count of the most frequent value / m. Bucketed on the raw
+    // bit pattern -- grid answers are expected to be small discrete codes
+    // (Likert points), so exact float equality is the right notion of
+    // "the same answer" here.
+    let mut counts: HashMap<u64, usize> = HashMap::with_capacity(m);
+    for &v in row {
+        *counts.entry(v.to_bits()).or_insert(0) += 1;
+    }
+    let max_count = counts.values().copied().max().unwrap_or(0);
+    let mode_frac = max_count as f64 / m as f64;
+
+    let mean: f64 = row.iter().sum::<f64>() / m as f64;
+    let variance: f64 = row.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / m as f64;
+
+    let half_range = (scale_max - scale_min) / 2.0;
+    let max_var = half_range * half_range;
+
+    let score = if max_var > 0.0 {
+        let var_norm = (variance / max_var).clamp(0.0, 1.0);
+        mode_frac.max(1.0 - var_norm)
+    } else {
+        // Degenerate/unconfigured scale (scale_max <= scale_min): the
+        // variance component is meaningless (no "maximum possible
+        // variance" to normalize against), so fall back to mode_frac alone
+        // rather than letting `1 - var_norm` collapse to a vacuous 1.0.
+        mode_frac
+    };
+    Some(score.clamp(0.0, 1.0))
+}
+
+// ============================================================================
+// Gibberish detection
+// ============================================================================
+
+const ENGLISH_VOWEL_RATIO: f64 = 0.38;
+const CONSONANT_RUN_CAP: f64 = 6.0;
+const VOWELS: [char; 5] = ['a', 'e', 'i', 'o', 'u'];
+
+/// Gibberish/keyboard-mash suspicion score for one open-end answer.
+///
+/// English-only heuristic (documented limitation): normalizes to lowercase
+/// `[a-z ]` only (digits/punctuation/non-Latin scripts are stripped).
+/// Returns `None` when fewer than `min_chars` letters survive normalization
+/// -- both because there's too little signal to judge, and so that
+/// non-Latin-script text (which normalizes to ~nothing) gets a null score
+/// rather than a false "gibberish" flag.
+///
+/// Three components, weighted-summed (weights are a documented, subjective
+/// convention -- see `docs/QUALITY_FLAGS.md`):
+/// - `consonant_run` (weight 0.5): longest run of consecutive consonants
+///   (a run breaks on any vowel or space), normalized by a 6-char cap.
+///   Keyboard mash like "asdkjfh" has long consonant runs; English rarely
+///   exceeds 3-4.
+/// - `vowel_dev` (weight 0.3): relative deviation of the letter-only vowel
+///   ratio from English's ~0.38.
+/// - `entropy_term` (weight 0.2): normalized Shannon entropy of character
+///   bigrams (over the whole normalized string, spaces included). Weak
+///   alone (English isn't low-entropy either) but a useful tie-breaker.
+pub fn gibberish_score(text: &str, min_chars: usize) -> Option<f64> {
+    let normalized: String = text
+        .to_lowercase()
+        .chars()
+        .filter(|c| c.is_ascii_lowercase() || *c == ' ')
+        .collect();
+
+    let letters: Vec<char> = normalized
+        .chars()
+        .filter(|c| c.is_ascii_lowercase())
+        .collect();
+    if letters.len() < min_chars.max(1) {
+        return None;
+    }
+
+    let vowel_count = letters.iter().filter(|c| VOWELS.contains(c)).count();
+    let vowel_ratio = vowel_count as f64 / letters.len() as f64;
+    let vowel_dev = ((vowel_ratio - ENGLISH_VOWEL_RATIO).abs() / ENGLISH_VOWEL_RATIO).min(1.0);
+
+    let mut max_run = 0usize;
+    let mut cur_run = 0usize;
+    for c in normalized.chars() {
+        if c.is_ascii_lowercase() && !VOWELS.contains(&c) {
+            cur_run += 1;
+            max_run = max_run.max(cur_run);
+        } else {
+            cur_run = 0;
+        }
+    }
+    let consonant_run = (max_run as f64 / CONSONANT_RUN_CAP).min(1.0);
+
+    let chars: Vec<char> = normalized.chars().collect();
+    let entropy_term = if chars.len() < 2 {
+        0.0
+    } else {
+        // BTreeMap (not HashMap): iteration order must be deterministic --
+        // std HashMap randomizes its hasher per-instance, which would make
+        // this floating-point sum (and therefore the score) vary in its
+        // last bit from call to call on identical input.
+        let mut bigram_counts: std::collections::BTreeMap<(char, char), usize> =
+            std::collections::BTreeMap::new();
+        for w in chars.windows(2) {
+            *bigram_counts.entry((w[0], w[1])).or_insert(0) += 1;
+        }
+        let total: usize = bigram_counts.values().sum();
+        if total == 0 {
+            0.0
+        } else {
+            let h: f64 = bigram_counts
+                .values()
+                .map(|&c| {
+                    let p = c as f64 / total as f64;
+                    -p * p.log2()
+                })
+                .sum();
+            let n_distinct = (bigram_counts.len() as f64).max(2.0);
+            (h / n_distinct.log2()).min(1.0)
+        }
+    };
+
+    let score = 0.5 * consonant_run + 0.3 * vowel_dev + 0.2 * entropy_term;
+    Some(score.clamp(0.0, 1.0))
+}
+
+// ============================================================================
+// Duplicate-answer detection
+// ============================================================================
+
+/// Normalize an answer for duplicate comparison: lowercase, collapse any
+/// run of non-alphanumeric characters (whitespace or punctuation) into a
+/// single space, and trim. `"The product is great."` and `"the product is
+/// great"` normalize identically.
+fn normalize_for_duplicate(s: &str) -> String {
+    let lower = s.to_lowercase();
+    let mut out = String::with_capacity(lower.len());
+    let mut pending_space = false;
+    for c in lower.chars() {
+        if c.is_alphanumeric() {
+            if pending_space && !out.is_empty() {
+                out.push(' ');
+            }
+            pending_space = false;
+            out.push(c);
+        } else {
+            pending_space = true;
+        }
+    }
+    out
+}
+
+/// Cross-answer near-duplicate suspicion score for one respondent's set of
+/// open-end answers (e.g. several open-ends in the same survey).
+///
+/// Normalizes each answer (see `normalize_for_duplicate`) and drops any
+/// answer shorter than `min_answer_chars` (so legitimate short repeats like
+/// "yes"/"n/a" across several open-ends don't trip this). Returns `None`
+/// when fewer than 2 answers survive that filter.
+///
+/// Score is the maximum pairwise token-set Jaccard similarity
+/// (`|A ∩ B| / |A ∪ B|`) over every pair of surviving answers -- `1.0` for a
+/// verbatim (post-normalization) repeat, lower for partial overlap. One
+/// mechanism covers both "exact" (Jaccard == 1.0) and "near" duplicates.
+pub fn duplicate_answer_score(answers: &[&str], min_answer_chars: usize) -> Option<f64> {
+    let normalized: Vec<String> = answers
+        .iter()
+        .map(|a| normalize_for_duplicate(a))
+        .filter(|a| a.chars().count() >= min_answer_chars)
+        .collect();
+    if normalized.len() < 2 {
+        return None;
+    }
+
+    let token_sets: Vec<std::collections::HashSet<&str>> = normalized
+        .iter()
+        .map(|a| a.split_whitespace().collect())
+        .collect();
+
+    let mut max_jaccard = 0.0f64;
+    for i in 0..token_sets.len() {
+        for j in (i + 1)..token_sets.len() {
+            let inter = token_sets[i].intersection(&token_sets[j]).count();
+            let union = token_sets[i].union(&token_sets[j]).count();
+            let jaccard = if union == 0 {
+                0.0
+            } else {
+                inter as f64 / union as f64
+            };
+            if jaccard > max_jaccard {
+                max_jaccard = jaccard;
+            }
+        }
+    }
+    Some(max_jaccard.clamp(0.0, 1.0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_close(actual: f64, expected: f64, tol: f64) {
+        assert!(
+            (actual - expected).abs() < tol,
+            "expected {expected}, got {actual} (tol {tol})"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // straightline_score
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_straightline_all_identical_is_one() {
+        let row = [4.0, 4.0, 4.0, 4.0, 4.0];
+        assert_close(straightline_score(&row, 1.0, 5.0, 3).unwrap(), 1.0, 1e-12);
+    }
+
+    #[test]
+    fn test_straightline_alternating_endpoints_is_low() {
+        // Alternating 1,5,1,5,1: mode_frac = 3/5 = 0.6, but variance is
+        // maximal (half_range^2 = 4), so `1 - var_norm` ~ 0 and mode_frac
+        // dominates but is well below the 0.85 default threshold band we
+        // document -- assert it's meaningfully lower than the all-identical
+        // case (correctness property, not a pinned threshold).
+        let identical = [4.0, 4.0, 4.0, 4.0, 4.0];
+        let alternating = [1.0, 5.0, 1.0, 5.0, 1.0];
+        let s_identical = straightline_score(&identical, 1.0, 5.0, 3).unwrap();
+        let s_alternating = straightline_score(&alternating, 1.0, 5.0, 3).unwrap();
+        assert!(s_alternating < s_identical);
+        assert!(s_alternating < 0.65);
+    }
+
+    #[test]
+    fn test_straightline_normal_variation_is_lower_than_straightliner() {
+        let straightliner = [4.0, 4.0, 4.0, 4.0, 4.0];
+        let normal = [2.0, 4.0, 3.0, 5.0, 1.0];
+        let s_straight = straightline_score(&straightliner, 1.0, 5.0, 3).unwrap();
+        let s_normal = straightline_score(&normal, 1.0, 5.0, 3).unwrap();
+        assert!(s_straight > s_normal);
+        assert_close(s_straight, 1.0, 1e-12);
+    }
+
+    #[test]
+    fn test_straightline_below_min_answers_is_none() {
+        let row = [4.0, 4.0];
+        assert_eq!(straightline_score(&row, 1.0, 5.0, 3), None);
+    }
+
+    #[test]
+    fn test_straightline_empty_is_none() {
+        let row: [f64; 0] = [];
+        assert_eq!(straightline_score(&row, 1.0, 5.0, 3), None);
+    }
+
+    #[test]
+    fn test_straightline_degenerate_scale_falls_back_to_mode_frac() {
+        // scale_max <= scale_min: variance component skipped.
+        let row = [3.0, 3.0, 5.0];
+        let score = straightline_score(&row, 2.0, 2.0, 3).unwrap();
+        assert_close(score, 2.0 / 3.0, 1e-12);
+    }
+
+    // ------------------------------------------------------------------
+    // gibberish_score
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_gibberish_keyboard_mash_scores_higher_than_english() {
+        let mash = gibberish_score("asdkjfhaslkdjf", 8).unwrap();
+        let english = gibberish_score("The service was slow but friendly", 8).unwrap();
+        assert!(
+            mash > english + 0.3,
+            "mash={mash}, english={english} (want margin >= 0.3)"
+        );
+    }
+
+    #[test]
+    fn test_gibberish_repeated_char_is_bounded_and_vowel_deviant() {
+        // "aaaaaaaa": vowel_ratio=1.0 maxes out vowel_dev (weight 0.3), but
+        // consonant_run (weight 0.5) is 0 (never a consonant) -- the
+        // dominant weight doesn't fire here by design (a repeated-vowel
+        // string isn't the "keyboard mash" shape this heuristic targets;
+        // see the module-level weighting discussion). Just pin it's a
+        // valid, non-trivial score, not an ordering vs. English text.
+        let score = gibberish_score("aaaaaaaa", 8).unwrap();
+        assert!((0.0..=1.0).contains(&score));
+        assert!(score > 0.25);
+    }
+
+    #[test]
+    fn test_gibberish_too_short_is_none() {
+        assert_eq!(gibberish_score("hi", 8), None);
+    }
+
+    #[test]
+    fn test_gibberish_non_latin_script_is_none() {
+        // Normalizes to ~nothing (no [a-z] survives) -- null, not a false
+        // "gibberish" flag. Documented limitation (English-only heuristic).
+        assert_eq!(gibberish_score("こんにちは世界", 8), None);
+    }
+
+    #[test]
+    fn test_gibberish_empty_is_none() {
+        assert_eq!(gibberish_score("", 8), None);
+    }
+
+    #[test]
+    fn test_gibberish_score_bounded() {
+        for text in ["asdkjfhaslkdjf qwpoeiruqpwoeiru", "The quick brown fox jumps"] {
+            let s = gibberish_score(text, 8).unwrap();
+            assert!((0.0..=1.0).contains(&s));
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // duplicate_answer_score
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_duplicate_exact_repeat_is_one() {
+        let a = "The product is great and I would recommend it";
+        let b = "the product is great and I would recommend it.";
+        let score = duplicate_answer_score(&[a, b], 10).unwrap();
+        assert_close(score, 1.0, 1e-12);
+    }
+
+    #[test]
+    fn test_duplicate_distinct_answers_is_low() {
+        let a = "The product is great and I would recommend it";
+        let b = "Shipping was slow and the box arrived damaged";
+        let score = duplicate_answer_score(&[a, b], 10).unwrap();
+        assert!(score < 0.3);
+    }
+
+    #[test]
+    fn test_duplicate_partial_overlap() {
+        let a = "the product is great and fast";
+        let b = "the product is great but pricey";
+        // tokens: {the,product,is,great,and,fast} vs {the,product,is,great,but,pricey}
+        // intersection = {the,product,is,great} = 4, union = 8
+        let score = duplicate_answer_score(&[a, b], 10).unwrap();
+        assert_close(score, 4.0 / 8.0, 1e-12);
+    }
+
+    #[test]
+    fn test_duplicate_short_answers_skipped() {
+        // Both answers below min_answer_chars=10 -- legit "yes"/"n/a" repeats.
+        let score = duplicate_answer_score(&["yes", "yes"], 10);
+        assert_eq!(score, None);
+    }
+
+    #[test]
+    fn test_duplicate_single_survivor_is_none() {
+        let a = "The product is great and I would recommend it";
+        let score = duplicate_answer_score(&[a, "n/a"], 10);
+        assert_eq!(score, None);
+    }
+
+    #[test]
+    fn test_duplicate_empty_is_none() {
+        let score = duplicate_answer_score(&[], 10);
+        assert_eq!(score, None);
+    }
+
+    #[test]
+    fn test_duplicate_three_answers_max_pairwise() {
+        let a = "the weather today is quite nice";
+        let b = "the weather today is quite nice";
+        let c = "completely unrelated statement about pricing";
+        let score = duplicate_answer_score(&[a, b, c], 10).unwrap();
+        assert_close(score, 1.0, 1e-12);
+    }
+}

--- a/tests/test_quality_flags.py
+++ b/tests/test_quality_flags.py
@@ -1,0 +1,540 @@
+"""Tests for survey data-quality flags (issue #80): `quality_report`,
+`QualityConfig`, and the standalone heuristic-tier expressions
+(`straightlining_score`, `gibberish_score`, `duplicate_answer_score`,
+`response_length_score`, `speeder_score`).
+
+CI-safe: the heuristic tier makes zero API calls and needs no `mlx` /
+API key, so every test in this file runs unconditionally. The
+embedding/LLM tier (`QualityConfig(llm_tier=True)`) is exercised
+separately in `tests/test_quality_llm.py`, gated on `OPENAI_API_KEY`.
+"""
+
+import random
+
+import polars as pl
+import pytest
+
+from polar_llama import (
+    QualityConfig,
+    QualityReport,
+    duplicate_answer_score,
+    gibberish_score,
+    quality_report,
+    response_length_score,
+    speeder_score,
+    straightlining_score,
+)
+
+GRID_COLS = ["g1", "g2", "g3", "g4", "g5"]
+TEXT_COLS = ["oe1", "oe2", "oe3"]
+DURATION_COL = "duration_s"
+
+_SENTENCE_POOL = [
+    "The customer service team was really helpful when I called about my broken order last week.",
+    "I think the app works fine most days but sometimes it crashes right after I open it.",
+    "Overall I'm happy with the purchase although shipping took a bit longer than the site promised.",
+    "My favorite part of the update is the new dashboard, it loads noticeably faster than before.",
+    "The instructions were a little confusing at first but customer support cleared things up quickly.",
+    "I would probably buy this again since the price felt fair for what you actually get.",
+    "Delivery was fast and the packaging was solid, nothing got damaged during the whole trip.",
+    "The interface takes some getting used to but once you learn it things move pretty smoothly.",
+    "Not a huge fan of the new pricing tiers, they feel more expensive than the old plan.",
+    "Support answered within an hour which honestly surprised me given how busy their queue looked.",
+    "The onboarding flow was clear enough that I didn't need to contact anyone for help.",
+    "Battery life dropped a bit after the last update but everything else feels about the same.",
+]
+
+
+def _make_filler_rows(n: int, *, seed: int = 42):
+    rng = random.Random(seed)
+    rows = []
+    for i in range(n):
+        # A shuffled permutation of 1..5 always has the same population
+        # variance (2.0) regardless of order, so it can never brush the
+        # straightlining threshold by chance the way independent uniform
+        # draws occasionally can (e.g. 4-of-5 identical) -- deterministic,
+        # not just "usually", non-suspicious grid answers.
+        grid = [1, 2, 3, 4, 5]
+        rng.shuffle(grid)
+        sentences = rng.sample(_SENTENCE_POOL, 3)
+        duration = rng.randint(200, 400)
+        rows.append(
+            {
+                "respondent_id": f"filler_{i}",
+                "g1": grid[0],
+                "g2": grid[1],
+                "g3": grid[2],
+                "g4": grid[3],
+                "g5": grid[4],
+                "oe1": sentences[0],
+                "oe2": sentences[1],
+                "oe3": sentences[2],
+                "duration_s": duration,
+            }
+        )
+    return rows
+
+
+def _build_fixture() -> pl.DataFrame:
+    targeted_rows = [
+        {
+            "respondent_id": "straightliner",
+            "g1": 4,
+            "g2": 4,
+            "g3": 4,
+            "g4": 4,
+            "g5": 4,
+            "oe1": _SENTENCE_POOL[0],
+            "oe2": _SENTENCE_POOL[1],
+            "oe3": _SENTENCE_POOL[2],
+            "duration_s": 300,
+        },
+        {
+            "respondent_id": "gibberisher",
+            "g1": 2,
+            "g2": 4,
+            "g3": 1,
+            "g4": 5,
+            "g5": 3,
+            "oe1": "asdkjfhaslkdjf",
+            "oe2": "qwpoeiruqpwoeiru zxmcnvb",
+            "oe3": _SENTENCE_POOL[3],
+            "duration_s": 280,
+        },
+        {
+            "respondent_id": "duplicator",
+            "g1": 1,
+            "g2": 3,
+            "g3": 5,
+            "g4": 2,
+            "g5": 4,
+            "oe1": "The product is great and I would recommend it",
+            "oe2": "the product is great and I would recommend it.",
+            "oe3": _SENTENCE_POOL[4],
+            "duration_s": 320,
+        },
+        {
+            "respondent_id": "speeder",
+            "g1": 3,
+            "g2": 2,
+            "g3": 4,
+            "g4": 1,
+            "g5": 5,
+            "oe1": _SENTENCE_POOL[5],
+            "oe2": _SENTENCE_POOL[6],
+            "oe3": _SENTENCE_POOL[7],
+            "duration_s": 12,
+        },
+        {
+            "respondent_id": "normal",
+            "g1": 2,
+            "g2": 4,
+            "g3": 3,
+            "g4": 5,
+            "g5": 1,
+            "oe1": _SENTENCE_POOL[8],
+            "oe2": _SENTENCE_POOL[9],
+            "oe3": _SENTENCE_POOL[10],
+            "duration_s": 290,
+        },
+        {
+            "respondent_id": "long_ranter",
+            "g1": 3,
+            "g2": 4,
+            "g3": 2,
+            "g4": 5,
+            "g5": 3,
+            "oe1": "x" * 2000,
+            "oe2": _SENTENCE_POOL[11],
+            "oe3": _SENTENCE_POOL[0],
+            "duration_s": 310,
+        },
+    ]
+    rows = targeted_rows + _make_filler_rows(15)
+    return pl.DataFrame(rows)
+
+
+def _row(report: QualityReport, respondent_id: str) -> dict:
+    return (
+        report.df.filter(pl.col("respondent_id") == respondent_id)
+        .select("quality")
+        .to_series()[0]
+    )
+
+
+@pytest.fixture(scope="module")
+def fixture_df() -> pl.DataFrame:
+    return _build_fixture()
+
+
+@pytest.fixture(scope="module")
+def config() -> QualityConfig:
+    return QualityConfig(
+        id_column="respondent_id",
+        grid_columns=GRID_COLS,
+        text_columns=TEXT_COLS,
+        duration_column=DURATION_COL,
+    )
+
+
+@pytest.fixture(scope="module")
+def report(fixture_df, config) -> QualityReport:
+    return quality_report(fixture_df, config)
+
+
+# ============================================================================
+# 1. Height / order preserved
+# ============================================================================
+
+
+def test_output_height_matches_input(fixture_df, report):
+    assert report.df.height == fixture_df.height
+
+
+def test_row_order_preserved(fixture_df, report):
+    assert report.df["respondent_id"].to_list() == fixture_df["respondent_id"].to_list()
+
+
+# ============================================================================
+# 2. Each target respondent's flag fires -- and only that flag
+# ============================================================================
+
+
+def test_straightliner_flags_only_straightlining(report):
+    q = _row(report, "straightliner")
+    assert q["straightlining"]["flag"] is True
+    assert q["gibberish"]["flag"] is False
+    assert q["duplicate_answers"]["flag"] is False
+    assert q["speeder"]["flag"] is False
+
+
+def test_gibberisher_flags_only_gibberish(report):
+    q = _row(report, "gibberisher")
+    assert q["gibberish"]["flag"] is True
+    assert q["straightlining"]["flag"] is False
+    assert q["duplicate_answers"]["flag"] is False
+    assert q["speeder"]["flag"] is False
+
+
+def test_duplicator_flags_only_duplicate_answers(report):
+    q = _row(report, "duplicator")
+    assert q["duplicate_answers"]["flag"] is True
+    assert q["duplicate_answers"]["score"] == pytest.approx(1.0, abs=1e-9)
+    assert q["straightlining"]["flag"] is False
+    assert q["gibberish"]["flag"] is False
+    assert q["speeder"]["flag"] is False
+
+
+def test_speeder_flags_only_speeder(report):
+    q = _row(report, "speeder")
+    assert q["speeder"]["flag"] is True
+    assert q["straightlining"]["flag"] is False
+    assert q["gibberish"]["flag"] is False
+    assert q["duplicate_answers"]["flag"] is False
+
+
+def test_long_ranter_flags_length_outlier(report):
+    q = _row(report, "long_ranter")
+    assert q["length_outlier"]["flag"] is True
+    assert q["length_outlier"]["z"] > 0
+
+
+def test_normal_respondent_has_no_flags(report):
+    q = _row(report, "normal")
+    assert q["any_flag"] is False
+    assert q["n_flags"] == 0
+    for name in ("straightlining", "gibberish", "duplicate_answers", "speeder", "length_outlier"):
+        assert q[name]["flag"] is False
+
+
+def test_filler_rows_mostly_unflagged(report):
+    # Not a hard "zero false positives" guarantee (random fixture data can
+    # rarely brush a subjective threshold), but the overwhelming majority of
+    # 15 filler rows built from normal-length, non-repeating, non-gibberish
+    # text and moderate grid variety should not trip anything.
+    filler = report.df.filter(pl.col("respondent_id").str.starts_with("filler_"))
+    n_flagged = filler.select(pl.col("quality").struct.field("any_flag").sum()).item()
+    assert n_flagged <= 2, f"too many false positives among filler rows: {n_flagged}/15"
+
+
+# ============================================================================
+# 3. Graded ordering
+# ============================================================================
+
+
+def test_straightlining_score_ordering(report):
+    straightliner = _row(report, "straightliner")["straightlining"]["score"]
+    normal = _row(report, "normal")["straightlining"]["score"]
+    assert straightliner > normal
+
+
+def test_gibberish_score_ordering_and_margin():
+    mash = pl.DataFrame({"t": ["asdkjfhaslkdjf"]}).select(
+        s=gibberish_score("t")
+    ).item()
+    normal = pl.DataFrame({"t": ["The service was slow but friendly today overall"]}).select(
+        s=gibberish_score("t")
+    ).item()
+    assert mash > normal + 0.3
+
+
+def test_duplicate_score_is_one_for_verbatim_after_normalization():
+    df = pl.DataFrame(
+        {
+            "a": ["The product is great and I would recommend it"],
+            "b": ["the product is great and I would recommend it."],
+        }
+    )
+    score = df.select(s=duplicate_answer_score(["a", "b"])).item()
+    assert score == pytest.approx(1.0, abs=1e-9)
+
+
+def test_speeder_score_is_max_for_fastest(report, fixture_df):
+    scores = report.df.select(
+        pl.col("respondent_id"), pl.col("quality").struct.field("speeder").struct.field("score")
+    )
+    speeder_score_value = scores.filter(pl.col("respondent_id") == "speeder")["score"][0]
+    others_max = scores.filter(pl.col("respondent_id") != "speeder")["score"].max()
+    assert speeder_score_value > 0
+    assert speeder_score_value > (others_max or 0.0)
+
+
+# ============================================================================
+# 4. Standalone expressions agree with the report struct fields
+# ============================================================================
+
+
+def test_standalone_straightlining_matches_report(fixture_df, report, config):
+    scale_vals = pl.concat([fixture_df[c].cast(pl.Float64) for c in GRID_COLS])
+    standalone = fixture_df.select(
+        s=straightlining_score(
+            GRID_COLS, scale_min=scale_vals.min(), scale_max=scale_vals.max()
+        )
+    )["s"]
+    report_scores = report.df.select(
+        pl.col("quality").struct.field("straightlining").struct.field("score")
+    )["score"]
+    for a, b in zip(standalone.to_list(), report_scores.to_list()):
+        if a is None or b is None:
+            assert a is None and b is None
+        else:
+            assert a == pytest.approx(b, abs=1e-9)
+
+
+def test_standalone_gibberish_matches_report(fixture_df, report):
+    for col in TEXT_COLS:
+        standalone = fixture_df.select(s=gibberish_score(col))["s"].to_list()
+        # report's gibberish score is a max over columns, so only compare
+        # rows where this column achieves the row max.
+        report_scores = report.df.select(
+            pl.col("quality").struct.field("gibberish").struct.field("score")
+        )["score"].to_list()
+        for a, b in zip(standalone, report_scores):
+            if a is not None and b is not None:
+                assert a <= b + 1e-9
+
+
+def test_standalone_duplicate_matches_report(fixture_df, report):
+    standalone = fixture_df.select(s=duplicate_answer_score(TEXT_COLS))["s"].to_list()
+    report_scores = report.df.select(
+        pl.col("quality").struct.field("duplicate_answers").struct.field("score")
+    )["score"].to_list()
+    for a, b in zip(standalone, report_scores):
+        if a is None or b is None:
+            assert a is None and b is None
+        else:
+            assert a == pytest.approx(b, abs=1e-9)
+
+
+def test_standalone_response_length_score_bounded(fixture_df):
+    scores = fixture_df.select(s=response_length_score("oe1"))["s"]
+    for v in scores.to_list():
+        if v is not None:
+            assert 0.0 <= v <= 1.0
+
+
+def test_standalone_speeder_matches_report(fixture_df, report):
+    standalone = fixture_df.select(s=speeder_score(DURATION_COL))["s"].to_list()
+    report_scores = report.df.select(
+        pl.col("quality").struct.field("speeder").struct.field("score")
+    )["score"].to_list()
+    for a, b in zip(standalone, report_scores):
+        if a is None or b is None:
+            assert a is None and b is None
+        else:
+            assert a == pytest.approx(b, abs=1e-9)
+
+
+def test_llama_namespace_matches_functional(fixture_df):
+    functional = fixture_df.select(s=gibberish_score("oe1"))["s"]
+    namespaced = fixture_df.select(s=pl.col("oe1").llama.gibberish_score())["s"]
+    assert functional.to_list() == namespaced.to_list()
+
+    functional_dup = fixture_df.select(s=duplicate_answer_score(TEXT_COLS))["s"]
+    namespaced_dup = fixture_df.select(
+        s=pl.col("oe1").llama.duplicate_answer_score(["oe2", "oe3"])
+    )["s"]
+    assert functional_dup.to_list() == namespaced_dup.to_list()
+
+    functional_speed = fixture_df.select(s=speeder_score(DURATION_COL))["s"]
+    namespaced_speed = fixture_df.select(s=pl.col(DURATION_COL).llama.speeder_score())["s"]
+    assert functional_speed.to_list() == namespaced_speed.to_list()
+
+    functional_len = fixture_df.select(s=response_length_score("oe1"))["s"]
+    namespaced_len = fixture_df.select(s=pl.col("oe1").llama.response_length_score())["s"]
+    assert functional_len.to_list() == namespaced_len.to_list()
+
+    scale_vals = pl.concat([fixture_df[c].cast(pl.Float64) for c in GRID_COLS])
+    functional_sl = fixture_df.select(
+        s=straightlining_score(
+            GRID_COLS, scale_min=scale_vals.min(), scale_max=scale_vals.max()
+        )
+    )["s"]
+    namespaced_sl = fixture_df.select(
+        s=pl.col("g1").llama.straightlining_score(
+            ["g2", "g3", "g4", "g5"],
+            scale_min=scale_vals.min(),
+            scale_max=scale_vals.max(),
+        )
+    )["s"]
+    assert functional_sl.to_list() == namespaced_sl.to_list()
+
+
+# ============================================================================
+# 5. Config validation
+# ============================================================================
+
+
+def test_config_rejects_empty_config():
+    with pytest.raises(ValueError):
+        QualityConfig()
+
+
+def test_config_rejects_out_of_range_threshold():
+    with pytest.raises(ValueError):
+        QualityConfig(grid_columns=GRID_COLS, straightlining_threshold=1.5)
+
+
+def test_config_rejects_zero_threshold():
+    with pytest.raises(ValueError):
+        QualityConfig(grid_columns=GRID_COLS, gibberish_threshold=0.0)
+
+
+def test_config_rejects_bad_scale_bounds():
+    with pytest.raises(ValueError):
+        QualityConfig(grid_columns=GRID_COLS, scale_min=5.0, scale_max=1.0)
+
+
+def test_config_rejects_llm_tier_without_text_columns():
+    with pytest.raises(ValueError):
+        QualityConfig(grid_columns=GRID_COLS, llm_tier=True)
+
+
+def test_quality_report_rejects_missing_column(fixture_df):
+    bad_config = QualityConfig(grid_columns=["g1", "does_not_exist"])
+    with pytest.raises(ValueError):
+        quality_report(fixture_df, bad_config)
+
+
+# ============================================================================
+# 6. Nulls: never flagged, row still present
+# ============================================================================
+
+
+def test_all_null_text_row_has_null_scores_and_no_flags():
+    df = pl.DataFrame(
+        {
+            "id": ["a", "b"],
+            "oe1": [None, "A perfectly normal open-end answer about the product quality."],
+            "oe2": [None, "Shipping was on time and the box looked undamaged on arrival."],
+        }
+    )
+    cfg = QualityConfig(id_column="id", text_columns=["oe1", "oe2"])
+    result = quality_report(df, cfg)
+    assert result.df.height == 2
+    row = result.df.filter(pl.col("id") == "a").select("quality").to_series()[0]
+    assert row["gibberish"]["score"] is None
+    assert row["gibberish"]["flag"] is False
+    assert row["duplicate_answers"]["score"] is None
+    assert row["duplicate_answers"]["flag"] is False
+    assert row["any_flag"] is False
+
+
+# ============================================================================
+# 7. Summary shape
+# ============================================================================
+
+
+def test_summary_shape(report):
+    assert report.summary.columns == [
+        "flag",
+        "n_scored",
+        "n_flagged",
+        "rate",
+        "threshold",
+        "mean_score",
+    ]
+    flags = report.summary["flag"].to_list()
+    assert "any_flag" in flags
+    for expected in ("straightlining", "gibberish", "duplicate_answers", "speeder", "length_outlier"):
+        assert expected in flags
+
+
+def test_summary_n_flagged_matches_manual_count(report):
+    row = report.summary.filter(pl.col("flag") == "straightlining").row(0, named=True)
+    manual = report.df.select(
+        pl.col("quality").struct.field("straightlining").struct.field("flag").sum()
+    ).item()
+    assert row["n_flagged"] == manual
+    assert row["rate"] == pytest.approx(row["n_flagged"] / row["n_scored"])
+
+
+def test_summary_any_flag_row(report, fixture_df):
+    row = report.summary.filter(pl.col("flag") == "any_flag").row(0, named=True)
+    assert row["n_scored"] == fixture_df.height
+    manual = report.df.select(pl.col("quality").struct.field("any_flag").sum()).item()
+    assert row["n_flagged"] == manual
+
+
+# ============================================================================
+# 8. llm_tier=False makes zero network calls (no key needed)
+# ============================================================================
+
+
+def test_llm_tier_false_needs_no_api_key(fixture_df, monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    cfg = QualityConfig(
+        grid_columns=GRID_COLS,
+        text_columns=TEXT_COLS,
+        duration_column=DURATION_COL,
+        llm_tier=False,
+    )
+    result = quality_report(fixture_df, cfg)
+    assert result.df.height == fixture_df.height
+    q = result.df.select("quality").to_series()[0]
+    assert "near_duplicate" not in q
+    assert "likely_ai" not in q
+
+
+# ============================================================================
+# 9. quality_report never drops rows even with degenerate per-flag inputs
+# ============================================================================
+
+
+def test_single_row_dataframe_is_not_dropped():
+    df = pl.DataFrame({"g1": [3], "g2": [3], "g3": [3]})
+    cfg = QualityConfig(grid_columns=["g1", "g2", "g3"])
+    result = quality_report(df, cfg)
+    assert result.df.height == 1
+
+
+def test_grid_only_config_omits_text_and_duration_substructs():
+    df = pl.DataFrame({"g1": [3, 1], "g2": [3, 5], "g3": [3, 2]})
+    cfg = QualityConfig(grid_columns=["g1", "g2", "g3"])
+    result = quality_report(df, cfg)
+    q = result.df.select("quality").to_series()[0]
+    assert "straightlining" in q
+    assert "gibberish" not in q
+    assert "duplicate_answers" not in q
+    assert "speeder" not in q

--- a/tests/test_quality_llm.py
+++ b/tests/test_quality_llm.py
@@ -1,0 +1,105 @@
+"""Real-API tests for the survey data-quality embedding/LLM tier (issue
+#80): `near_duplicate` and `likely_ai` via `QualityConfig(llm_tier=True)`.
+
+Gated on `OPENAI_API_KEY` -- never runs in CI without a key (convention
+from `tests/test_codebook.py::test_induce_and_apply_codebook_real_api`).
+The heuristic tier (zero API calls) is fully covered, unconditionally, by
+`tests/test_quality_flags.py`.
+"""
+
+import os
+
+import polars as pl
+import pytest
+
+from polar_llama import Provider, QualityConfig, quality_report
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
+)
+
+
+AI_STYLE_ANSWER = (
+    "As a valued customer, I appreciate the opportunity to share my feedback "
+    "regarding this product. On one hand, the build quality is commendable "
+    "and the packaging was handled with care. On the other hand, the setup "
+    "process could benefit from clearer documentation for new users. In "
+    "conclusion, I believe this represents a solid offering with room for "
+    "incremental improvement, and I would recommend it to others seeking a "
+    "reliable solution within this category of products."
+)
+
+HUMAN_STYLE_ANSWERS = [
+    "tbh works fine i guess, box was a lil banged up tho lol",
+    "meh. instructions sucked but got it working eventually. wouldve been nice to have a video",
+    "pretty good!! fast shipping, kid loves it, would prob buy again ngl",
+]
+
+NEAR_DUP_A = "The onboarding process was confusing and I had to contact support twice to get it working."
+NEAR_DUP_B = "The onboarding process was confusing and I had to contact support twice to get things working."
+
+
+@pytest.fixture(scope="module")
+def llm_fixture_df() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "respondent_id": ["dup_a", "dup_b", "ai_style", "human_1", "human_2", "human_3"],
+            "oe1": [NEAR_DUP_A, NEAR_DUP_B, AI_STYLE_ANSWER, *HUMAN_STYLE_ANSWERS],
+        }
+    )
+
+
+@pytest.fixture(scope="module")
+def llm_report(llm_fixture_df) -> "pl.DataFrame":
+    config = QualityConfig(
+        id_column="respondent_id",
+        text_columns=["oe1"],
+        llm_tier=True,
+        embedding_provider=Provider.OPENAI,
+        provider=Provider.OPENAI,
+        model="gpt-4o-mini",
+    )
+    return quality_report(llm_fixture_df, config)
+
+
+def test_llm_tier_preserves_height(llm_fixture_df, llm_report):
+    assert llm_report.df.height == llm_fixture_df.height
+
+
+def test_near_duplicate_pair_flags_each_other(llm_report):
+    q = llm_report.df.select("respondent_id", "quality").rows(named=True)
+    by_id = {row["respondent_id"]: row["quality"] for row in q}
+
+    assert by_id["dup_a"]["near_duplicate"]["flag"] is True
+    assert by_id["dup_b"]["near_duplicate"]["flag"] is True
+    assert by_id["dup_a"]["near_duplicate"]["neighbor_id"] == "dup_b"
+    assert by_id["dup_b"]["near_duplicate"]["neighbor_id"] == "dup_a"
+
+    others_scores = [
+        by_id[rid]["near_duplicate"]["score"]
+        for rid in ("ai_style", "human_1", "human_2", "human_3")
+        if by_id[rid]["near_duplicate"]["score"] is not None
+    ]
+    for score in others_scores:
+        assert score < 0.97
+
+
+def test_likely_ai_scores_ai_style_higher_than_human_style(llm_report):
+    q = llm_report.df.select("respondent_id", "quality").rows(named=True)
+    by_id = {row["respondent_id"]: row["quality"] for row in q}
+
+    ai_score = by_id["ai_style"]["likely_ai"]["score"]
+    human_scores = [
+        by_id[rid]["likely_ai"]["score"] for rid in ("human_1", "human_2", "human_3")
+    ]
+    assert ai_score is not None
+    assert all(s is not None for s in human_scores)
+
+    # Graded ordering only -- never an absolute-value or perfection claim
+    # (see the mandatory AI-detection limitation in docs/QUALITY_FLAGS.md).
+    assert ai_score > max(human_scores)
+
+    for rid in by_id:
+        rationale = by_id[rid]["likely_ai"]["rationale"]
+        assert rationale is not None
+        assert len(rationale) > 0


### PR DESCRIPTION
Closes #80. Ships as **0.7.2**. **Zero new dependencies.**

## What
A two-tier, DataFrame-shaped `quality_report(df, config)` for survey open-ends. Returns a per-respondent flag **Struct** (each sub-flag `{score, flag}`, plus `any_flag` + `n_flags`) and a **summary** DataFrame — graded score+threshold, **never silent row drops** (output height == input height).

**Heuristic tier (zero API, Rust)** — each also a standalone Polars expression + `.llama` namespace:
- `straightlining_score` (mode-dominated / low-variance grids), `gibberish_score` (char-bigram entropy + vowel-ratio + consonant-run), `duplicate_answer_score` (token-set Jaccard), `response_length_score` (robust-z outlier), `speeder_score` (percentile / absolute-floor / median-fraction).

**Embedding/LLM tier (opt-in)** — reuses `embedding_async` + `knn_hnsw` + structured output: near-duplicate detection across respondents; a **graded likely-AI score (flag-not-verdict)** with documented false-positive + non-native-speaker-bias limitations (`docs/QUALITY_FLAGS.md` §7).

## Adversarial review (Opus): **APPROVE**
All acceptance criteria met and verified end-to-end. Never-drops-rows checked adversarially (empty/all-null/single-row); zero-API guarantee is structural (embedding/LLM imported only inside the `llm_tier` branch); flags graded with `fill_null(False)` so missing signal never force-flags. 19 Rust + 32 Python tests pass; 105 existing tests no regression. Three non-blocking documented-design advisories, no fix required.

## Tests & proof
- `tests/test_quality_flags.py` (heuristic, CI-safe) + `tests/test_quality_llm.py` (gated real API). `cargo clippy --all-features` clean under `-Dwarnings`.
- **Verified live**: heuristic flags fire on the right synthetic respondents only, no rows dropped, graded scores order correctly; the LLM tier pairs a near-verbatim duplicate at **0.914 cosine** (with `neighbor_id`) and ranks a corporate-AI-sounding response highest for likely-AI (**0.7** vs 0.1–0.2).

Note: `quality_report`'s **heuristic tier makes zero API calls** (the acceptance criterion); the embedding/LLM tier is strictly opt-in via `config.llm_tier=True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnthn-ai/codesmith/polar_llama/pr/94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786625314&installation_id=141504833&pr_number=94&repository=pnthn-ai%2Fpolar_llama&return_to=https%3A%2F%2Fgithub.com%2Fpnthn-ai%2Fpolar_llama%2Fpull%2F94&signature=8ed422263523f13d7ad7b8598ae1d1da216bf69c7c21c76b4ccb8556526956f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->