### PR TITLE
feat: persistent, incrementally-updatable HNSW index (HnswIndex) (#82) + release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-07-14
+
+### Added
+- **Persistent, incrementally updatable HNSW index** (`HnswIndex`, issue #82): a DataFrame-native, stateful, serializable ANN index (precedent: `Checkpoint` #75, `Codebook` #78) built on top of `instant-distance`'s `HnswMap` -- which is immutable once built, so this is a small LSM-like layer around it, not a new HNSW implementation. `HnswIndex.build(df, id_col, embedding_col)` builds a fresh index; `.add(df, id_col, embedding_col)` upserts into a brute-force staging buffer, queryable immediately without touching the immutable main graph; `.remove(ids)` soft-deletes via a tombstone set. `.query(query_df, embedding_col, k)` returns `DataFrame(query_id|neighbor_id|distance|rank)` (`query_id` is the query row's 0-based index); `.query_one(vector, k)` is the single-vector convenience form; `.knn(expr, k) -> pl.Expr` bridges the same batch core into a `map_batches` expression (`List[Struct{neighbor_id, distance, rank}]` per row). Queries over-fetch from the main graph (`k' = min(k + tombstone_count, ef_search)`) to compensate for tombstoned hits, merge with the staging buffer, and filter dead ids. **Compaction** (automatic via `auto_compact=True`, default on, once the staging buffer or tombstone count crosses `max(threshold_min, threshold_ratio * len(index))`; or manual via `.compact()`) rebuilds the main graph from every currently-live point and clears staging/tombstones. External ids are arbitrary caller strings, mapped to a stable internal-id space that survives compaction. `.save(path)`/`HnswIndex.load(path)` round-trip the whole index -- main graph, pending staging/tombstones, id maps, dimension, and the pinned build seed (for deterministic compaction) -- through a small `bincode`-encoded file with a magic+version header; `bincode` is the only new Rust dependency this feature adds (pure-Rust, serde-only -- `instant-distance`'s already-enabled `with-serde` feature supplies `Serialize`/`Deserialize` for the graph itself). Implemented as a new `#[pyclass]` (`src/index.rs::PyHnswIndex`, Python name `_HnswIndexCore`) taking/returning `pyo3-polars` `PySeries`/`PyDataFrame` directly (zero-copy Arrow, no JSON shuttle) with batch queries releasing the GIL; `src/ann.rs` and the stateless `knn_hnsw` expression are untouched -- `HnswIndex` reuses `ann::EmbeddingPoint`'s cosine-distance metric verbatim. See `docs/VECTOR_SIMILARITY_AND_ANN.md`.
+
+### Notes
+- Query latency at 100k points is single-digit milliseconds after compaction; loading a 100k-point index from disk is a low-single-digit-second `bincode` deserialization (see `scripts/bench_hnsw_index.py`). `instant-distance` has no mmap/lazy-load path, so `.load()` always deserializes the full graph into memory up front -- there is no partial/streaming load.
+
 ## [0.7.3] - 2026-07-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,15 @@ dependencies = [
 
 [[package]]
 name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
@@ -1984,12 +1993,13 @@ dependencies = [
 
 [[package]]
 name = "polar-llama"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-bedrockruntime",
  "aws-smithy-http-client",
+ "bincode 1.3.3",
  "dotenvy",
  "futures",
  "instant-distance",
@@ -2447,7 +2457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c97cabf53eb8fbf6050cde3fef8f596c51cc25fd7d55fbde108d815ee6674abf"
 dependencies = [
  "argminmax",
- "bincode",
+ "bincode 2.0.1",
  "bytemuck",
  "bytes",
  "compact_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polar-llama"
-version = "0.7.3"
+version = "0.8.0"
 edition = "2021"
 
 [lib]
@@ -39,6 +39,11 @@ instant-distance = { version = "0.6", features = ["with-serde"] }
 tiktoken-rs = "0.12"
 # SHA-256 hashing for cache prefix detection
 sha2 = "0.10"
+# Pure-Rust, serde-only binary (de)serialization for the persistent HNSW
+# index's on-disk format (issue #82). The only new dependency this feature
+# adds -- instant-distance's `HnswMap`/`EmbeddingPoint` already derive
+# Serialize/Deserialize via the `with-serde` feature above.
+bincode = "1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 jemallocator = { version = "0.5", features = ["disable_initial_exec_tls"] }

--- a/README.md
+++ b/README.md
@@ -623,6 +623,24 @@ query = query.with_columns(
 
 See `docs/VECTOR_SIMILARITY_AND_ANN.md` for complete documentation and advanced examples.
 
+#### Persistent HNSW Index
+
+`knn_hnsw` above rebuilds its graph on every call — fine for a one-off query, wasteful if you query the same corpus repeatedly or want to grow it over time. `HnswIndex` (issue #82) is a persistent, incrementally updatable index: build it once, `.add()`/`.remove()` points into it (queryable immediately, via a brute-force staging buffer + soft-delete tombstones on top of `instant-distance`'s otherwise-immutable HNSW graph, auto-compacted periodically), and `.save()`/`.load()` it to/from disk.
+
+```python
+from polar_llama import HnswIndex
+
+index = HnswIndex.build(corpus, id_col="doc_id", embedding_col="embedding")
+index.add(new_docs, id_col="doc_id", embedding_col="embedding")  # incremental, queryable immediately
+index.remove(["doc-2"])                                          # soft-delete
+
+results = index.query(queries, embedding_col="embedding", k=5)   # query_id | neighbor_id | distance | rank
+index.save("my_index.bin")
+index = HnswIndex.load("my_index.bin")
+```
+
+See `docs/VECTOR_SIMILARITY_AND_ANN.md#persistent-hnsw-index-hnswindex` for the full API (`.query_one`, `.knn()` expression bridge, compaction policy, performance characteristics).
+
 #### Codebook Induction
 
 Build a qualitative-coding codebook from a text column — embed, cluster, and let the LLM name and define each cluster — then apply it back as multi-label tags. No external clustering dependency: `cluster_embeddings` is a hand-rolled k-means (k-means++ / Lloyd's, in Rust) with automatic `k` selection via sampled silhouette.

--- a/docs/VECTOR_SIMILARITY_AND_ANN.md
+++ b/docs/VECTOR_SIMILARITY_AND_ANN.md
@@ -602,7 +602,8 @@ df = df.lazy().with_columns([
 
 | Function | Description | Returns |
 |----------|-------------|---------|
-| `knn_hnsw(query, corpus, k)` | K-nearest neighbors via HNSW | List[Int64] indices |
+| `knn_hnsw(query, corpus, k)` | K-nearest neighbors via HNSW (stateless, rebuilds the graph every call) | List[Int64] indices |
+| `HnswIndex.build/add/remove/query/query_one/save/load` | Persistent, incrementally updatable HNSW index (issue #82) -- see [below](#persistent-hnsw-index-hnswindex) | `HnswIndex` / `pl.DataFrame` |
 
 ### Namespace Methods
 
@@ -680,6 +681,170 @@ result = df.with_columns(
 
 ---
 
+## Persistent HNSW Index (`HnswIndex`)
+
+`knn_hnsw` above is **stateless**: every call rebuilds the HNSW graph from
+scratch out of whatever corpus column you pass it. That's fine for a
+one-off query, but wasteful (and, for a large corpus, slow) if you want to
+query the *same* corpus repeatedly, or grow it incrementally over time.
+
+`HnswIndex` (issue #82) is a **persistent, incrementally updatable** index:
+build it once, then `.add()`/`.remove()` points into it, `.query()` it as
+many times as you like, and `.save()`/`HnswIndex.load()` it to/from disk.
+It's a DataFrame-native, stateful, serializable object -- the same shape as
+`Checkpoint` and `Codebook` elsewhere in Polar Llama -- not a Polars
+expression.
+
+### Why not just rebuild the graph every time?
+
+`instant-distance`'s `HnswMap` (what `knn_hnsw` builds under the hood) is
+**immutable** once built -- there is no incremental insert/delete in the
+underlying library. `HnswIndex` layers add/remove on top of that immutable
+graph itself:
+
+- New/updated points (`.add()`) go into a small brute-force **staging
+  buffer**, not the graph -- queryable immediately, without rebuilding
+  anything.
+- Removed points (`.remove()`) are **soft-deleted** (tombstoned), not
+  physically removed -- `.query()` over-fetches from the graph to
+  compensate and filters tombstoned ids out of the results.
+- Periodically (**compaction**, automatic by default, or via `.compact()`)
+  the graph is rebuilt from scratch out of every currently-live point, and
+  the staging buffer / tombstones are cleared.
+
+This means a `.add()`/`.remove()` call is cheap (no full rebuild), at the
+cost of the staging buffer being brute-force-scanned on every query until
+the next compaction -- see [Performance](#performance) below.
+
+### Quick Start
+
+```python
+import polars as pl
+from polar_llama import HnswIndex, embedding_async, Provider
+
+corpus = pl.DataFrame({
+    "doc_id": ["doc-1", "doc-2", "doc-3", "doc-4"],
+    "text": ["AI research", "cooking tips", "machine learning", "recipes"],
+}).with_columns(
+    embedding=embedding_async(pl.col("text"), provider=Provider.OPENAI)
+)
+
+# Build once.
+index = HnswIndex.build(corpus, id_col="doc_id", embedding_col="embedding")
+
+# Query as many times as you like -- no rebuild.
+queries = pl.DataFrame({"q": ["artificial intelligence"]}).with_columns(
+    embedding=embedding_async(pl.col("q"), provider=Provider.OPENAI)
+)
+results = index.query(queries, embedding_col="embedding", k=2)
+# shape: (2, 4) — query_id | neighbor_id | distance | rank
+
+# Grow the index incrementally -- queryable immediately.
+new_docs = pl.DataFrame({
+    "doc_id": ["doc-5"],
+    "text": ["neural networks"],
+}).with_columns(embedding=embedding_async(pl.col("text"), provider=Provider.OPENAI))
+index.add(new_docs, id_col="doc_id", embedding_col="embedding")
+
+# Soft-delete.
+index.remove(["doc-2"])
+assert "doc-2" not in index
+
+# Persist and reload -- identical query results, including any pending
+# (not-yet-compacted) staging/tombstone state.
+index.save("my_index.bin")
+reloaded = HnswIndex.load("my_index.bin")
+```
+
+### API
+
+```python
+HnswIndex.build(df, id_col, embedding_col, *, ef_construction=200, ef_search=200,
+                 seed=42, auto_compact=True, compact_staged_min=1000,
+                 compact_staged_ratio=0.10, compact_tombstone_min=1000,
+                 compact_tombstone_ratio=0.10) -> HnswIndex
+HnswIndex.load(path) -> HnswIndex
+
+index.add(df, id_col, embedding_col) -> int        # rows upserted
+index.remove(ids: list[str] | pl.Series) -> int    # rows soft-deleted
+index.compact() -> None                            # force a rebuild now
+
+index.query(query_df, embedding_col, k=10) -> pl.DataFrame  # query_id | neighbor_id | distance | rank
+index.query_one(vector: list[float], k=10) -> pl.DataFrame  # neighbor_id | distance | rank
+index.knn(expr, k=10) -> pl.Expr                    # List[Struct{neighbor_id, distance, rank}] per row
+
+index.save(path) -> None
+len(index)              # live point count
+index.dim               # embedding dimensionality
+"some_id" in index       # membership check
+index.staged_len         # pending (not-yet-compacted) adds
+index.tombstone_len      # pending (not-yet-compacted) removals
+index.should_compact     # would `.compact()` do real work right now?
+index.auto_compact       # get/set
+```
+
+`.query()`'s `query_id` column is `query_df`'s **0-based row index** --
+there's no separate id parameter for queries, only for the indexed corpus
+(`id_col` on `.build()`/`.add()`).
+
+`.knn()` bridges `.query()`'s batch core into a lazy expression via
+`map_batches`, for use inside `with_columns`:
+
+```python
+queries.with_columns(
+    neighbors=index.knn(pl.col("embedding"), k=5)
+).explode("neighbors").unnest("neighbors")
+```
+
+### Upsert and soft-delete semantics
+
+- **Upsert**: `.add()` with an id already in the index replaces its vector
+  -- the old entry is tombstoned (never mutated in place, since the main
+  graph is immutable) and the new one goes into staging. A duplicate id
+  *within* one `.build()`/`.add()` call resolves last-row-wins.
+- **Soft-delete**: `.remove()` on an id not currently live (unknown, or
+  already removed) is a silent no-op. `k` neighbors are still returned
+  after a removal as long as the index has that many *live* points left --
+  `.query()`'s over-fetch (`k' = min(k + tombstone_count, ef_search)`)
+  exists specifically so removed points don't silently shrink your result
+  count.
+
+### Compaction
+
+`auto_compact=True` (the default) triggers `.compact()` automatically,
+after `.add()`/`.remove()`, once the staging buffer or the tombstone count
+exceeds `max(compact_*_min, compact_*_ratio * len(index))`. Set
+`auto_compact=False` to batch many `.add()`/`.remove()` calls and
+`.compact()` once yourself (cheaper than compacting after every call);
+`index.should_compact` tells you whether a threshold is currently crossed.
+
+### Performance
+
+- **Query**: sub-millisecond to a few milliseconds per query against a
+  compacted 100k-point index (approximate HNSW search, same complexity
+  class as `knn_hnsw`); each un-compacted staged point adds one brute-force
+  distance computation per query, so a large pending staging buffer
+  (thousands of points) is the main way to slow queries down between
+  compactions.
+- **`.save()`/`.load()`**: a low-single-digit number of seconds for a
+  100k-point index (dominated by `bincode` (de)serializing the graph).
+  `instant-distance` has no mmap or lazy-load path, so `.load()` always
+  deserializes the whole graph into memory up front -- there is no
+  partial/streaming load for indexes too large to fit in RAM.
+- See `scripts/bench_hnsw_index.py` for a runnable 100k-point benchmark
+  (not part of the test suite -- it's slow by design).
+
+### When to use `HnswIndex` vs. `knn_hnsw`
+
+| | `knn_hnsw` | `HnswIndex` |
+|---|---|---|
+| Corpus | Rebuilt every call | Built once, updated incrementally |
+| State | None (pure expression) | Stateful object (build/add/remove/save/load) |
+| Best for | One-off query against a corpus you already have in memory | A corpus you query repeatedly, or that grows over time |
+| Persistence | None | `.save()`/`.load()` |
+
+---
+
 ## Examples
 
 Complete runnable examples are available in the `examples/` directory:
@@ -754,5 +919,5 @@ python advanced_semantic_search_demo.py
 
 ---
 
-**Last Updated**: 2025-12-17
-**Version**: 0.2.2
+**Last Updated**: 2026-07-14
+**Version**: 0.8.0

--- a/polar_llama/__init__.py
+++ b/polar_llama/__init__.py
@@ -2016,6 +2016,16 @@ from polar_llama.tools import (
 
 
 # ============================================================================
+# Persistent HNSW Index (issue #82) — see docs/VECTOR_SIMILARITY_AND_ANN.md
+# ============================================================================
+
+from polar_llama.index import (
+    NEIGHBOR_STRUCT_DTYPE,
+    HnswIndex,
+)
+
+
+# ============================================================================
 # Polars Namespace Accessor
 # ============================================================================
 

--- a/polar_llama/index.py
+++ b/polar_llama/index.py
@@ -1,0 +1,442 @@
+"""Persistent, incrementally updatable HNSW index (issue #82).
+
+Design summary -- see `docs/VECTOR_SIMILARITY_AND_ANN.md` for the full
+write-up:
+
+`instant-distance`'s `HnswMap` (the same type the stateless `knn_hnsw`
+expression -- `src/ann.rs` / `src/expressions.rs`, both untouched by this
+feature -- builds fresh on every call) is immutable once built: there is no
+incremental insert or delete. `HnswIndex` is a Python-facing,
+DataFrame-native wrapper (precedent: `Checkpoint` #75, `Codebook` #78 --
+a stateful, serializable object, not a stateless plugin expression) around a
+small Rust core (`src/index.rs::PyHnswIndex`, registered as the private
+`_HnswIndexCore` pyclass) that layers add/remove on top of that immutable
+graph:
+
+- **`.build(df, id_col, embedding_col)`**: a fresh `HnswMap` from an entire
+  DataFrame.
+- **`.add(df, id_col, embedding_col)`**: upserts go into a small brute-force
+  *staging* buffer, not the graph -- new/updated points are queryable
+  immediately (`.query()`/`.query_one()` merge the graph and the staging
+  buffer at search time), without touching the immutable `main` index.
+- **`.remove(ids)`**: soft-delete via a *tombstone* set of internal ids;
+  `.query()` over-fetches from the graph to compensate for tombstoned hits
+  it can't yet physically remove.
+- **`.compact()`** (also automatic -- `auto_compact=True` by default, once
+  the staging buffer or tombstone set crosses a policy threshold): rebuilds
+  `main` from scratch out of every currently-live point, then clears
+  staging/tombstones. See `src/index.rs` module docs for the exact
+  threshold formula and the internal-id bookkeeping that makes this safe.
+- **`.save(path)` / `HnswIndex.load(path)`**: the whole index -- graph,
+  pending staging buffer, tombstones, id maps, dimension, and the pinned
+  build parameters (including the HNSW `seed`, for reproducible
+  compaction) -- round-trips through a small `bincode` file (see
+  `src/index.rs`; `bincode` is the only new Rust dependency this feature
+  adds).
+
+External ids are arbitrary caller-supplied strings (cast from whatever
+dtype `id_col` is), stable across every operation above, including
+save/load.
+
+Ids and embeddings cross the Rust boundary as real Polars columns
+(`pyo3_polars::{PySeries, PyDataFrame}`, zero-copy Arrow) -- never JSON.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Sequence, Union
+
+import polars as pl
+
+from polar_llama.utils import parse_into_expr
+
+if TYPE_CHECKING:
+    from polars.type_aliases import IntoExpr
+
+# Import the compiled core from the extension module, matching the
+# try/relative-then-absolute-import fallback pattern `polar_llama/__init__.py`
+# uses for `Provider` / `_stream_inference_batch`.
+try:
+    from .polar_llama import _HnswIndexCore
+except ImportError:  # pragma: no cover - exercised only in broken installs
+    try:
+        from polar_llama.polar_llama import _HnswIndexCore
+    except ImportError:  # pragma: no cover
+        _HnswIndexCore = None
+
+
+#: Struct dtype of each element in the list `.knn()` returns per row.
+NEIGHBOR_STRUCT_DTYPE = pl.Struct(
+    {
+        "neighbor_id": pl.Utf8,
+        "distance": pl.Float64,
+        "rank": pl.UInt32,
+    }
+)
+
+
+def _require_core() -> None:
+    if _HnswIndexCore is None:  # pragma: no cover - exercised only in broken installs
+        raise ImportError(
+            "HnswIndex requires the compiled polar_llama Rust extension "
+            "(`_HnswIndexCore`), which failed to import. Reinstall "
+            "polar-llama, or rebuild it locally with "
+            "`maturin develop --release`."
+        )
+
+
+def _require_column(df: pl.DataFrame, col: str, what: str) -> None:
+    if col not in df.columns:
+        raise ValueError(f"{what} {col!r} not found in DataFrame columns {df.columns}")
+
+
+def _require_embedding_dtype(df: pl.DataFrame, embedding_col: str) -> None:
+    dtype = df.schema[embedding_col]
+    if not isinstance(dtype, pl.List):
+        raise ValueError(
+            f"embedding_col {embedding_col!r} must have a List dtype "
+            f"(e.g. List[Float64]/List[Float32]), got {dtype}"
+        )
+
+
+def _require_non_negative_k(k: int) -> None:
+    if k < 0:
+        raise ValueError(f"k must be >= 0, got {k}")
+
+
+class HnswIndex:
+    """A persistent, incrementally updatable approximate-nearest-neighbor
+    index over embedding vectors, backed by `instant-distance`'s HNSW graph.
+
+    Construct via `HnswIndex.build(...)` or `HnswIndex.load(...)` -- never
+    the constructor directly.
+
+    >>> import polars as pl
+    >>> from polar_llama import HnswIndex
+    >>> df = pl.DataFrame({
+    ...     "id": ["a", "b", "c"],
+    ...     "embedding": [[1.0, 0.0], [0.0, 1.0], [0.9, 0.1]],
+    ... })
+    >>> index = HnswIndex.build(df, id_col="id", embedding_col="embedding")
+    >>> index.query_one([1.0, 0.0], k=2)["neighbor_id"].to_list()
+    ['a', 'c']
+    >>> index.add(
+    ...     pl.DataFrame({"id": ["d"], "embedding": [[1.0, 0.0]]}),
+    ...     id_col="id",
+    ...     embedding_col="embedding",
+    ... )
+    1
+    >>> index.remove(["a"])
+    1
+    >>> "a" in index
+    False
+    """
+
+    __slots__ = ("_core",)
+
+    def __init__(self, core: "_HnswIndexCore") -> None:
+        # Internal -- use `HnswIndex.build(...)` / `HnswIndex.load(...)`.
+        self._core = core
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def build(
+        cls,
+        df: pl.DataFrame,
+        id_col: str,
+        embedding_col: str,
+        *,
+        ef_construction: int = 200,
+        ef_search: int = 200,
+        seed: int = 42,
+        auto_compact: bool = True,
+        compact_staged_min: int = 1000,
+        compact_staged_ratio: float = 0.10,
+        compact_tombstone_min: int = 1000,
+        compact_tombstone_ratio: float = 0.10,
+    ) -> "HnswIndex":
+        """Build a fresh index from every row of `df`.
+
+        Parameters
+        ----------
+        df
+            Source DataFrame.
+        id_col
+            Column of stable external ids. Cast to `Utf8` internally, so
+            any dtype works, but a duplicate *string representation*
+            within `df` resolves last-row-wins -- the same upsert semantics
+            `.add()` uses for a repeated id.
+        embedding_col
+            Column of `List[Float32]`/`List[Float64]` embedding vectors,
+            all the same length (the length of row 0 is taken as the
+            index's dimensionality; a differing row raises `ValueError`
+            naming it). Null or empty-vector rows are rejected -- filter
+            them out first (e.g. `df.drop_nulls(embedding_col)`) if your
+            data has them.
+        ef_construction, ef_search
+            `instant-distance` HNSW build-quality / search-breadth
+            parameters (higher = more accurate, slower). `ef_search` also
+            upper-bounds how many candidates a single query can pull from
+            the main graph, which in turn caps how much `.query()`'s
+            soft-delete over-fetch (`k + tombstone_len`, see
+            `src/index.rs`) can compensate for -- an index accumulating a
+            great many un-compacted removals wants a larger `ef_search`.
+        seed
+            Pinned HNSW build seed. Fixed (never re-randomized) so the
+            graph -- and therefore query results -- is reproducible for a
+            given point set; persisted, and reused by every future
+            `.compact()` too.
+        auto_compact
+            Automatically call `.compact()` after `.add()`/`.remove()` once
+            a policy threshold below is crossed. Default `True`. Set
+            `False` to control compaction timing yourself (e.g. batch many
+            adds, then `.compact()` once).
+        compact_staged_min, compact_staged_ratio
+            Auto-compact once the staging buffer (pending `.add()`s) grows
+            past `max(compact_staged_min, compact_staged_ratio * len(index))`.
+        compact_tombstone_min, compact_tombstone_ratio
+            Same formula, for the tombstone (soft-deleted) count.
+
+        Returns
+        -------
+        HnswIndex
+        """
+        _require_core()
+        _require_column(df, id_col, "id_col")
+        _require_column(df, embedding_col, "embedding_col")
+        _require_embedding_dtype(df, embedding_col)
+        if df.height == 0:
+            raise ValueError("HnswIndex.build requires a non-empty DataFrame")
+
+        core = _HnswIndexCore.build(
+            df.get_column(id_col),
+            df.get_column(embedding_col),
+            ef_construction=ef_construction,
+            ef_search=ef_search,
+            seed=seed,
+            auto_compact=auto_compact,
+            compact_staged_min=compact_staged_min,
+            compact_staged_ratio=compact_staged_ratio,
+            compact_tombstone_min=compact_tombstone_min,
+            compact_tombstone_ratio=compact_tombstone_ratio,
+        )
+        return cls(core)
+
+    @classmethod
+    def load(cls, path: Union[str, Path]) -> "HnswIndex":
+        """Load an index previously written by `.save()`.
+
+        Round-trips everything: the main graph, any pending staging-buffer
+        rows and tombstones that hadn't been compacted yet, the id maps,
+        dimension, and build parameters -- querying a freshly loaded index
+        gives identical results to the index right before it was saved.
+        """
+        _require_core()
+        return cls(_HnswIndexCore.load(str(path)))
+
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    def add(self, df: pl.DataFrame, id_col: str, embedding_col: str) -> int:
+        """Upsert every row of `df` into the index; queryable immediately.
+
+        An id already live in the index has its old vector soft-deleted
+        (tombstoned) and the new vector inserted fresh into the staging
+        buffer -- the underlying HNSW graph is immutable, so an upsert
+        never mutates a point already baked into it. Embeddings must match
+        this index's dimensionality (`.dim`).
+
+        Returns the number of rows processed (0 for an empty `df`). May
+        trigger an automatic `.compact()` -- see `auto_compact` on
+        `.build()`.
+        """
+        _require_column(df, id_col, "id_col")
+        _require_column(df, embedding_col, "embedding_col")
+        _require_embedding_dtype(df, embedding_col)
+        if df.height == 0:
+            return 0
+        return self._core.add(df.get_column(id_col), df.get_column(embedding_col))
+
+    def remove(self, ids: Union[Sequence[str], "pl.Series"]) -> int:
+        """Soft-delete (tombstone) `ids`.
+
+        An id not currently live (unknown, or already removed) is silently
+        skipped. Returns the number of ids actually removed. May trigger
+        an automatic `.compact()` -- see `auto_compact` on `.build()`.
+        """
+        if not isinstance(ids, pl.Series):
+            ids = pl.Series("id", list(ids))
+        return self._core.remove(ids)
+
+    def compact(self) -> None:
+        """Rebuild the main graph from every currently live point, now.
+
+        Runs regardless of `auto_compact`/the policy thresholds -- useful
+        after `auto_compact=False` batch loading, or to force a query
+        latency reset after many soft-deletes.
+        """
+        self._core.compact()
+
+    # ------------------------------------------------------------------
+    # Querying
+    # ------------------------------------------------------------------
+
+    def query(self, query_df: pl.DataFrame, embedding_col: str, k: int = 10) -> pl.DataFrame:
+        """Batch k-nearest-neighbor search.
+
+        Parameters
+        ----------
+        query_df
+            DataFrame holding the query embeddings. No id column is needed
+            -- `query_id` in the result is `query_df`'s 0-based row index.
+        embedding_col
+            Column of `List[Float32]`/`List[Float64]` query vectors.
+        k
+            Neighbors per query row (`k=0` returns an empty DataFrame).
+
+        Returns
+        -------
+        pl.DataFrame
+            `query_id | neighbor_id | distance | rank`, `rank` 1-based
+            (nearest first). A query row can return *fewer* than `k` rows
+            (a small index, or every candidate tombstoned); a null or
+            empty-vector query row contributes zero result rows, not an
+            error.
+        """
+        _require_column(query_df, embedding_col, "embedding_col")
+        _require_embedding_dtype(query_df, embedding_col)
+        _require_non_negative_k(k)
+        return self._core.query(query_df.get_column(embedding_col), k)
+
+    def query_one(self, vector: Sequence[float], k: int = 10) -> pl.DataFrame:
+        """k-nearest-neighbor search for a single query vector.
+
+        Convenience form of `.query()` for one-off lookups outside a
+        DataFrame pipeline.
+
+        Returns
+        -------
+        pl.DataFrame
+            `neighbor_id | distance | rank`, nearest first (no `query_id`
+            column -- there is only one query).
+        """
+        _require_non_negative_k(k)
+        return self._core.query_one(list(vector), k)
+
+    def knn(self, embedding_expr: "IntoExpr", k: int = 10) -> pl.Expr:
+        """Row-wise k-NN search against this index, as a lazy expression.
+
+        Bridges `.query()`'s whole-batch core into a `map_batches`
+        expression: for every row of `embedding_expr`'s column, returns a
+        `List[Struct{neighbor_id, distance, rank}]` of that row's `k`
+        nearest neighbors in this index (an empty list for a null/empty
+        embedding row -- never `null`, so `.list.len()` always works).
+
+        Each `map_batches` invocation makes exactly one batch call into the
+        Rust core (same cost profile as `.query()`), not one call per row.
+
+        >>> import polars as pl
+        >>> from polar_llama import HnswIndex
+        >>> corpus = pl.DataFrame({
+        ...     "id": ["a", "b", "c"],
+        ...     "embedding": [[1.0, 0.0], [0.0, 1.0], [0.9, 0.1]],
+        ... })
+        >>> index = HnswIndex.build(corpus, id_col="id", embedding_col="embedding")
+        >>> queries = pl.DataFrame({"embedding": [[1.0, 0.0]]})
+        >>> queries.with_columns(nbrs=index.knn(pl.col("embedding"), k=2))["nbrs"][0].struct.field("neighbor_id").to_list()  # doctest: +SKIP
+        ['a', 'c']
+        """
+        _require_non_negative_k(k)
+        core = self._core
+
+        def _knn_batch(s: pl.Series) -> pl.Series:
+            n = len(s)
+            result = core.query(s, k)
+            grouped = (
+                result.select(
+                    pl.col("query_id"),
+                    pl.struct(["neighbor_id", "distance", "rank"]).alias("nbrs"),
+                )
+                .group_by("query_id", maintain_order=True)
+                .agg(pl.col("nbrs"))
+            )
+            empty = pl.Series("nbrs", [[]] * n, dtype=pl.List(NEIGHBOR_STRUCT_DTYPE))
+            base = pl.DataFrame(
+                {
+                    "query_id": pl.Series("query_id", range(n), dtype=pl.Int64),
+                    "nbrs": empty,
+                }
+            )
+            out = base.update(grouped, on="query_id").get_column("nbrs")
+            return out.rename(s.name)
+
+        return parse_into_expr(embedding_expr).map_batches(
+            _knn_batch,
+            return_dtype=pl.List(NEIGHBOR_STRUCT_DTYPE),
+        )
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    def save(self, path: Union[str, Path]) -> None:
+        """Serialize the whole index to `path`, atomically.
+
+        Includes the main graph, any not-yet-compacted staging/tombstone
+        state, the id maps, dimension, and build parameters (including the
+        pinned HNSW seed) -- see the module docstring and `src/index.rs`.
+        Writes via a temp-file-then-rename in `path`'s directory, so a
+        crash mid-write can never leave a truncated file at `path`.
+        """
+        self._core.save(str(path))
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    @property
+    def dim(self) -> int:
+        """Embedding dimensionality this index was built with."""
+        return self._core.dim
+
+    @property
+    def staged_len(self) -> int:
+        """Number of points in the staging buffer (pending compaction)."""
+        return self._core.staged_len
+
+    @property
+    def tombstone_len(self) -> int:
+        """Number of soft-deleted internal ids (pending compaction)."""
+        return self._core.tombstone_len
+
+    @property
+    def should_compact(self) -> bool:
+        """Whether a policy threshold is currently crossed (see `.build()`'s
+        `compact_*` parameters) -- `.compact()` would do real work right now."""
+        return self._core.should_compact()
+
+    @property
+    def auto_compact(self) -> bool:
+        return self._core.auto_compact
+
+    @auto_compact.setter
+    def auto_compact(self, value: bool) -> None:
+        self._core.auto_compact = value
+
+    def __len__(self) -> int:
+        """Number of currently live points (survives add/remove/compact)."""
+        return len(self._core)
+
+    def __contains__(self, id_: object) -> bool:
+        return self._core.contains(str(id_))
+
+    def __repr__(self) -> str:
+        return (
+            f"HnswIndex(len={len(self)}, dim={self.dim}, "
+            f"staged={self.staged_len}, tombstones={self.tombstone_len})"
+        )

--- a/scripts/bench_hnsw_index.py
+++ b/scripts/bench_hnsw_index.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python
+"""Benchmark `HnswIndex` (issue #82) at realistic scale (default 100k points).
+
+Not part of the test suite -- deliberately slow (100k-point HNSW build +
+`bincode` save/load), and its pass/fail bar is "reasonable ballpark", not a
+strict regression gate. `tests/test_hnsw_index.py::test_10k_points_build_and_query_smoke`
+covers the same code paths at a CI-friendly 10k points with loose timing
+bounds.
+
+Measures, over synthetic seeded unit vectors (no network, no API key):
+
+- fresh `.build()` wall time
+- `.query()` batch latency (ms/query, for a batch of queries)
+- `.add()` incremental-insert latency (queryable immediately, pre-compaction)
+- `.compact()` wall time after accumulating a staging buffer
+- `.save()` / `.load()` wall time and on-disk file size
+- approximate recall@10 vs. brute-force cosine-distance ground truth, over a
+  small query sample (brute force itself is O(n) per query, so this stays
+  small even at n=100k)
+
+Usage::
+
+    python scripts/bench_hnsw_index.py
+    python scripts/bench_hnsw_index.py --n 200000 --dim 768 --queries 200
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import random
+import tempfile
+import time
+from pathlib import Path
+
+import polars as pl
+
+from polar_llama import HnswIndex
+
+
+def _random_unit_vectors(rng: random.Random, n: int, dim: int) -> list[list[float]]:
+    vecs = []
+    for _ in range(n):
+        v = [rng.gauss(0.0, 1.0) for _ in range(dim)]
+        norm = math.sqrt(sum(x * x for x in v)) or 1.0
+        vecs.append([x / norm for x in v])
+    return vecs
+
+
+def _cosine_distance(a: list[float], b: list[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(x * x for x in b))
+    if na == 0.0 or nb == 0.0:
+        return 1.0
+    cos = max(-1.0, min(1.0, dot / (na * nb)))
+    return 1.0 - cos
+
+
+def _brute_force_topk(ids: list[str], vectors: list[list[float]], query: list[float], k: int):
+    scored = sorted(zip(ids, vectors), key=lambda iv: _cosine_distance(iv[1], query))
+    return [i for i, _ in scored[:k]]
+
+
+def _fmt_bytes(n: int) -> str:
+    for unit in ("B", "KB", "MB", "GB"):
+        if n < 1024:
+            return f"{n:.1f}{unit}"
+        n /= 1024
+    return f"{n:.1f}TB"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--n", type=int, default=100_000, help="number of indexed points")
+    parser.add_argument("--dim", type=int, default=256, help="embedding dimensionality")
+    parser.add_argument("--queries", type=int, default=100, help="number of benchmark queries")
+    parser.add_argument("--k", type=int, default=10, help="neighbors per query")
+    parser.add_argument("--add-n", type=int, default=2000, help="points to `.add()` incrementally")
+    parser.add_argument("--recall-sample", type=int, default=5000, help="brute-force ground-truth corpus size (kept small -- O(n) per query in pure Python)")
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    print(f"HnswIndex benchmark: n={args.n} dim={args.dim} k={args.k}\n")
+
+    rng = random.Random(args.seed)
+    ids = [f"pt{i}" for i in range(args.n)]
+    print("Generating synthetic vectors...")
+    t0 = time.monotonic()
+    vectors = _random_unit_vectors(rng, args.n, args.dim)
+    print(f"  {time.monotonic() - t0:.2f}s\n")
+
+    df = pl.DataFrame({"id": ids, "embedding": vectors})
+
+    print("build()...")
+    t0 = time.monotonic()
+    index = HnswIndex.build(df, id_col="id", embedding_col="embedding", seed=42)
+    build_s = time.monotonic() - t0
+    print(f"  {build_s:.2f}s ({args.n / build_s:,.0f} points/s)\n")
+
+    queries = _random_unit_vectors(random.Random(args.seed + 1), args.queries, args.dim)
+    query_df = pl.DataFrame({"embedding": queries})
+
+    print("query() (batch)...")
+    t0 = time.monotonic()
+    result = index.query(query_df, embedding_col="embedding", k=args.k)
+    query_s = time.monotonic() - t0
+    per_query_ms = (query_s / args.queries) * 1000
+    print(f"  {query_s * 1000:.1f}ms total, {per_query_ms:.3f}ms/query "
+          f"({result.height} result rows)\n")
+
+    print(f"add() ({args.add_n} incremental points, pre-compaction)...")
+    index.auto_compact = False
+    extra_ids = [f"extra{i}" for i in range(args.add_n)]
+    extra_vectors = _random_unit_vectors(random.Random(args.seed + 2), args.add_n, args.dim)
+    extra_df = pl.DataFrame({"id": extra_ids, "embedding": extra_vectors})
+    t0 = time.monotonic()
+    index.add(extra_df, "id", "embedding")
+    add_s = time.monotonic() - t0
+    print(f"  {add_s * 1000:.1f}ms total, {(add_s / args.add_n) * 1000:.4f}ms/point "
+          f"(staged_len={index.staged_len})\n")
+
+    print("query() with a non-trivial staging buffer (pre-compaction)...")
+    t0 = time.monotonic()
+    index.query(query_df, embedding_col="embedding", k=args.k)
+    staged_query_s = time.monotonic() - t0
+    print(f"  {staged_query_s * 1000:.1f}ms total "
+          f"({(staged_query_s / args.queries) * 1000:.3f}ms/query)\n")
+
+    print("compact()...")
+    t0 = time.monotonic()
+    index.compact()
+    compact_s = time.monotonic() - t0
+    print(f"  {compact_s:.2f}s (staged_len={index.staged_len}, "
+          f"tombstone_len={index.tombstone_len}, len={len(index)})\n")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "bench_index.bin"
+
+        print("save()...")
+        t0 = time.monotonic()
+        index.save(str(path))
+        save_s = time.monotonic() - t0
+        size = path.stat().st_size
+        print(f"  {save_s:.2f}s, {_fmt_bytes(size)} on disk\n")
+
+        print("load()...")
+        t0 = time.monotonic()
+        reloaded = HnswIndex.load(str(path))
+        load_s = time.monotonic() - t0
+        print(f"  {load_s:.2f}s (len={len(reloaded)})\n")
+
+    print(f"Recall@{args.k} sanity check (a separate, smaller "
+          f"{args.recall_sample}-point index -- brute force over the full "
+          f"{args.n}-point main index in pure Python would dominate this "
+          f"script's runtime, so recall is measured on a corpus size where "
+          f"exact brute force stays cheap; the *same* corpus backs both the "
+          f"approximate and exact search, so this is a real recall number, "
+          f"not an artifact of comparing against a mismatched candidate "
+          f"pool)...")
+    recall_ids = ids[: args.recall_sample]
+    recall_vectors = vectors[: args.recall_sample]
+    recall_index = HnswIndex.build(
+        pl.DataFrame({"id": recall_ids, "embedding": recall_vectors}),
+        id_col="id",
+        embedding_col="embedding",
+        seed=42,
+    )
+    recall_queries = queries[: min(20, args.queries)]
+    overlaps = []
+    for q in recall_queries:
+        got = recall_index.query_one(q, k=args.k)["neighbor_id"].to_list()
+        want = _brute_force_topk(recall_ids, recall_vectors, q, args.k)
+        overlaps.append(len(set(got) & set(want)) / args.k)
+    recall = sum(overlaps) / len(overlaps)
+    print(f"  recall@{args.k} ~= {recall:.3f}\n")
+
+    print("Summary")
+    print("-------")
+    print(f"  build:            {build_s:.2f}s")
+    print(f"  query (compacted):     {per_query_ms:.3f}ms/query")
+    print(f"  query (staged):        {(staged_query_s / args.queries) * 1000:.3f}ms/query")
+    print(f"  add (per point):       {(add_s / args.add_n) * 1000:.4f}ms")
+    print(f"  compact:               {compact_s:.2f}s")
+    print(f"  save:                  {save_s:.2f}s ({_fmt_bytes(size)})")
+    print(f"  load:                  {load_s:.2f}s")
+    print(f"  recall@{args.k} (sample): {recall:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,0 +1,1067 @@
+//! Persistent, incrementally updatable HNSW index (issue #82).
+//!
+//! `instant-distance`'s `HnswMap` (the same type `src/ann.rs`'s stateless
+//! `knn_hnsw` expression builds fresh on every call) has no incremental
+//! `insert`/`remove` -- it is an immutable graph produced once by
+//! `Builder::build`. This module wraps that immutable graph in a small
+//! LSM-like layer so the *index as a whole* supports add/remove without a
+//! full rebuild on every call:
+//!
+//! - **main**: an immutable `HnswMap<EmbeddingPoint, u32>` (the same
+//!   `EmbeddingPoint`/cosine-distance metric as `src/ann.rs`, reused
+//!   verbatim -- `src/ann.rs` itself is untouched). Its `u32` values are
+//!   *our* stable internal ids, not `instant_distance::PointId` (which is
+//!   re-numbered on every rebuild).
+//! - **staged**: a brute-force `Vec<(internal_id, EmbeddingPoint)>` holding
+//!   points added since the last compaction. New points are queryable
+//!   immediately (linear-scanned and merged with the `main` graph's
+//!   results at query time), without touching `main`.
+//! - **tombstones**: a `HashSet<u32>` of internal ids that used to be live
+//!   (removed via `.remove()`, or superseded by a newer upsert of the same
+//!   external id) but may still physically exist inside `main` or
+//!   `staged`. Query time filters them out and over-fetches
+//!   `k' = min(k + tombstones.len(), ef_search)` from `main` so genuinely
+//!   live results still surface even when some of `main`'s nearest
+//!   candidates turn out to be dead.
+//! - **compaction**: rebuilds `main` from scratch out of every currently
+//!   live point (`main`'s survivors, via `HnswMap::iter()`, plus `staged`),
+//!   then clears `staged`/`tombstones`. Runs automatically
+//!   (`auto_compact`, default on) once `staged.len()` or `tombstones.len()`
+//!   crosses `max(compact_*_min, compact_*_ratio * main.len())`, or
+//!   on-demand via `.compact()`.
+//!
+//! External ids are arbitrary, caller-supplied strings, stable across
+//! add/remove/compact/save/load. Internally they're mapped to a private,
+//! monotonically increasing `u32` internal-id space (`id_to_internal` /
+//! `internal_to_id`) that both `main`'s values and `staged` are keyed by --
+//! this is what lets a point move from `staged` into `main` at compaction
+//! time (or get tombstoned) without disturbing any external-facing id.
+//!
+//! Persistence (`.save()`/`.load()`) serializes the whole
+//! `PersistentIndex` (main graph, staged buffer, tombstones, id maps,
+//! dimension, and the pinned build parameters -- including the HNSW
+//! `seed`, so a reloaded-then-compacted index rebuilds deterministically)
+//! with `bincode` 1.x behind an 8-byte magic + `u32` format-version header.
+//! `bincode` is the *only* new dependency this feature adds (see
+//! `Cargo.toml`) -- pure-Rust, serde-only, no unsafe transmute tricks.
+//! `instant-distance`'s `with-serde` feature (already enabled) supplies
+//! `Serialize`/`Deserialize` for `HnswMap`/`EmbeddingPoint` for free.
+//!
+//! The `#[pyclass]` boundary (`PyHnswIndex` / Python name `_HnswIndexCore`)
+//! takes and returns `pyo3_polars::{PySeries, PyDataFrame}` directly --
+//! ids and embeddings cross as real Polars columns (zero-copy Arrow, no
+//! JSON shuttle), and batch queries release the GIL
+//! (`Python::detach`, pyo3 0.27's current name for `allow_threads`) while
+//! the actual HNSW/brute-force search runs. `polar_llama/index.py` wraps
+//! this core with the DataFrame-native `HnswIndex` Python API (`.build`,
+//! `.add`, `.remove`, `.query`, `.query_one`, `.save`/`.load`, `.knn`).
+
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use instant_distance::{Builder, HnswMap, Point, Search};
+use polars::prelude::*;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3_polars::{PyDataFrame, PySeries};
+use serde::{Deserialize, Serialize};
+
+use crate::ann::EmbeddingPoint;
+
+/// File-format magic bytes, written at the very start of every `.save()`d
+/// file. Guards against loading an unrelated file (or a future,
+/// incompatible format) as an index.
+const MAGIC: &[u8; 8] = b"PLHNSWI\0";
+/// Bumped whenever the on-disk `bincode` layout of `PersistentIndex`
+/// changes in a way that isn't forward/backward compatible.
+const FORMAT_VERSION: u32 = 1;
+
+fn default_ef_construction() -> usize {
+    200
+}
+fn default_ef_search() -> usize {
+    200
+}
+fn default_seed() -> u64 {
+    42
+}
+fn default_compact_min() -> usize {
+    1000
+}
+fn default_compact_ratio() -> f64 {
+    0.10
+}
+
+/// Build-time / policy parameters, persisted alongside the graph so a
+/// reloaded index compacts deterministically and with the same policy it
+/// was built with.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct IndexParams {
+    #[serde(default = "default_ef_construction")]
+    pub ef_construction: usize,
+    #[serde(default = "default_ef_search")]
+    pub ef_search: usize,
+    /// Pinned `instant_distance::Builder` seed -- fixed (not re-randomized
+    /// per build/compact) so the graph -- and therefore query results -- is
+    /// reproducible for a given point set.
+    #[serde(default = "default_seed")]
+    pub seed: u64,
+    #[serde(default = "default_auto_compact")]
+    pub auto_compact: bool,
+    #[serde(default = "default_compact_min")]
+    pub compact_staged_min: usize,
+    #[serde(default = "default_compact_ratio")]
+    pub compact_staged_ratio: f64,
+    #[serde(default = "default_compact_min")]
+    pub compact_tombstone_min: usize,
+    #[serde(default = "default_compact_ratio")]
+    pub compact_tombstone_ratio: f64,
+}
+
+fn default_auto_compact() -> bool {
+    true
+}
+
+impl Default for IndexParams {
+    fn default() -> Self {
+        IndexParams {
+            ef_construction: default_ef_construction(),
+            ef_search: default_ef_search(),
+            seed: default_seed(),
+            auto_compact: default_auto_compact(),
+            compact_staged_min: default_compact_min(),
+            compact_staged_ratio: default_compact_ratio(),
+            compact_tombstone_min: default_compact_min(),
+            compact_tombstone_ratio: default_compact_ratio(),
+        }
+    }
+}
+
+/// A single point sitting in the brute-force staging buffer, keyed by our
+/// own stable internal id (not `instant_distance::PointId`).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct StagedPoint {
+    internal_id: u32,
+    point: EmbeddingPoint,
+}
+
+/// The whole index: an immutable `main` HNSW graph, a brute-force `staged`
+/// buffer of points added since the last compaction, a `tombstones` set of
+/// internal ids that are no longer live, and the external<->internal id
+/// maps. See the module docs for the full design.
+#[derive(Serialize, Deserialize)]
+pub struct PersistentIndex {
+    pub dim: usize,
+    pub params: IndexParams,
+    main: Option<HnswMap<EmbeddingPoint, u32>>,
+    staged: Vec<StagedPoint>,
+    tombstones: HashSet<u32>,
+    id_to_internal: HashMap<String, u32>,
+    internal_to_id: HashMap<u32, String>,
+    next_internal_id: u32,
+}
+
+impl PersistentIndex {
+    /// Fresh build from a full `(id, embedding)` batch. All ids are
+    /// assumed live going in; last-value-wins on a duplicate id within
+    /// `pairs` (matching `.add()`'s upsert semantics -- internal ids are
+    /// still assigned in first-occurrence order, but that's an
+    /// implementation detail: the *set* of live points and every query
+    /// result is identical to inserting the same rows one at a time via
+    /// `.add()`).
+    pub fn build(pairs: Vec<(String, Vec<f64>)>, params: IndexParams) -> Result<Self, String> {
+        if pairs.is_empty() {
+            return Err("build requires at least one (id, embedding) row".to_string());
+        }
+        let dim = pairs[0].1.len();
+        if dim == 0 {
+            return Err("embedding vectors must be non-empty".to_string());
+        }
+        for (i, (_, v)) in pairs.iter().enumerate() {
+            if v.len() != dim {
+                return Err(format!(
+                    "embedding dimension mismatch at row {i}: expected dim={dim} \
+                     (inferred from row 0), got dim={}",
+                    v.len()
+                ));
+            }
+        }
+
+        // Last-id-wins dedup within the batch, preserving first-occurrence
+        // order for internal-id assignment.
+        let mut order: Vec<String> = Vec::with_capacity(pairs.len());
+        let mut by_id: HashMap<String, Vec<f64>> = HashMap::with_capacity(pairs.len());
+        for (id, v) in pairs {
+            if !by_id.contains_key(&id) {
+                order.push(id.clone());
+            }
+            by_id.insert(id, v);
+        }
+
+        let mut points = Vec::with_capacity(order.len());
+        let mut values = Vec::with_capacity(order.len());
+        let mut id_to_internal = HashMap::with_capacity(order.len());
+        let mut internal_to_id = HashMap::with_capacity(order.len());
+        for (internal_id, id) in order.into_iter().enumerate() {
+            let v = by_id
+                .remove(&id)
+                .expect("id was just pushed into `order`, must still be in `by_id`");
+            let internal_id = internal_id as u32;
+            points.push(EmbeddingPoint(v));
+            values.push(internal_id);
+            id_to_internal.insert(id.clone(), internal_id);
+            internal_to_id.insert(internal_id, id);
+        }
+        let next_internal_id = points.len() as u32;
+
+        let main = Builder::default()
+            .seed(params.seed)
+            .ef_construction(params.ef_construction)
+            .ef_search(params.ef_search)
+            .build(points, values);
+
+        Ok(PersistentIndex {
+            dim,
+            params,
+            main: Some(main),
+            staged: Vec::new(),
+            tombstones: HashSet::new(),
+            id_to_internal,
+            internal_to_id,
+            next_internal_id,
+        })
+    }
+
+    /// Upsert `pairs` into the staging buffer (queryable immediately,
+    /// merged with `main` at query time). An id that already exists (in
+    /// `main` or `staged`) has its old internal id tombstoned and gets a
+    /// fresh one -- `main` is immutable, so an upsert can never mutate a
+    /// point already baked into it. Duplicate ids *within* `pairs` are
+    /// resolved the same way, in order (last one wins). Returns the number
+    /// of rows processed. Auto-compacts afterward if `params.auto_compact`
+    /// and a threshold is crossed.
+    pub fn add(&mut self, pairs: Vec<(String, Vec<f64>)>) -> Result<usize, String> {
+        for (i, (_, v)) in pairs.iter().enumerate() {
+            if v.is_empty() {
+                return Err(format!("embedding vectors must be non-empty (row {i})"));
+            }
+            if v.len() != self.dim {
+                return Err(format!(
+                    "embedding dimension mismatch at row {i}: index dim={}, got dim={}",
+                    self.dim,
+                    v.len()
+                ));
+            }
+        }
+
+        let n = pairs.len();
+        for (id, vec) in pairs {
+            if let Some(&old_internal) = self.id_to_internal.get(&id) {
+                self.tombstones.insert(old_internal);
+            }
+            let internal_id = self.next_internal_id;
+            self.next_internal_id += 1;
+            self.staged.push(StagedPoint {
+                internal_id,
+                point: EmbeddingPoint(vec),
+            });
+            self.id_to_internal.insert(id.clone(), internal_id);
+            self.internal_to_id.insert(internal_id, id);
+        }
+
+        if self.params.auto_compact && self.should_compact() {
+            self.compact();
+        }
+        Ok(n)
+    }
+
+    /// Tombstone every id in `ids` that is currently live. Ids that aren't
+    /// currently live (unknown, or already removed) are silently skipped.
+    /// Returns the number actually removed. Auto-compacts afterward if
+    /// `params.auto_compact` and a threshold is crossed.
+    pub fn remove(&mut self, ids: &[String]) -> usize {
+        let mut n = 0usize;
+        for id in ids {
+            if let Some(internal_id) = self.id_to_internal.remove(id) {
+                self.internal_to_id.remove(&internal_id);
+                self.tombstones.insert(internal_id);
+                n += 1;
+            }
+        }
+        if self.params.auto_compact && self.should_compact() {
+            self.compact();
+        }
+        n
+    }
+
+    /// Policy compaction trigger: `staged` or `tombstones` has grown past
+    /// `max(min, ratio * main.len())`.
+    pub fn should_compact(&self) -> bool {
+        let main_len = self.main.as_ref().map(|m| m.values.len()).unwrap_or(0) as f64;
+        let staged_threshold = (self.params.compact_staged_min as f64)
+            .max(main_len * self.params.compact_staged_ratio) as usize;
+        let tomb_threshold = (self.params.compact_tombstone_min as f64)
+            .max(main_len * self.params.compact_tombstone_ratio) as usize;
+        self.staged.len() > staged_threshold || self.tombstones.len() > tomb_threshold
+    }
+
+    /// Rebuild `main` from every currently live point (`main`'s survivors
+    /// plus `staged`), then clear `staged`/`tombstones` and prune
+    /// `internal_to_id` down to only-live entries. "Live" is derived from
+    /// `id_to_internal`'s current values, independent of the (possibly
+    /// stale, pre-compaction) `tombstones` set -- so this is correct even
+    /// if `tombstones` under- or over-counts relative to reality.
+    pub fn compact(&mut self) {
+        let live: HashSet<u32> = self.id_to_internal.values().copied().collect();
+
+        let mut points: Vec<EmbeddingPoint> = Vec::with_capacity(live.len());
+        let mut values: Vec<u32> = Vec::with_capacity(live.len());
+
+        if let Some(main) = &self.main {
+            for (i, (_pid, point)) in main.iter().enumerate() {
+                let internal_id = main.values[i];
+                if live.contains(&internal_id) {
+                    points.push(point.clone());
+                    values.push(internal_id);
+                }
+            }
+        }
+        for sp in &self.staged {
+            if live.contains(&sp.internal_id) {
+                points.push(sp.point.clone());
+                values.push(sp.internal_id);
+            }
+        }
+
+        self.main = if points.is_empty() {
+            None
+        } else {
+            Some(
+                Builder::default()
+                    .seed(self.params.seed)
+                    .ef_construction(self.params.ef_construction)
+                    .ef_search(self.params.ef_search)
+                    .build(points, values),
+            )
+        };
+        self.staged.clear();
+        self.tombstones.clear();
+        self.internal_to_id.retain(|k, _| live.contains(k));
+    }
+
+    /// k-nearest-neighbor search for one query vector: over-fetches from
+    /// `main` to absorb tombstoned candidates, brute-force scans `staged`,
+    /// merges, sorts by distance, and truncates to `k`. Returns
+    /// `(external_id, distance)` pairs, nearest first.
+    pub fn query_one(&self, query: &[f64], k: usize) -> Vec<(String, f32)> {
+        if k == 0 {
+            return Vec::new();
+        }
+        let point = EmbeddingPoint(query.to_vec());
+        let mut candidates: Vec<(u32, f32)> = Vec::new();
+
+        if let Some(main) = &self.main {
+            let main_len = main.values.len();
+            if main_len > 0 {
+                let ef = self.params.ef_search.max(1);
+                let over_fetch = k.saturating_add(self.tombstones.len());
+                let k_main = over_fetch.min(ef).min(main_len);
+                let mut search = Search::default();
+                for item in main.search(&point, &mut search).take(k_main) {
+                    if !self.tombstones.contains(item.value) {
+                        candidates.push((*item.value, item.distance));
+                    }
+                }
+            }
+        }
+
+        for sp in &self.staged {
+            if self.tombstones.contains(&sp.internal_id) {
+                continue;
+            }
+            candidates.push((sp.internal_id, point.distance(&sp.point)));
+        }
+
+        candidates.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+        candidates.truncate(k);
+
+        candidates
+            .into_iter()
+            .filter_map(|(internal_id, dist)| {
+                self.internal_to_id
+                    .get(&internal_id)
+                    .map(|id| (id.clone(), dist))
+            })
+            .collect()
+    }
+
+    /// Batch form of `query_one`: `None` entries (null embedding rows)
+    /// produce an empty result vector for that row, never an error.
+    pub fn query_batch(&self, queries: &[Option<Vec<f64>>], k: usize) -> Vec<Vec<(String, f32)>> {
+        queries
+            .iter()
+            .map(|q| match q {
+                Some(v) => self.query_one(v, k),
+                None => Vec::new(),
+            })
+            .collect()
+    }
+
+    pub fn contains(&self, id: &str) -> bool {
+        self.id_to_internal.contains_key(id)
+    }
+
+    /// Number of currently live points (survives add/remove/compact).
+    pub fn len(&self) -> usize {
+        self.id_to_internal.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.id_to_internal.is_empty()
+    }
+
+    pub fn staged_len(&self) -> usize {
+        self.staged.len()
+    }
+
+    pub fn tombstone_len(&self) -> usize {
+        self.tombstones.len()
+    }
+
+    pub fn to_bytes(&self) -> Result<Vec<u8>, String> {
+        let mut buf = Vec::with_capacity(MAGIC.len() + 4);
+        buf.extend_from_slice(MAGIC);
+        buf.extend_from_slice(&FORMAT_VERSION.to_le_bytes());
+        let body =
+            bincode::serialize(self).map_err(|e| format!("failed to serialize index: {e}"))?;
+        buf.extend_from_slice(&body);
+        Ok(buf)
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, String> {
+        let header_len = MAGIC.len() + 4;
+        if bytes.len() < header_len {
+            return Err("not a valid HnswIndex file (too short)".to_string());
+        }
+        if &bytes[..MAGIC.len()] != MAGIC {
+            return Err("not a valid HnswIndex file (bad magic bytes)".to_string());
+        }
+        let version = u32::from_le_bytes(
+            bytes[MAGIC.len()..header_len]
+                .try_into()
+                .expect("slice of exactly 4 bytes"),
+        );
+        if version != FORMAT_VERSION {
+            return Err(format!(
+                "unsupported HnswIndex file format version {version} \
+                 (this build supports version {FORMAT_VERSION})"
+            ));
+        }
+        bincode::deserialize(&bytes[header_len..])
+            .map_err(|e| format!("failed to deserialize index: {e}"))
+    }
+
+    /// Atomic write: serialize to a temp file in the same directory, then
+    /// rename over the destination -- a crash mid-write can never leave a
+    /// truncated/corrupt file at `path` (same convention as
+    /// `polar_llama/checkpoint.py`'s store writes).
+    pub fn save(&self, path: &Path) -> Result<(), String> {
+        let bytes = self.to_bytes()?;
+        let dir: PathBuf = match path.parent() {
+            Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
+            _ => PathBuf::from("."),
+        };
+        fs::create_dir_all(&dir).map_err(|e| format!("failed to create directory {dir:?}: {e}"))?;
+        let file_name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("hnsw_index");
+        let tmp_path = dir.join(format!(".{file_name}.tmp-{}", std::process::id()));
+        fs::write(&tmp_path, &bytes)
+            .map_err(|e| format!("failed to write {tmp_path:?}: {e}"))?;
+        fs::rename(&tmp_path, path).map_err(|e| format!("failed to finalize {path:?}: {e}"))?;
+        Ok(())
+    }
+
+    pub fn load(path: &Path) -> Result<Self, String> {
+        let bytes = fs::read(path).map_err(|e| format!("failed to read {path:?}: {e}"))?;
+        Self::from_bytes(&bytes)
+    }
+}
+
+// ============================================================================
+// Polars <-> Rust extraction helpers
+// ============================================================================
+
+/// Cast to `String` and collect, erroring (naming the offending row) on any
+/// null.
+fn extract_string_vec(series: &Series) -> PolarsResult<Vec<String>> {
+    let casted = series.cast(&DataType::String)?;
+    let ca = casted.str()?;
+    let mut out = Vec::with_capacity(ca.len());
+    for (i, v) in ca.into_iter().enumerate() {
+        match v {
+            Some(s) => out.push(s.to_string()),
+            None => {
+                return Err(PolarsError::ComputeError(
+                    format!("id column contains a null value at row {i}").into(),
+                ));
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Extract a `List[Float64]` (or any numeric list dtype, cast to Float64)
+/// column into `Option<Vec<f64>>` per row -- `None` for a null row or an
+/// empty vector. A vector with a null *inside* it is an error (naming the
+/// row), since a partially-null embedding is never valid input.
+fn extract_embeddings(series: &Series) -> PolarsResult<Vec<Option<Vec<f64>>>> {
+    let list = series.list()?;
+    let mut out = Vec::with_capacity(list.len());
+    for i in 0..list.len() {
+        match list.get_as_series(i) {
+            None => out.push(None),
+            Some(s) => {
+                if s.is_empty() {
+                    out.push(None);
+                    continue;
+                }
+                let casted = s.cast(&DataType::Float64)?;
+                let ca = casted.f64()?;
+                if ca.null_count() > 0 {
+                    return Err(PolarsError::ComputeError(
+                        format!("embedding vector at row {i} contains a null value").into(),
+                    ));
+                }
+                out.push(Some(ca.into_no_null_iter().collect()));
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Same as `extract_embeddings`, but a null/empty row is an error (naming
+/// the row) rather than `None` -- used for `.build()`/`.add()`, where every
+/// row must contribute a real point.
+fn extract_embeddings_required(series: &Series) -> PolarsResult<Vec<Vec<f64>>> {
+    extract_embeddings(series)?
+        .into_iter()
+        .enumerate()
+        .map(|(i, o)| {
+            o.ok_or_else(|| {
+                PolarsError::ComputeError(
+                    format!("embedding column contains a null/empty value at row {i}").into(),
+                )
+            })
+        })
+        .collect()
+}
+
+fn extract_id_embedding_pairs(
+    ids: &Series,
+    embeddings: &Series,
+) -> PolarsResult<Vec<(String, Vec<f64>)>> {
+    if ids.len() != embeddings.len() {
+        return Err(PolarsError::ShapeMismatch(
+            format!(
+                "id column has {} rows, embedding column has {} rows",
+                ids.len(),
+                embeddings.len()
+            )
+            .into(),
+        ));
+    }
+    let id_vals = extract_string_vec(ids)?;
+    let emb_vals = extract_embeddings_required(embeddings)?;
+    Ok(id_vals.into_iter().zip(emb_vals).collect())
+}
+
+fn build_query_result_df(results: &[Vec<(String, f32)>]) -> DataFrame {
+    let mut query_ids: Vec<i64> = Vec::new();
+    let mut neighbor_ids: Vec<String> = Vec::new();
+    let mut distances: Vec<f64> = Vec::new();
+    let mut ranks: Vec<u32> = Vec::new();
+
+    for (qi, row) in results.iter().enumerate() {
+        for (rank, (id, dist)) in row.iter().enumerate() {
+            query_ids.push(qi as i64);
+            neighbor_ids.push(id.clone());
+            distances.push(*dist as f64);
+            ranks.push((rank + 1) as u32);
+        }
+    }
+
+    let height = query_ids.len();
+    let columns = vec![
+        Series::from_vec(PlSmallStr::from_static("query_id"), query_ids).into_column(),
+        Series::new(PlSmallStr::from_static("neighbor_id"), neighbor_ids.as_slice())
+            .into_column(),
+        Series::from_vec(PlSmallStr::from_static("distance"), distances).into_column(),
+        Series::from_vec(PlSmallStr::from_static("rank"), ranks).into_column(),
+    ];
+    DataFrame::new(height, columns).expect("columns constructed with matching lengths")
+}
+
+fn build_single_query_result_df(results: &[(String, f32)]) -> DataFrame {
+    let mut neighbor_ids: Vec<String> = Vec::with_capacity(results.len());
+    let mut distances: Vec<f64> = Vec::with_capacity(results.len());
+    let mut ranks: Vec<u32> = Vec::with_capacity(results.len());
+    for (rank, (id, dist)) in results.iter().enumerate() {
+        neighbor_ids.push(id.clone());
+        distances.push(*dist as f64);
+        ranks.push((rank + 1) as u32);
+    }
+
+    let height = neighbor_ids.len();
+    let columns = vec![
+        Series::new(PlSmallStr::from_static("neighbor_id"), neighbor_ids.as_slice())
+            .into_column(),
+        Series::from_vec(PlSmallStr::from_static("distance"), distances).into_column(),
+        Series::from_vec(PlSmallStr::from_static("rank"), ranks).into_column(),
+    ];
+    DataFrame::new(height, columns).expect("columns constructed with matching lengths")
+}
+
+fn to_pyerr(e: PolarsError) -> PyErr {
+    PyValueError::new_err(e.to_string())
+}
+
+// ============================================================================
+// PyO3 boundary
+// ============================================================================
+
+/// `#[pyclass]` core backing `polar_llama.index.HnswIndex`. Ids and
+/// embeddings cross the Python boundary as real `pyo3_polars`
+/// `PySeries`/`PyDataFrame` (zero-copy Arrow, no JSON shuttle); batch
+/// queries release the GIL around the actual search.
+#[pyclass(name = "_HnswIndexCore")]
+pub struct PyHnswIndex {
+    inner: PersistentIndex,
+}
+
+#[pymethods]
+impl PyHnswIndex {
+    #[staticmethod]
+    #[pyo3(signature = (
+        ids,
+        embeddings,
+        ef_construction=200,
+        ef_search=200,
+        seed=42,
+        auto_compact=true,
+        compact_staged_min=1000,
+        compact_staged_ratio=0.10,
+        compact_tombstone_min=1000,
+        compact_tombstone_ratio=0.10,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn build(
+        ids: PySeries,
+        embeddings: PySeries,
+        ef_construction: usize,
+        ef_search: usize,
+        seed: u64,
+        auto_compact: bool,
+        compact_staged_min: usize,
+        compact_staged_ratio: f64,
+        compact_tombstone_min: usize,
+        compact_tombstone_ratio: f64,
+    ) -> PyResult<Self> {
+        let pairs = extract_id_embedding_pairs(&ids.0, &embeddings.0).map_err(to_pyerr)?;
+        let params = IndexParams {
+            ef_construction,
+            ef_search,
+            seed,
+            auto_compact,
+            compact_staged_min,
+            compact_staged_ratio,
+            compact_tombstone_min,
+            compact_tombstone_ratio,
+        };
+        let inner = PersistentIndex::build(pairs, params).map_err(PyValueError::new_err)?;
+        Ok(PyHnswIndex { inner })
+    }
+
+    fn add(&mut self, ids: PySeries, embeddings: PySeries) -> PyResult<usize> {
+        let pairs = extract_id_embedding_pairs(&ids.0, &embeddings.0).map_err(to_pyerr)?;
+        self.inner.add(pairs).map_err(PyValueError::new_err)
+    }
+
+    fn remove(&mut self, ids: PySeries) -> PyResult<usize> {
+        let ids = extract_string_vec(&ids.0).map_err(to_pyerr)?;
+        Ok(self.inner.remove(&ids))
+    }
+
+    fn compact(&mut self) {
+        self.inner.compact();
+    }
+
+    fn should_compact(&self) -> bool {
+        self.inner.should_compact()
+    }
+
+    fn contains(&self, id: &str) -> bool {
+        self.inner.contains(id)
+    }
+
+    fn query(&self, py: Python<'_>, embeddings: PySeries, k: usize) -> PyResult<PyDataFrame> {
+        let queries = extract_embeddings(&embeddings.0).map_err(to_pyerr)?;
+        // Validate every non-null query row's dimension up front. Without this,
+        // a wrong-dim query silently returns garbage (EmbeddingPoint::distance
+        // zips over the shorter length) on the primary DataFrame-native API --
+        // mirror the single-vector query_one check. Null rows stay empty.
+        for (row, q) in queries.iter().enumerate() {
+            if let Some(v) = q {
+                if v.len() != self.inner.dim {
+                    return Err(PyValueError::new_err(format!(
+                        "query vector at row {row} has dim={}, index dim={}",
+                        v.len(),
+                        self.inner.dim
+                    )));
+                }
+            }
+        }
+        let inner = &self.inner;
+        let results = py.detach(|| inner.query_batch(&queries, k));
+        Ok(PyDataFrame(build_query_result_df(&results)))
+    }
+
+    fn query_one(&self, py: Python<'_>, vector: Vec<f64>, k: usize) -> PyResult<PyDataFrame> {
+        if vector.is_empty() || vector.len() != self.inner.dim {
+            return Err(PyValueError::new_err(format!(
+                "query vector has dim={}, index dim={}",
+                vector.len(),
+                self.inner.dim
+            )));
+        }
+        let inner = &self.inner;
+        let results = py.detach(|| inner.query_one(&vector, k));
+        Ok(PyDataFrame(build_single_query_result_df(&results)))
+    }
+
+    fn save(&self, path: &str) -> PyResult<()> {
+        self.inner
+            .save(Path::new(path))
+            .map_err(PyValueError::new_err)
+    }
+
+    #[staticmethod]
+    fn load(path: &str) -> PyResult<Self> {
+        let inner = PersistentIndex::load(Path::new(path)).map_err(PyValueError::new_err)?;
+        Ok(PyHnswIndex { inner })
+    }
+
+    #[getter]
+    fn dim(&self) -> usize {
+        self.inner.dim
+    }
+
+    #[getter]
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn __len__(&self) -> usize {
+        self.inner.len()
+    }
+
+    #[getter]
+    fn staged_len(&self) -> usize {
+        self.inner.staged_len()
+    }
+
+    #[getter]
+    fn tombstone_len(&self) -> usize {
+        self.inner.tombstone_len()
+    }
+
+    #[getter]
+    fn auto_compact(&self) -> bool {
+        self.inner.params.auto_compact
+    }
+
+    #[setter]
+    fn set_auto_compact(&mut self, value: bool) {
+        self.inner.params.auto_compact = value;
+    }
+}
+
+// ============================================================================
+// Unit tests (pure Rust, no pyo3 -- runnable with plain `cargo test`)
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn blob(cx: f64, cy: f64, n: usize, spread: f64, seed: u64) -> Vec<Vec<f64>> {
+        // Tiny deterministic LCG so tests don't need the `rand` crate.
+        let mut state = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        let mut next = || {
+            state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+            ((state >> 33) as f64) / (u32::MAX as f64)
+        };
+        (0..n)
+            .map(|_| {
+                let dx = (next() - 0.5) * spread;
+                let dy = (next() - 0.5) * spread;
+                vec![cx + dx, cy + dy]
+            })
+            .collect()
+    }
+
+    fn brute_force_nearest(points: &[(String, Vec<f64>)], query: &[f64], k: usize) -> Vec<String> {
+        let q = EmbeddingPoint(query.to_vec());
+        let mut scored: Vec<(String, f32)> = points
+            .iter()
+            .map(|(id, v)| (id.clone(), q.distance(&EmbeddingPoint(v.clone()))))
+            .collect();
+        scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+        scored.into_iter().take(k).map(|(id, _)| id).collect()
+    }
+
+    fn small_dataset() -> Vec<(String, Vec<f64>)> {
+        let mut pairs = Vec::new();
+        for (i, v) in blob(10.0, 0.0, 20, 0.5, 1).into_iter().enumerate() {
+            pairs.push((format!("a{i}"), v));
+        }
+        for (i, v) in blob(0.0, 10.0, 20, 0.5, 2).into_iter().enumerate() {
+            pairs.push((format!("b{i}"), v));
+        }
+        pairs
+    }
+
+    #[test]
+    fn test_build_and_query_matches_brute_force_top1() {
+        let pairs = small_dataset();
+        let idx = PersistentIndex::build(pairs.clone(), IndexParams::default()).unwrap();
+
+        let query = vec![10.0, 0.0];
+        let got = idx.query_one(&query, 5);
+        let want = brute_force_nearest(&pairs, &query, 5);
+
+        assert_eq!(got.len(), 5);
+        // Top-1 should agree (approximate search on a tiny, well-separated
+        // dataset finds the exact nearest neighbor).
+        assert_eq!(got[0].0, want[0]);
+        // Every returned id came from the "a" blob (nearest cluster).
+        assert!(got.iter().all(|(id, _)| id.starts_with('a')));
+    }
+
+    #[test]
+    fn test_add_is_queryable_immediately_without_compaction() {
+        let pairs = small_dataset();
+        let mut idx = PersistentIndex::build(pairs, IndexParams::default()).unwrap();
+        idx.params.auto_compact = false;
+
+        idx.add(vec![("new1".to_string(), vec![10.0, 0.0])]).unwrap();
+        assert_eq!(idx.staged_len(), 1);
+
+        let got = idx.query_one(&[10.0, 0.0], 1);
+        assert_eq!(got[0].0, "new1");
+        assert!((got[0].1).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_upsert_tombstones_old_internal_id() {
+        // A second, always-live point near the origin so "the old position
+        // is no longer reachable as x" is actually falsifiable -- with only
+        // one point in the whole index, querying near its old position
+        // would trivially still return it (nothing else to return).
+        let mut idx = PersistentIndex::build(
+            vec![
+                ("x".to_string(), vec![0.0, 0.0]),
+                ("other".to_string(), vec![0.1, 0.1]),
+            ],
+            IndexParams::default(),
+        )
+        .unwrap();
+        idx.params.auto_compact = false;
+
+        idx.add(vec![("x".to_string(), vec![100.0, 100.0])]).unwrap();
+        assert_eq!(idx.tombstone_len(), 1);
+        assert_eq!(idx.len(), 2);
+
+        let got = idx.query_one(&[100.0, 100.0], 1);
+        assert_eq!(got[0].0, "x");
+        assert!((got[0].1).abs() < 1e-3);
+
+        // The old position must no longer be reachable as "x" -- "other"
+        // (still live near the origin) wins instead.
+        let near_origin = idx.query_one(&[0.0, 0.0], 1);
+        assert_eq!(near_origin[0].0, "other");
+    }
+
+    #[test]
+    fn test_remove_excludes_id_and_k_still_returned() {
+        let pairs = small_dataset();
+        let mut idx = PersistentIndex::build(pairs, IndexParams::default()).unwrap();
+        idx.params.auto_compact = false;
+
+        let removed = idx.remove(&["a0".to_string(), "a1".to_string()]);
+        assert_eq!(removed, 2);
+        assert_eq!(idx.tombstone_len(), 2);
+        assert!(!idx.contains("a0"));
+
+        let got = idx.query_one(&[10.0, 0.0], 5);
+        assert_eq!(got.len(), 5); // over-fetch backfills the removed slots
+        assert!(got.iter().all(|(id, _)| id != "a0" && id != "a1"));
+    }
+
+    #[test]
+    fn test_remove_unknown_id_is_a_noop() {
+        let mut idx = PersistentIndex::build(
+            vec![("x".to_string(), vec![0.0, 0.0])],
+            IndexParams::default(),
+        )
+        .unwrap();
+        assert_eq!(idx.remove(&["does-not-exist".to_string()]), 0);
+        assert_eq!(idx.len(), 1);
+    }
+
+    #[test]
+    fn test_compaction_shrinks_staged_and_tombstones_and_preserves_query_results() {
+        let pairs = small_dataset();
+        let mut idx = PersistentIndex::build(pairs.clone(), IndexParams::default()).unwrap();
+        idx.params.auto_compact = false;
+
+        idx.add(vec![("c0".to_string(), vec![10.1, 0.1])]).unwrap();
+        idx.remove(&["a0".to_string()]);
+        assert_eq!(idx.staged_len(), 1);
+        assert_eq!(idx.tombstone_len(), 1);
+
+        let before = idx.query_one(&[10.0, 0.0], 5);
+
+        idx.compact();
+        assert_eq!(idx.staged_len(), 0);
+        assert_eq!(idx.tombstone_len(), 0);
+        assert!(!idx.contains("a0"));
+        assert!(idx.contains("c0"));
+
+        let after = idx.query_one(&[10.0, 0.0], 5);
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn test_auto_compact_triggers_past_threshold() {
+        let params = IndexParams {
+            compact_staged_min: 3,
+            ..Default::default()
+        };
+        let mut idx =
+            PersistentIndex::build(vec![("x".to_string(), vec![0.0, 0.0])], params).unwrap();
+
+        for i in 0..4 {
+            idx.add(vec![(format!("y{i}"), vec![1.0, 1.0])]).unwrap();
+        }
+        // Should have auto-compacted at least once, so staged shouldn't
+        // have been allowed to grow past the threshold indefinitely.
+        assert!(idx.staged_len() <= 3);
+        assert_eq!(idx.len(), 5);
+    }
+
+    #[test]
+    fn test_save_load_round_trip_preserves_query_results_and_pending_state() {
+        let pairs = small_dataset();
+        let mut idx = PersistentIndex::build(pairs, IndexParams::default()).unwrap();
+        idx.params.auto_compact = false;
+        idx.add(vec![("pending1".to_string(), vec![10.0, 0.05])]).unwrap();
+        idx.remove(&["a0".to_string()]);
+
+        let query = vec![10.0, 0.0];
+        let before = idx.query_one(&query, 6);
+
+        let dir = std::env::temp_dir().join(format!(
+            "polar_llama_hnsw_test_{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("index.bin");
+        idx.save(&path).unwrap();
+
+        let loaded = PersistentIndex::load(&path).unwrap();
+        assert_eq!(loaded.dim, idx.dim);
+        assert_eq!(loaded.staged_len(), idx.staged_len());
+        assert_eq!(loaded.tombstone_len(), idx.tombstone_len());
+        assert_eq!(loaded.len(), idx.len());
+
+        let after = loaded.query_one(&query, 6);
+        assert_eq!(before, after);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_load_rejects_bad_magic() {
+        let dir = std::env::temp_dir().join(format!(
+            "polar_llama_hnsw_test_badmagic_{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("not_an_index.bin");
+        std::fs::write(&path, b"not an hnsw index file at all").unwrap();
+
+        let err = match PersistentIndex::load(&path) {
+            Err(e) => e,
+            Ok(_) => panic!("expected loading a bad-magic file to fail"),
+        };
+        assert!(err.contains("bad magic"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_build_rejects_empty_input() {
+        let err = match PersistentIndex::build(Vec::new(), IndexParams::default()) {
+            Err(e) => e,
+            Ok(_) => panic!("expected building from an empty batch to fail"),
+        };
+        assert!(err.contains("at least one"));
+    }
+
+    #[test]
+    fn test_build_rejects_dimension_mismatch() {
+        let err = match PersistentIndex::build(
+            vec![
+                ("a".to_string(), vec![1.0, 2.0]),
+                ("b".to_string(), vec![1.0, 2.0, 3.0]),
+            ],
+            IndexParams::default(),
+        ) {
+            Err(e) => e,
+            Ok(_) => panic!("expected a dimension mismatch to fail"),
+        };
+        assert!(err.contains("dimension mismatch"));
+    }
+
+    #[test]
+    fn test_build_last_id_wins_on_duplicate() {
+        let idx = PersistentIndex::build(
+            vec![
+                ("dup".to_string(), vec![0.0, 0.0]),
+                ("dup".to_string(), vec![50.0, 50.0]),
+            ],
+            IndexParams::default(),
+        )
+        .unwrap();
+        assert_eq!(idx.len(), 1);
+        let got = idx.query_one(&[50.0, 50.0], 1);
+        assert_eq!(got[0].0, "dup");
+        assert!((got[0].1).abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_query_batch_null_row_returns_empty_not_error() {
+        let idx = PersistentIndex::build(
+            vec![("x".to_string(), vec![0.0, 0.0])],
+            IndexParams::default(),
+        )
+        .unwrap();
+        let out = idx.query_batch(&[Some(vec![0.0, 0.0]), None], 1);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].len(), 1);
+        assert!(out[1].is_empty());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod utils;
 pub mod model_client;
 pub mod ann;
 pub mod cost;
+pub mod index;
 pub mod kmeans;
 pub mod mcp;
 pub mod metrics;
@@ -72,6 +73,10 @@ fn polar_llama(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // Add the PyProvider class to the module
     m.add_class::<PyProvider>()?;
+
+    // Persistent, incrementally updatable HNSW index (issue #82); wrapped by
+    // `polar_llama.index.HnswIndex`.
+    m.add_class::<index::PyHnswIndex>()?;
 
     // Add the register_expressions function to the module
     m.add_function(wrap_pyfunction!(register_expressions, m)?)?;

--- a/tests/test_hnsw_index.py
+++ b/tests/test_hnsw_index.py
@@ -1,0 +1,574 @@
+"""Tests for the persistent, incrementally updatable HNSW index (issue #82).
+
+Pure local computation -- HNSW build/query, brute-force ground truth, and
+(de)serialization all run entirely in Rust/Python with no network call, no
+API key, and no mlx, so these tests never skip. All vectors are synthetic
+and seeded (`random.Random(seed)`), so every test is deterministic.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+import time
+
+import polars as pl
+import pytest
+
+from polar_llama import HnswIndex, NEIGHBOR_STRUCT_DTYPE
+
+
+# ============================================================================
+# Synthetic data helpers
+# ============================================================================
+
+
+def _random_unit_vectors(rng: random.Random, n: int, dim: int):
+    vecs = []
+    for _ in range(n):
+        v = [rng.gauss(0.0, 1.0) for _ in range(dim)]
+        norm = math.sqrt(sum(x * x for x in v)) or 1.0
+        vecs.append([x / norm for x in v])
+    return vecs
+
+
+def _cosine_distance(a, b):
+    """Same convention as `src/ann.rs::EmbeddingPoint::distance`."""
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(x * x for x in b))
+    if na == 0.0 or nb == 0.0:
+        return 1.0
+    cos = max(-1.0, min(1.0, dot / (na * nb)))
+    return 1.0 - cos
+
+
+def _brute_force_topk(ids, vectors, query, k):
+    scored = sorted(zip(ids, vectors), key=lambda iv: _cosine_distance(iv[1], query))
+    return [i for i, _ in scored[:k]]
+
+
+def _dataset(seed=0, n=300, dim=16):
+    rng = random.Random(seed)
+    ids = [f"p{i}" for i in range(n)]
+    vectors = _random_unit_vectors(rng, n, dim)
+    return ids, vectors
+
+
+def _df(ids, vectors):
+    return pl.DataFrame({"id": ids, "embedding": vectors})
+
+
+def _avg_recall_at_k(index: HnswIndex, ids, vectors, queries, k=10) -> float:
+    """Average top-k overlap (as a fraction in [0, 1]) between the index's
+    approximate results and exact brute-force cosine-distance ranking."""
+    overlaps = []
+    for q in queries:
+        got = index.query_one(q, k=k)["neighbor_id"].to_list()
+        want = _brute_force_topk(ids, vectors, q, k)
+        overlaps.append(len(set(got) & set(want)) / k)
+    return sum(overlaps) / len(overlaps)
+
+
+# ============================================================================
+# Recall: fresh build vs. incremental build+add, vs. brute-force ground truth
+# ============================================================================
+
+
+def test_build_recall_matches_brute_force():
+    ids, vectors = _dataset(seed=1, n=300, dim=16)
+    index = HnswIndex.build(_df(ids, vectors), id_col="id", embedding_col="embedding", seed=7)
+
+    queries = _random_unit_vectors(random.Random(2), 20, 16)
+    recall = _avg_recall_at_k(index, ids, vectors, queries, k=10)
+    assert recall >= 0.85, f"top-10 recall {recall:.3f} too low vs. brute force"
+
+
+def test_incremental_build_then_add_matches_fresh_build_recall():
+    """Build half the dataset, `.add()` the other half incrementally, and
+    confirm recall is statistically indistinguishable from building the
+    whole dataset in one `.build()` call."""
+    ids, vectors = _dataset(seed=3, n=400, dim=16)
+    half = len(ids) // 2
+    queries = _random_unit_vectors(random.Random(4), 25, 16)
+
+    fresh = HnswIndex.build(_df(ids, vectors), id_col="id", embedding_col="embedding", seed=11)
+    fresh_recall = _avg_recall_at_k(fresh, ids, vectors, queries, k=10)
+
+    incremental = HnswIndex.build(
+        _df(ids[:half], vectors[:half]), id_col="id", embedding_col="embedding", seed=11
+    )
+    incremental.add(_df(ids[half:], vectors[half:]), id_col="id", embedding_col="embedding")
+    incremental_recall = _avg_recall_at_k(incremental, ids, vectors, queries, k=10)
+
+    assert len(incremental) == len(ids)
+    # Both should be close to brute-force ground truth; incremental must not
+    # be meaningfully worse than a fresh build over the same final point set.
+    assert incremental_recall >= 0.80
+    assert incremental_recall >= fresh_recall - 0.15
+
+
+def test_recall_preserved_across_compaction():
+    ids, vectors = _dataset(seed=5, n=300, dim=16)
+    half = len(ids) // 2
+    queries = _random_unit_vectors(random.Random(6), 20, 16)
+
+    index = HnswIndex.build(
+        _df(ids[:half], vectors[:half]), id_col="id", embedding_col="embedding", seed=13
+    )
+    index.auto_compact = False
+    index.add(_df(ids[half:], vectors[half:]), id_col="id", embedding_col="embedding")
+
+    pre_compaction_recall = _avg_recall_at_k(index, ids, vectors, queries, k=10)
+    assert index.staged_len == len(ids) - half
+
+    index.compact()
+    assert index.staged_len == 0
+    assert index.tombstone_len == 0
+
+    post_compaction_recall = _avg_recall_at_k(index, ids, vectors, queries, k=10)
+    assert post_compaction_recall >= 0.80
+    assert abs(post_compaction_recall - pre_compaction_recall) <= 0.15
+
+
+# ============================================================================
+# add() -- queryable immediately
+# ============================================================================
+
+
+def test_add_is_queryable_immediately():
+    ids, vectors = _dataset(seed=10, n=50, dim=8)
+    index = HnswIndex.build(_df(ids, vectors), id_col="id", embedding_col="embedding")
+    index.auto_compact = False
+
+    new_vec = [0.0] * 8
+    new_vec[0] = 1.0
+    n = index.add(pl.DataFrame({"id": ["brand_new"], "embedding": [new_vec]}), "id", "embedding")
+    assert n == 1
+    assert index.staged_len == 1
+    assert "brand_new" in index
+
+    got = index.query_one(new_vec, k=1)
+    assert got["neighbor_id"].to_list() == ["brand_new"]
+    assert got["distance"][0] == pytest.approx(0.0, abs=1e-6)
+
+
+def test_add_empty_dataframe_is_a_noop():
+    ids, vectors = _dataset(seed=11, n=10, dim=4)
+    index = HnswIndex.build(_df(ids, vectors), id_col="id", embedding_col="embedding")
+    n = index.add(pl.DataFrame({"id": [], "embedding": []}, schema={"id": pl.Utf8, "embedding": pl.List(pl.Float64)}), "id", "embedding")
+    assert n == 0
+    assert len(index) == 10
+
+
+# ============================================================================
+# Soft-delete / upsert
+# ============================================================================
+
+
+def test_remove_excludes_id_and_k_neighbors_still_returned():
+    ids, vectors = _dataset(seed=20, n=100, dim=8)
+    index = HnswIndex.build(_df(ids, vectors), id_col="id", embedding_col="embedding")
+
+    query = vectors[0]
+    before = index.query_one(query, k=10)["neighbor_id"].to_list()
+
+    removed = index.remove(before[:3])
+    assert removed == 3
+    assert index.tombstone_len == 3
+    for rid in before[:3]:
+        assert rid not in index
+
+    after = index.query_one(query, k=10)
+    assert len(after) == 10  # over-fetch backfills the removed slots
+    for rid in before[:3]:
+        assert rid not in after["neighbor_id"].to_list()
+
+
+def test_remove_unknown_id_is_a_noop():
+    ids, vectors = _dataset(seed=21, n=20, dim=4)
+    index = HnswIndex.build(_df(ids, vectors), id_col="id", embedding_col="embedding")
+    assert index.remove(["does-not-exist"]) == 0
+    assert len(index) == 20
+
+
+def test_remove_accepts_a_polars_series():
+    ids, vectors = _dataset(seed=22, n=20, dim=4)
+    index = HnswIndex.build(_df(ids, vectors), id_col="id", embedding_col="embedding")
+    removed = index.remove(pl.Series(["p0", "p1"]))
+    assert removed == 2
+    assert len(index) == 18
+
+
+def test_upsert_replaces_vector_and_old_position_unreachable():
+    ids, vectors = _dataset(seed=30, n=100, dim=8)
+    index = HnswIndex.build(_df(ids, vectors), id_col="id", embedding_col="embedding")
+    index.auto_compact = False
+
+    target_id = ids[0]
+    original_vec = vectors[0]
+    far_vec = [-x for x in original_vec]  # antipodal: maximally far under cosine distance
+
+    index.add(pl.DataFrame({"id": [target_id], "embedding": [far_vec]}), "id", "embedding")
+    assert len(index) == 100  # still just an upsert, not a new point
+    assert index.tombstone_len == 1
+
+    got = index.query_one(far_vec, k=1)
+    assert got["neighbor_id"][0] == target_id
+    assert got["distance"][0] == pytest.approx(0.0, abs=1e-6)
+
+    # Querying near the *old* position should no longer surface target_id
+    # ahead of everything else -- it moved to the antipode.
+    near_old = index.query_one(original_vec, k=5)["neighbor_id"].to_list()
+    assert target_id not in near_old[:1]
+
+
+# ============================================================================
+# Persistence: save / load
+# ============================================================================
+
+
+def test_save_load_round_trip_identical_query_results(tmp_path):
+    ids, vectors = _dataset(seed=40, n=150, dim=12)
+    index = HnswIndex.build(_df(ids, vectors), id_col="id", embedding_col="embedding", seed=99)
+
+    path = tmp_path / "index.bin"
+    index.save(str(path))
+    reloaded = HnswIndex.load(str(path))
+
+    assert reloaded.dim == index.dim
+    assert len(reloaded) == len(index)
+
+    queries = _random_unit_vectors(random.Random(41), 10, 12)
+    for q in queries:
+        before = index.query_one(q, k=10)
+        after = reloaded.query_one(q, k=10)
+        assert before["neighbor_id"].to_list() == after["neighbor_id"].to_list()
+        assert before["distance"].to_list() == pytest.approx(after["distance"].to_list())
+
+
+def test_save_load_round_trip_preserves_pending_staging_and_tombstones(tmp_path):
+    ids, vectors = _dataset(seed=42, n=100, dim=8)
+    index = HnswIndex.build(_df(ids, vectors), id_col="id", embedding_col="embedding")
+    index.auto_compact = False
+
+    new_vec = [0.0] * 8
+    new_vec[0] = 1.0
+    index.add(pl.DataFrame({"id": ["pending1"], "embedding": [new_vec]}), "id", "embedding")
+    index.remove([ids[0]])
+
+    assert index.staged_len == 1
+    assert index.tombstone_len == 1
+
+    path = tmp_path / "pending_index.bin"
+    index.save(str(path))
+    reloaded = HnswIndex.load(str(path))
+
+    assert reloaded.staged_len == 1
+    assert reloaded.tombstone_len == 1
+    assert "pending1" in reloaded
+    assert ids[0] not in reloaded
+
+    got = reloaded.query_one(new_vec, k=1)
+    assert got["neighbor_id"].to_list() == ["pending1"]
+
+
+def test_save_creates_parent_directories(tmp_path):
+    ids, vectors = _dataset(seed=43, n=10, dim=4)
+    index = HnswIndex.build(_df(ids, vectors), id_col="id", embedding_col="embedding")
+    path = tmp_path / "nested" / "dir" / "index.bin"
+    index.save(str(path))
+    assert path.exists()
+    reloaded = HnswIndex.load(str(path))
+    assert len(reloaded) == 10
+
+
+def test_load_rejects_a_non_index_file(tmp_path):
+    path = tmp_path / "not_an_index.bin"
+    path.write_bytes(b"definitely not an hnsw index file")
+    with pytest.raises(ValueError):
+        HnswIndex.load(str(path))
+
+
+# ============================================================================
+# Compaction correctness
+# ============================================================================
+
+
+def test_compaction_resets_staged_and_tombstones_and_preserves_live_set():
+    ids, vectors = _dataset(seed=50, n=100, dim=8)
+    index = HnswIndex.build(_df(ids, vectors), id_col="id", embedding_col="embedding")
+    index.auto_compact = False
+
+    extra_vec = [0.0] * 8
+    extra_vec[0] = 1.0
+    index.add(pl.DataFrame({"id": ["new1"], "embedding": [extra_vec]}), "id", "embedding")
+    index.remove([ids[0], ids[1]])
+
+    assert index.staged_len == 1
+    assert index.tombstone_len == 2
+    assert index.should_compact is False  # thresholds (default 1000) not crossed yet
+
+    index.compact()
+    assert index.staged_len == 0
+    assert index.tombstone_len == 0
+    assert len(index) == 99  # 100 - 2 removed + 1 added
+    assert "new1" in index
+    assert ids[0] not in index
+    assert ids[1] not in index
+    assert ids[2] in index
+
+
+def test_auto_compact_triggers_past_threshold():
+    ids, vectors = _dataset(seed=51, n=20, dim=4)
+    index = HnswIndex.build(
+        _df(ids, vectors),
+        id_col="id",
+        embedding_col="embedding",
+        auto_compact=True,
+        compact_staged_min=3,
+    )
+    for i in range(5):
+        v = [0.0] * 4
+        v[0] = float(i + 1)
+        index.add(pl.DataFrame({"id": [f"extra{i}"], "embedding": [v]}), "id", "embedding")
+
+    # Auto-compact must have fired at least once -- staged never allowed to
+    # grow unboundedly past the (very low) threshold.
+    assert index.staged_len <= 3
+    assert len(index) == 25
+
+
+def test_auto_compact_disabled_never_compacts_automatically():
+    ids, vectors = _dataset(seed=52, n=10, dim=4)
+    index = HnswIndex.build(
+        _df(ids, vectors),
+        id_col="id",
+        embedding_col="embedding",
+        auto_compact=False,
+        compact_staged_min=1,
+    )
+    for i in range(5):
+        v = [0.0] * 4
+        v[0] = float(i + 1)
+        index.add(pl.DataFrame({"id": [f"extra{i}"], "embedding": [v]}), "id", "embedding")
+    assert index.staged_len == 5  # would have auto-compacted if enabled
+
+
+# ============================================================================
+# query() / query_one() / knn() shapes and dtypes
+# ============================================================================
+
+
+def test_batch_query_wrong_dim_raises():
+    # Regression (#82 review): a wrong-dimension query on the primary batch
+    # .query() API must raise (like .query_one), not silently return garbage
+    # (EmbeddingPoint::distance zips over the shorter length).
+    ids, vectors = _dataset(seed=61, n=30, dim=6)
+    index = HnswIndex.build(_df(ids, vectors), id_col="id", embedding_col="embedding")
+
+    bad = pl.DataFrame({"embedding": [[0.1, 0.2, 0.3]]})  # dim 3 != index dim 6
+    with pytest.raises((ValueError, Exception), match=r"dim"):
+        index.query(bad, embedding_col="embedding", k=3)
+
+
+def test_query_dataframe_shape_and_dtypes():
+    ids, vectors = _dataset(seed=60, n=30, dim=6)
+    index = HnswIndex.build(_df(ids, vectors), id_col="id", embedding_col="embedding")
+
+    queries = pl.DataFrame({"embedding": vectors[:5]})
+    result = index.query(queries, embedding_col="embedding", k=3)
+
+    assert result.schema["query_id"] == pl.Int64
+    assert result.schema["neighbor_id"] == pl.Utf8
+    assert result.schema["distance"] == pl.Float64
+    assert result.schema["rank"] == pl.UInt32
+    assert result.height == 5 * 3
+    assert result["query_id"].n_unique() == 5
+
+    for qid in range(5):
+        sub = result.filter(pl.col("query_id") == qid)
+        assert sub["rank"].to_list() == [1, 2, 3]
+        # rank 1 (self-match) should have ~0 distance for an exact point.
+        assert sub.filter(pl.col("rank") == 1)["distance"][0] == pytest.approx(0.0, abs=1e-6)
+
+
+def test_query_one_shape():
+    ids, vectors = _dataset(seed=61, n=20, dim=6)
+    index = HnswIndex.build(_df(ids, vectors), id_col="id", embedding_col="embedding")
+    result = index.query_one(vectors[0], k=5)
+    assert result.columns == ["neighbor_id", "distance", "rank"]
+    assert result.height == 5
+    assert result["rank"].to_list() == [1, 2, 3, 4, 5]
+
+
+def test_query_k_zero_returns_empty():
+    ids, vectors = _dataset(seed=62, n=10, dim=4)
+    index = HnswIndex.build(_df(ids, vectors), id_col="id", embedding_col="embedding")
+    result = index.query_one(vectors[0], k=0)
+    assert result.height == 0
+
+
+def test_query_null_embedding_row_contributes_zero_rows_not_error():
+    ids, vectors = _dataset(seed=63, n=10, dim=4)
+    index = HnswIndex.build(_df(ids, vectors), id_col="id", embedding_col="embedding")
+    queries = pl.DataFrame(
+        {"embedding": [vectors[0], None]}, schema={"embedding": pl.List(pl.Float64)}
+    )
+    result = index.query(queries, embedding_col="embedding", k=3)
+    assert result.filter(pl.col("query_id") == 0).height == 3
+    assert result.filter(pl.col("query_id") == 1).height == 0
+
+
+def test_knn_expression_bridge():
+    ids, vectors = _dataset(seed=70, n=30, dim=6)
+    index = HnswIndex.build(_df(ids, vectors), id_col="id", embedding_col="embedding")
+
+    queries = pl.DataFrame({"embedding": vectors[:4]})
+    out = queries.with_columns(nbrs=index.knn(pl.col("embedding"), k=3))
+
+    assert out.schema["nbrs"] == pl.List(NEIGHBOR_STRUCT_DTYPE)
+    assert out["nbrs"].list.len().to_list() == [3, 3, 3, 3]
+
+    # Cross-check against `.query()`'s batch output for the same input.
+    via_query = index.query(queries, embedding_col="embedding", k=3)
+    exploded = out.with_row_index("query_id").explode("nbrs").unnest("nbrs")
+    assert exploded["neighbor_id"].to_list() == via_query["neighbor_id"].to_list()
+
+
+def test_knn_null_embedding_row_yields_empty_list_not_null():
+    ids, vectors = _dataset(seed=71, n=10, dim=4)
+    index = HnswIndex.build(_df(ids, vectors), id_col="id", embedding_col="embedding")
+    queries = pl.DataFrame(
+        {"embedding": [vectors[0], None]}, schema={"embedding": pl.List(pl.Float64)}
+    )
+    out = queries.with_columns(nbrs=index.knn(pl.col("embedding"), k=2))
+    assert out["nbrs"][1].to_list() == []
+    assert out["nbrs"][1] is not None
+
+
+# ============================================================================
+# Validation / error handling
+# ============================================================================
+
+
+def test_build_requires_non_empty_dataframe():
+    empty = pl.DataFrame({"id": [], "embedding": []}, schema={"id": pl.Utf8, "embedding": pl.List(pl.Float64)})
+    with pytest.raises(ValueError):
+        HnswIndex.build(empty, id_col="id", embedding_col="embedding")
+
+
+def test_build_rejects_missing_columns():
+    df = pl.DataFrame({"id": ["a"], "embedding": [[1.0, 2.0]]})
+    with pytest.raises(ValueError):
+        HnswIndex.build(df, id_col="nope", embedding_col="embedding")
+    with pytest.raises(ValueError):
+        HnswIndex.build(df, id_col="id", embedding_col="nope")
+
+
+def test_build_rejects_non_list_embedding_column():
+    df = pl.DataFrame({"id": ["a"], "embedding": [1.0]})
+    with pytest.raises(ValueError):
+        HnswIndex.build(df, id_col="id", embedding_col="embedding")
+
+
+def test_build_rejects_dimension_mismatch():
+    df = pl.DataFrame({"id": ["a", "b"], "embedding": [[1.0, 2.0], [1.0, 2.0, 3.0]]})
+    with pytest.raises(ValueError):
+        HnswIndex.build(df, id_col="id", embedding_col="embedding")
+
+
+def test_add_rejects_dimension_mismatch():
+    ids, vectors = _dataset(seed=80, n=10, dim=4)
+    index = HnswIndex.build(_df(ids, vectors), id_col="id", embedding_col="embedding")
+    bad = pl.DataFrame({"id": ["x"], "embedding": [[1.0, 2.0]]})
+    with pytest.raises(ValueError):
+        index.add(bad, "id", "embedding")
+
+
+def test_build_duplicate_id_last_row_wins():
+    df = pl.DataFrame(
+        {"id": ["dup", "dup"], "embedding": [[1.0, 0.0], [0.0, 1.0]]}
+    )
+    index = HnswIndex.build(df, id_col="id", embedding_col="embedding")
+    assert len(index) == 1
+    got = index.query_one([0.0, 1.0], k=1)
+    assert got["neighbor_id"].to_list() == ["dup"]
+    assert got["distance"][0] == pytest.approx(0.0, abs=1e-6)
+
+
+# ============================================================================
+# Introspection
+# ============================================================================
+
+
+def test_len_dim_and_contains():
+    ids, vectors = _dataset(seed=90, n=25, dim=5)
+    index = HnswIndex.build(_df(ids, vectors), id_col="id", embedding_col="embedding")
+    assert len(index) == 25
+    assert index.dim == 5
+    assert "p0" in index
+    assert "does-not-exist" not in index
+
+
+def test_auto_compact_property_get_set():
+    ids, vectors = _dataset(seed=91, n=10, dim=4)
+    index = HnswIndex.build(
+        _df(ids, vectors), id_col="id", embedding_col="embedding", auto_compact=False
+    )
+    assert index.auto_compact is False
+    index.auto_compact = True
+    assert index.auto_compact is True
+
+
+def test_repr_contains_key_stats():
+    ids, vectors = _dataset(seed=92, n=5, dim=3)
+    index = HnswIndex.build(_df(ids, vectors), id_col="id", embedding_col="embedding")
+    text = repr(index)
+    assert "len=5" in text
+    assert "dim=3" in text
+
+
+# ============================================================================
+# 10k-point CI smoke test (loose timing -- not a benchmark; the real 100k
+# benchmark lives in scripts/bench_hnsw_index.py, outside the test suite)
+# ============================================================================
+
+
+def test_10k_points_build_and_query_smoke():
+    ids, vectors = _dataset(seed=100, n=10_000, dim=32)
+    df = _df(ids, vectors)
+
+    start = time.monotonic()
+    index = HnswIndex.build(df, id_col="id", embedding_col="embedding", seed=1)
+    build_elapsed = time.monotonic() - start
+    assert build_elapsed < 60.0, f"10k build took {build_elapsed:.1f}s -- unexpectedly slow"
+
+    assert len(index) == 10_000
+    assert index.dim == 32
+
+    queries = _random_unit_vectors(random.Random(101), 50, 32)
+    query_df = pl.DataFrame({"embedding": queries})
+
+    start = time.monotonic()
+    result = index.query(query_df, embedding_col="embedding", k=10)
+    query_elapsed = time.monotonic() - start
+    assert query_elapsed < 15.0, f"50 queries against 10k points took {query_elapsed:.1f}s"
+    assert result.height == 50 * 10
+
+    # Sanity: a small sample's recall should still be reasonably high.
+    sample_ids = ids[:2000]
+    sample_vectors = vectors[:2000]
+    recall = _avg_recall_at_k(index, sample_ids, sample_vectors, queries[:5], k=10)
+    # Ground truth is computed only over a 2000-point sample (brute-force
+    # over the full 10k would be slow in pure Python), so this is a loose
+    # sanity check, not a strict recall bound.
+    assert recall >= 0.0  # smoke: query completes and returns sane results
+
+    # Incremental add + remove still work at this scale.
+    index.add(
+        pl.DataFrame({"id": ["extra_pt"], "embedding": [vectors[0]]}), "id", "embedding"
+    )
+    assert "extra_pt" in index
+    removed = index.remove(["p0"])
+    assert removed == 1


### PR DESCRIPTION
Closes #82. Ships as **0.8.0** (new public class + on-disk format — minor bump).

## What
A stateful, serializable **`HnswIndex`** — the complement to the stateless `knn_hnsw` expression — for vault-scale semantic search that updates as data changes, no re-index per query.

DataFrame-native API (following the `Checkpoint`/`Codebook` precedent — a stateful serializable artifact with DataFrame-native verbs):
`HnswIndex.build(df, id_col, embedding_col)` · `.add(df, ...)` (upsert) · `.remove(ids)` · `.query(query_df, embedding_col, k) -> DataFrame(query_id, neighbor_id, distance, rank)` · `.query_one(vec, k)` · `.knn(expr, k) -> pl.Expr` · `.save(path)` / `HnswIndex.load(path)`. Stable external string IDs.

## How
`instant-distance`'s `HnswMap` is immutable, so this layers an LSM-like scheme: immutable **main** graph + brute-force **staging** buffer (adds queryable immediately, exact) + **tombstone** set (soft-delete + upsert-superseded). Queries over-fetch `k' = min(k+tombstones, ef_search)`, scan staging, merge, filter, truncate. **Compaction** rebuilds main from the live set via `HnswMap::iter()` (no vector duplication). Persistence via **bincode** + magic/version header, atomic writes. `src/ann.rs` and `knn_hnsw` untouched.

## Disclosures (per the design plan)
- **Adds `bincode`** — the only new dependency (tiny, pure-Rust, serde-only; effectively required to serialize a large index efficiently — JSON at 100k×768 is ~1.5 GB).
- **"100k load + query in ms" restated honestly**: query is **ms**, load is **low seconds** (one-time, vs minutes of rebuild). **Memory-mapping is not feasible** with instant-distance (it owns `Vec`s) — documented; an mmap-capable engine would be a new C++/heavy dep, deferred.

## Adversarial review (Opus) → fixed
Core verified sound (recall parity 1.000 fresh/incremental/post-compaction, soft-delete over-fetch, upsert, save/load with pending state, compaction id-pairing — all independently checked). One real bug fixed: the batch **`query()` didn't validate query-vector dimension** and silently returned wrong neighbors on a mismatch; it now raises like `query_one`. **Regression test added.** Plus a clippy nit.

## Tests & proof
- `tests/test_hnsw_index.py`: **33 pass** — recall parity vs brute-force, add-queryable-immediately, soft-delete + upsert, save/load round-trip **with pending staging+tombstones**, compaction correctness, wrong-dim regression, 10k CI smoke. `scripts/bench_hnsw_index.py` holds the 100k benchmark. 13 Rust unit tests; `cargo clippy --all-features` clean under `-Dwarnings`.
- **Independently verified**: recall@10 = **1.000** (fresh / incremental / post-compact) vs brute-force ground truth; soft-delete, upsert, and save/load-with-pending-state all correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnthn-ai/codesmith/polar_llama/pr/96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786639475&installation_id=141504833&pr_number=96&repository=pnthn-ai%2Fpolar_llama&return_to=https%3A%2F%2Fgithub.com%2Fpnthn-ai%2Fpolar_llama%2Fpull%2F96&signature=89f19322c29a748108b38133173d2aadfa331a7470e9115fc53bd8a9f7439ae1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->